### PR TITLE
fix: dismiss keyboard on login/OTP submit and clear stale data on logout

### DIFF
--- a/app/src/main/java/com/mezon/mobile/auth/LoginFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/auth/LoginFragment.kt
@@ -21,6 +21,7 @@ import android.widget.ProgressBar
 import android.widget.ScrollView
 import android.widget.TextView
 import com.mezon.mobile.R
+import com.mezon.mobile.core.AndroidUtilities
 import com.mezon.mobile.core.BaseFragment
 import com.mezon.mobile.core.LayoutHelper
 import com.mezon.mobile.di.FragmentEntryPoint
@@ -369,6 +370,7 @@ class LoginFragment : BaseFragment() {
     }
 
     private fun doSubmit() {
+        AndroidUtilities.hideKeyboard(fragmentView)
         when (currentMode) {
             LoginMode.SMS -> doSmsOTP()
             LoginMode.OTP -> doEmailOTP()

--- a/app/src/main/java/com/mezon/mobile/auth/OTPVerificationFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/auth/OTPVerificationFragment.kt
@@ -16,6 +16,7 @@ import android.widget.ProgressBar
 import android.widget.ScrollView
 import android.widget.TextView
 import com.mezon.mobile.R
+import com.mezon.mobile.core.AndroidUtilities
 import com.mezon.mobile.core.BaseFragment
 import com.mezon.mobile.core.LayoutHelper
 import com.mezon.mobile.di.FragmentEntryPoint
@@ -279,6 +280,7 @@ class OTPVerificationFragment : BaseFragment() {
         val code = getOtpCode()
         if (code.length != OTP_LENGTH) return
 
+        AndroidUtilities.hideKeyboard(fragmentView)
         showLoading()
 
         fragmentScope.launch(Dispatchers.Main) {

--- a/app/src/main/java/com/mezon/mobile/home/ChatController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChatController.kt
@@ -63,6 +63,14 @@ class ChatController @Inject constructor(
         }
     }
 
+    fun cleanup() {
+        synchronized(this) {
+            dialogMessage.clear()
+            initialFetchDone.clear()
+            cachedCurrentUserId = 0L
+        }
+    }
+
     fun openChannel(channelId: Long, clanId: Long, channelType: Int, isChannelPrivate: Boolean = false) {
         val isPublic = !isChannelPrivate
         val mode = channelTypeToStreamMode(channelType)

--- a/app/src/main/java/com/mezon/mobile/home/DialogsController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/DialogsController.kt
@@ -65,6 +65,15 @@ class DialogsController @Inject constructor(
         appScope.launch { observeMarkAsRead() }
     }
 
+    fun cleanup() {
+        synchronized(this) {
+            dialogs.clear()
+            dialogsDict.clear()
+            dialogsLoaded = false
+            currentChannelId = null
+        }
+    }
+
     @Synchronized
     fun getDialogs(): List<DirectMessage> = ArrayList(dialogs)
 

--- a/app/src/main/java/com/mezon/mobile/home/MessagesController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/MessagesController.kt
@@ -1,9 +1,18 @@
 package com.mezon.mobile.home
 
+import android.util.LongSparseArray
+import com.mezon.mobile.data.db.MezonDatabase
+import com.mezon.mobile.di.ApplicationScope
+import com.mezon.mobile.di.IoDispatcher
 import com.mezon.mobile.home.clans.ChannelController
 import com.mezon.mobile.home.clans.ClansController
+import com.mezon.mobile.home.notifications.NotificationStore
+import com.mezon.mobile.network.ApiCacheTracker
+import com.mezon.mobile.notification.ActiveChannelTracker
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import java.util.concurrent.ConcurrentHashMap
-import android.util.LongSparseArray
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -13,7 +22,13 @@ class MessagesController @Inject constructor(
     @Suppress("unused") val dialogsController: DialogsController,
     @Suppress("unused") val chatController: ChatController,
     @Suppress("unused") val clansController: ClansController,
-    @Suppress("unused") val channelController: ChannelController
+    @Suppress("unused") val channelController: ChannelController,
+    private val notificationStore: NotificationStore,
+    private val activeChannelTracker: ActiveChannelTracker,
+    private val cacheTracker: ApiCacheTracker,
+    private val database: MezonDatabase,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    @ApplicationScope private val appScope: CoroutineScope
 ) {
 
     val users = ConcurrentHashMap<Long, CachedUser>(100, 1.0f, 2)
@@ -44,7 +59,15 @@ class MessagesController @Inject constructor(
 
     fun disconnect() {
         connectionController.disconnect()
+        clansController.cleanup()
+        dialogsController.cleanup()
+        chatController.cleanup()
+        channelController.cleanup()
+        notificationStore.cleanup()
+        activeChannelTracker.clear()
+        cacheTracker.invalidateAll()
         users.clear()
         synchronized(this) { channels.clear() }
+        appScope.launch(ioDispatcher) { database.clearAllTables() }
     }
 }

--- a/app/src/main/java/com/mezon/mobile/home/clans/ChannelController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ChannelController.kt
@@ -44,6 +44,11 @@ class ChannelController @Inject constructor(
         observeSocketEvents()
     }
 
+    fun cleanup() {
+        _channelsByClan.value = emptyMap()
+        currentOpenChannelId = 0L
+    }
+
     fun loadChannelsForClan(clanId: Long, force: Boolean = false) {
         val cacheKey = apiCacheKey("listChannelsByClan", clanId.toString())
         appScope.launch {

--- a/app/src/main/java/com/mezon/mobile/home/clans/ClansController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ClansController.kt
@@ -68,6 +68,12 @@ class ClansController @Inject constructor(
         observeSocketEvents()
     }
 
+    fun cleanup() {
+        _clans.value = emptyList()
+        _selectedClanId.value = 0L
+        clansLoaded = false
+    }
+
     fun selectClan(clanId: Long) {
         if (_selectedClanId.value == clanId) return
         _selectedClanId.value = clanId

--- a/app/src/main/java/com/mezon/mobile/home/notifications/NotificationStore.kt
+++ b/app/src/main/java/com/mezon/mobile/home/notifications/NotificationStore.kt
@@ -38,6 +38,13 @@ class NotificationStore @Inject constructor(
 
     private var currentClanId: Long = 0L
 
+    fun cleanup() {
+        _mentions.value = emptyList()
+        _messages.value = emptyList()
+        _forYou.value = emptyList()
+        currentClanId = 0L
+    }
+
     fun setCurrentClan(clanId: Long) {
         if (currentClanId == clanId) return
         currentClanId = clanId

--- a/app/src/main/java/com/mezon/mobile/home/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/profile/ProfileFragment.kt
@@ -197,7 +197,7 @@ class ProfileFragment : BaseFragment() {
         ) {
             fragmentScope.launch(Dispatchers.Main) {
                 authRepository.logout()
-                notificationCenter.postNotificationOnMainThread(NotificationCenter.sessionExpired)
+                onLogout?.invoke()
             }
         }.show()
     }


### PR DESCRIPTION
- Add AndroidUtilities.hideKeyboard() in LoginFragment.doSubmit() and OTPVerificationFragment.doVerify()
- Add cleanup() to ClansController, DialogsController, ChatController, ChannelController, NotificationStore
- Wire full cleanup chain in MessagesController.disconnect() (caches + Room DB + ApiCacheTracker)
- Fix ProfileFragment.confirmLogout() to call onLogout callback instead of posting sessionExpired, ensuring disconnect() is actually invoked on logout