### PR TITLE
feat: add BadgeCoordinator and channel read state tracking

### DIFF
--- a/app/src/main/java/com/mezon/mobile/core/NotificationCenter.kt
+++ b/app/src/main/java/com/mezon/mobile/core/NotificationCenter.kt
@@ -66,6 +66,8 @@ class NotificationCenter(val currentAccount: Int) {
         val didReceiveNewMessages = nextId()
         val messageDidUpdate = nextId()
         val messageDidDelete = nextId()
+        val pendingMessageSent = nextId()
+        val pendingMessageError = nextId()
         val messagesLoadError = nextId()
         val messagesLastSeenFromServer = nextId()  
         val onlineStatusChanged = nextId()

--- a/app/src/main/java/com/mezon/mobile/data/db/ClanChannelDao.kt
+++ b/app/src/main/java/com/mezon/mobile/data/db/ClanChannelDao.kt
@@ -24,7 +24,4 @@ interface ClanChannelDao {
 
     @Query("UPDATE clan_channels SET unreadCount = :count WHERE channelId = :channelId")
     suspend fun updateUnread(channelId: Long, count: Int)
-
-    @Query("UPDATE clan_channels SET lastSeenMessageId = :messageId, unreadCount = 0 WHERE channelId = :channelId")
-    suspend fun updateLastSeen(channelId: Long, messageId: Long)
 }

--- a/app/src/main/java/com/mezon/mobile/data/db/DirectMessageDao.kt
+++ b/app/src/main/java/com/mezon/mobile/data/db/DirectMessageDao.kt
@@ -8,8 +8,8 @@ import androidx.room.Upsert
 @Dao
 interface DirectMessageDao {
 
-    @Query("SELECT * FROM direct_messages ORDER BY lastMessageTimestamp DESC LIMIT :limit")
-    suspend fun getAll(limit: Int = 200): List<DirectMessage>
+    @Query("SELECT * FROM direct_messages ORDER BY lastSentMessageTs DESC LIMIT :limit")
+    suspend fun getAll(limit: Int = 500): List<DirectMessage>
 
     @Query("SELECT * FROM direct_messages WHERE channelId = :channelId")
     suspend fun getById(channelId: Long): DirectMessage?

--- a/app/src/main/java/com/mezon/mobile/data/db/MezonDatabase.kt
+++ b/app/src/main/java/com/mezon/mobile/data/db/MezonDatabase.kt
@@ -14,7 +14,7 @@ import androidx.room.RoomDatabase
         ClanEntity::class,
         ClanChannelEntity::class
     ],
-    version = 15,
+    version = 19,
     exportSchema = false
 )
 abstract class MezonDatabase : RoomDatabase() {

--- a/app/src/main/java/com/mezon/mobile/home/BadgeCoordinator.kt
+++ b/app/src/main/java/com/mezon/mobile/home/BadgeCoordinator.kt
@@ -1,0 +1,248 @@
+package com.mezon.mobile.home
+
+import android.os.SystemClock
+import android.util.Log
+import com.mezon.mobile.core.NotificationCenter
+import com.mezon.mobile.di.ApplicationScope
+import com.mezon.mobile.di.MainDispatcher
+import com.mezon.mobile.home.clans.ChannelController
+import com.mezon.mobile.home.clans.ClansController
+import com.mezon.mobile.network.MezonSocket
+import com.mezon.mobile.network.channelTypeToStreamMode
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TAG = "BadgeCoordinator"
+private const val DEBOUNCE_LAST_SEEN_MS = 100L
+private const val DEDUP_FULL_READ_MS = 3000L
+private const val BATCH_CHANNEL_ACTIVITY_MS = 50L
+private const val CLAN_RECONCILE_MS = 500L
+private const val TS_MASK = 0xFFFF_FFFFL
+
+private data class PendingLastSeen(
+    val channelId: Long,
+    val clanId: Long,
+    val channelType: Int,
+    val messageId: Long,
+    val timestampSeconds: Int,
+    val badgeCount: Int
+)
+
+private data class ChannelActivityTick(
+    val clanId: Long,
+    val channelId: Long,
+    val messageId: Long,
+    val ts: Long
+)
+
+@Singleton
+class BadgeCoordinator @Inject constructor(
+    private val channelController: dagger.Lazy<ChannelController>,
+    private val clansController: dagger.Lazy<ClansController>,
+    private val dialogsController: DialogsController,
+    private val mezonSocket: MezonSocket,
+    private val notificationCenter: NotificationCenter,
+    @ApplicationScope private val appScope: CoroutineScope,
+    @MainDispatcher private val mainDispatcher: CoroutineDispatcher
+) {
+
+    private val lastSeenJobs = ConcurrentHashMap<String, Job>()
+    private val pendingLastSeen = ConcurrentHashMap<String, PendingLastSeen>()
+    private val deferredLastSeenByKey = ConcurrentHashMap<String, PendingLastSeen>()
+    private val fullReadDedupAt = ConcurrentHashMap<String, Long>()
+    private val reconcileJobs = ConcurrentHashMap<Long, Job>()
+
+    private val channelActivityTicks = ConcurrentHashMap<String, ChannelActivityTick>()
+    private var channelActivityJob: Job? = null
+    private val channelActivityLock = Any()
+
+    fun onReconnect() {
+        lastSeenJobs.values.forEach { it.cancel() }
+        lastSeenJobs.clear()
+        pendingLastSeen.clear()
+        deferredLastSeenByKey.clear()
+        fullReadDedupAt.clear()
+        reconcileJobs.values.forEach { it.cancel() }
+        reconcileJobs.clear()
+        channelActivityJob?.cancel()
+        channelActivityJob = null
+        synchronized(channelActivityLock) { channelActivityTicks.clear() }
+        Log.d(TAG, "onReconnect: cleared coordinator state")
+    }
+
+    fun scheduleLastSeenWrite(
+        channelId: Long,
+        clanId: Long,
+        channelType: Int,
+        messageId: Long,
+        timestampSeconds: Int,
+        badgeCount: Int = 0,
+        skipDefer: Boolean = false
+    ) {
+        val key = "${clanId}_$channelId"
+        val pending = PendingLastSeen(
+            channelId, clanId, channelType, messageId, timestampSeconds, badgeCount
+        )
+        if (!skipDefer && shouldDeferLastSeen(pending)) {
+            deferredLastSeenByKey[key] = pending
+            return
+        }
+        pendingLastSeen[key] = pending
+        lastSeenJobs[key]?.cancel()
+        lastSeenJobs[key] = appScope.launch(mainDispatcher) {
+            delay(DEBOUNCE_LAST_SEEN_MS)
+            flushLastSeen(key)
+        }
+    }
+
+    fun processDeferredQueue() {
+        appScope.launch(mainDispatcher) {
+            val snapshot = deferredLastSeenByKey.values.toList()
+            deferredLastSeenByKey.clear()
+            for (p in snapshot) {
+                if (shouldDeferLastSeen(p)) {
+                    deferredLastSeenByKey["${p.clanId}_${p.channelId}"] = p
+                } else {
+                    scheduleLastSeenWrite(
+                        p.channelId,
+                        p.clanId,
+                        p.channelType,
+                        p.messageId,
+                        p.timestampSeconds,
+                        p.badgeCount,
+                        skipDefer = true
+                    )
+                }
+            }
+        }
+    }
+
+    private fun shouldDeferLastSeen(p: PendingLastSeen): Boolean {
+        if (!clansController.get().clansLoaded) return true
+        if (p.clanId == 0L) {
+            return !dialogsController.dialogsLoaded
+        }
+        if (channelController.get().isChannelListLoading(p.clanId)) return true
+        return false
+    }
+
+    private fun flushLastSeen(key: String) {
+        lastSeenJobs.remove(key)
+        val p = pendingLastSeen.remove(key) ?: return
+        if (shouldSkipDuplicateFullRead(key, p)) {
+            Log.d(TAG, "flushLastSeen: skip dedup key=$key")
+            return
+        }
+        val socketBadgeCount = if (p.clanId != 0L) {
+            channelController.get().findChannelById(p.channelId)?.unreadCount ?: p.badgeCount
+        } else {
+            p.badgeCount
+        }
+        if (p.badgeCount == 0) {
+            fullReadDedupAt[key] = SystemClock.elapsedRealtime()
+        }
+        if (p.badgeCount == 0) {
+            if (p.clanId != 0L) {
+                channelController.get().markChannelAsRead(p.channelId, p.timestampSeconds)
+            } else {
+                dialogsController.markDialogAsRead(p.channelId, seenTimestampSeconds = p.timestampSeconds)
+            }
+        } else {
+            if (p.clanId != 0L) {
+                channelController.get().updateChannelLastSeen(
+                    p.channelId, p.messageId, p.badgeCount, p.timestampSeconds
+                )
+            } else {
+                dialogsController.updateDialogLastSeen(
+                    p.channelId, p.messageId, p.badgeCount, p.timestampSeconds
+                )
+            }
+        }
+        val mode = channelTypeToStreamMode(p.channelType)
+        appScope.launch {
+            try {
+                mezonSocket.writeLastSeenMessage(
+                    p.clanId, p.channelId, mode, p.messageId, p.timestampSeconds, socketBadgeCount
+                )
+                Log.d(
+                    TAG,
+                    "writeLastSeen: ch=${p.channelId} clan=${p.clanId} mid=${p.messageId} socketBadge=$socketBadgeCount argBadge=${p.badgeCount}"
+                )
+            } catch (e: Exception) {
+                Log.e(TAG, "writeLastSeenMessage failed", e)
+            }
+        }
+        if (p.clanId != 0L) {
+            scheduleClanReconcile(p.clanId)
+        }
+    }
+
+    private fun scheduleClanReconcile(clanId: Long) {
+        if (clanId == 0L) return
+        reconcileJobs[clanId]?.cancel()
+        reconcileJobs[clanId] = appScope.launch(mainDispatcher) {
+            delay(CLAN_RECONCILE_MS)
+            reconcileJobs.remove(clanId)
+            clansController.get().reconcileClanBadgeFromChannels(clanId)
+        }
+    }
+
+    private fun shouldSkipDuplicateFullRead(key: String, p: PendingLastSeen): Boolean {
+        if (p.badgeCount != 0) return false
+        val now = SystemClock.elapsedRealtime()
+        val last = fullReadDedupAt[key] ?: return false
+        if (now - last >= DEDUP_FULL_READ_MS) return false
+        if (p.clanId != 0L) {
+            val ch = channelController.get().findChannelById(p.channelId) ?: return false
+            return ch.unreadCount == 0 && !ch.hasUnread
+        }
+        val dm = dialogsController.getDialog(p.channelId) ?: return false
+        return dm.unreadCount == 0
+    }
+
+    fun onIncomingUnreadChannelSignal(clanId: Long, channelId: Long, messageId: Long, createTimeSeconds: Long) {
+        if (clanId == 0L) return
+        val k = "$clanId-$channelId"
+        val ts = createTimeSeconds and TS_MASK
+        synchronized(channelActivityLock) {
+            channelActivityTicks[k] = channelActivityTicks[k]?.let { prev ->
+                ChannelActivityTick(
+                    clanId,
+                    channelId,
+                    maxOf(prev.messageId, messageId),
+                    maxOf(prev.ts, ts)
+                )
+            } ?: ChannelActivityTick(clanId, channelId, messageId, ts)
+        }
+        channelActivityJob?.cancel()
+        channelActivityJob = appScope.launch(mainDispatcher) {
+            delay(BATCH_CHANNEL_ACTIVITY_MS)
+            val batch = synchronized(channelActivityLock) {
+                val list = ArrayList(channelActivityTicks.values)
+                channelActivityTicks.clear()
+                list
+            }
+            channelActivityJob = null
+            val clansTouched = HashSet<Long>()
+            for (tick in batch) {
+                channelController.get().updateLastSentMessage(tick.channelId, tick.messageId, tick.ts)
+                clansController.get().setHasUnread(tick.clanId)
+                clansTouched.add(tick.clanId)
+            }
+            if (batch.isNotEmpty()) {
+                notificationCenter.postNotificationOnMainThread(
+                    NotificationCenter.updateInterfaces, NotificationCenter.UPDATE_MASK_BADGE
+                )
+            }
+            for (cid in clansTouched) {
+                scheduleClanReconcile(cid)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/home/ChannelDescriptionReadState.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChannelDescriptionReadState.kt
@@ -1,0 +1,24 @@
+package com.mezon.mobile.home
+
+import com.mezon.mezon.api.ChannelDescription
+
+private const val TS_MASK = 0xFFFF_FFFFL
+
+fun ChannelDescription.extractLastSentMessageId(): Long =
+    if (hasLastSentMessage() && lastSentMessage.id != 0L) lastSentMessage.id else 0L
+
+fun ChannelDescription.extractLastSeenMessageId(): Long =
+    if (hasLastSeenMessage() && lastSeenMessage.id != 0L) lastSeenMessage.id else 0L
+
+fun ChannelDescription.extractLastSentMessageTs(fallbackToCreateTime: Boolean = true): Long {
+    val fromSent = if (hasLastSentMessage()) {
+        lastSentMessage.timestampSeconds.toLong() and TS_MASK
+    } else {
+        0L
+    }
+    if (fromSent > 0L) return fromSent
+    return if (fallbackToCreateTime) createTimeSeconds.toLong() and TS_MASK else 0L
+}
+
+fun ChannelDescription.extractLastSeenMessageTs(): Long =
+    if (hasLastSeenMessage()) lastSeenMessage.timestampSeconds.toLong() and TS_MASK else 0L

--- a/app/src/main/java/com/mezon/mobile/home/ConnectionController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ConnectionController.kt
@@ -35,6 +35,7 @@ class ConnectionController @Inject constructor(
     private val fcmRepository: FcmRepository,
     private val dialogsController: DialogsController,
     private val clansController: ClansController,
+    private val badgeCoordinator: dagger.Lazy<BadgeCoordinator>,
     @ApplicationContext private val appContext: Context,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     @ApplicationScope private val appScope: CoroutineScope
@@ -76,6 +77,7 @@ class ConnectionController @Inject constructor(
     private fun refreshOnReconnect() {
         Log.d(TAG, "refreshOnReconnect: invalidating cache + refreshing all lists")
 
+        badgeCoordinator.get().onReconnect()
         cacheTracker.invalidateAll()
 
         dialogsController.loadDialogs()

--- a/app/src/main/java/com/mezon/mobile/home/DialogsController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/DialogsController.kt
@@ -15,6 +15,7 @@ import com.mezon.mobile.network.CHANNEL_TYPE_GROUP
 import com.mezon.mobile.network.CODE_CHAT_REMOVE
 import com.mezon.mobile.network.CODE_CHAT_UPDATE
 import com.mezon.mobile.network.MezonApi
+import com.mezon.mobile.network.MezonSocket
 import com.mezon.mobile.network.NetworkMonitor
 import com.mezon.mobile.network.STREAM_MODE_DM
 import com.mezon.mobile.network.STREAM_MODE_GROUP
@@ -24,6 +25,9 @@ import com.mezon.mobile.notification.ActiveChannelTracker
 import com.mezon.mobile.notification.NotificationHelper
 import com.mezon.mobile.session.SessionManager
 import com.mezon.mobile.util.parseContentPreview
+import dagger.Lazy
+import com.mezon.mezon.api.ChannelDescription
+import com.mezon.mezon.rtapi.LastSeenMessageEvent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -44,6 +48,8 @@ class DialogsController @Inject constructor(
     private val cacheTracker: ApiCacheTracker,
     private val activeChannelTracker: ActiveChannelTracker,
     private val notificationHelper: NotificationHelper,
+    private val mezonSocket: MezonSocket,
+    private val badgeCoordinator: Lazy<BadgeCoordinator>,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     @ApplicationScope private val appScope: CoroutineScope
 ) {
@@ -118,56 +124,88 @@ class DialogsController @Inject constructor(
                     val merged = rawList
                         .filter { it.active == 1 }
                         .map { it.toDirectMessage(currentUserId) }
-                        .sortedByDescending { it.lastMessageTimestamp }
+                        .sortedByDescending { it.lastSentMessageTs }
 
                     Log.d(TAG, "loadDialogs: API returned ${merged.size} items")
                     putDialogs(merged)
                     cacheTracker.markCalled(cacheKey)
+                    runCatching {
+                        if (!mezonSocket.awaitConnected()) return@runCatching
+                        val badge = mezonSocket.fetchListChannelBadgeCountSocket(0L)
+                        applyDmReadStatePatchFromSocket(badge.channeldescList)
+                    }
                 }
 
                 dialogsLoaded = true
                 Log.d(TAG, "loadDialogs: done, posting dialogsNeedReload")
                 notificationCenter.postNotificationOnMainThread(NotificationCenter.dialogsNeedReload)
+                badgeCoordinator.get().processDeferredQueue()
             } catch (e: Exception) {
                 Log.e(TAG, "loadDialogs failed", e)
                 dialogsLoaded = true
                 notificationCenter.postNotificationOnMainThread(NotificationCenter.dialogsLoadError, e.message ?: "Failed to load")
+                badgeCoordinator.get().processDeferredQueue()
             }
         }
     }
 
-    fun updateDialogLastSeen(channelId: Long, messageId: Long, remainingUnread: Int) {
+    fun updateDialogLastSeen(
+        channelId: Long,
+        messageId: Long,
+        remainingUnread: Int,
+        timestampSeconds: Int = 0
+    ) {
+        var updated: DirectMessage? = null
         synchronized(this) {
             val dm = dialogsDict[channelId] ?: return
             if (messageId <= dm.lastSeenMessageId) return
-            val updated = dm.copy(
+            val newUnread = remainingUnread.coerceAtLeast(0)
+            if (newUnread == dm.unreadCount && messageId == dm.lastSeenMessageId) return
+            val tsLong = timestampSeconds.toLong() and 0xFFFF_FFFFL
+            val syncTs = when {
+                newUnread == 0 -> maxOf(dm.lastSeenMessageTs, dm.lastSentMessageTs, tsLong)
+                tsLong > 0L -> maxOf(dm.lastSeenMessageTs, tsLong)
+                else -> dm.lastSeenMessageTs
+            }
+            val u = dm.copy(
                 lastSeenMessageId = messageId,
-                unreadCount = remainingUnread.coerceAtLeast(0)
+                unreadCount = newUnread,
+                lastSeenMessageTs = syncTs
             )
-            dialogsDict.put(channelId, updated)
+            dialogsDict.put(channelId, u)
             val idx = dialogs.indexOfFirst { it.channelId == channelId }
-            if (idx >= 0) { dialogs[idx] = updated }
+            if (idx >= 0) dialogs[idx] = u
+            updated = u
         }
-        appScope.launch { directMessageDao.updateLastSeen(channelId, messageId) }
+        updated?.let { appScope.launch(ioDispatcher) { directMessageDao.upsert(it) } }
     }
 
-    fun markDialogAsRead(channelId: Long, postEvent: Boolean = true) {
+    fun markDialogAsRead(channelId: Long, postEvent: Boolean = true, seenTimestampSeconds: Int = 0) {
         var changed = false
         var newSeenId = 0L
+        var updated: DirectMessage? = null
         synchronized(this) {
             val dm = dialogsDict[channelId]
             if (dm == null || dm.unreadCount == 0) return
             newSeenId = maxOf(dm.lastSeenMessageId, dm.lastSentMessageId)
-            val updated = dm.copy(
+            val tsLong = seenTimestampSeconds.toLong() and 0xFFFF_FFFFL
+            val newSeenTs = maxOf(dm.lastSeenMessageTs, dm.lastSentMessageTs, tsLong)
+            val u = dm.copy(
                 unreadCount = 0,
-                lastSeenMessageId = newSeenId
+                lastSeenMessageId = newSeenId,
+                lastSeenMessageTs = newSeenTs
             )
-            dialogsDict.put(channelId, updated)
+            dialogsDict.put(channelId, u)
             val idx = dialogs.indexOfFirst { it.channelId == channelId }
-            if (idx >= 0) { dialogs[idx] = updated; changed = true }
+            if (idx >= 0) {
+                dialogs[idx] = u
+                changed = true
+            }
+            updated = u
         }
-        if (changed) {
-            appScope.launch { directMessageDao.updateLastSeen(channelId, newSeenId) }
+        if (changed && updated != null) {
+            val row = updated!!
+            appScope.launch(ioDispatcher) { directMessageDao.upsert(row) }
             if (postEvent) {
                 notificationCenter.postNotificationOnMainThread(NotificationCenter.dialogsNeedReload)
                 notificationCenter.postNotificationOnMainThread(
@@ -194,17 +232,19 @@ class DialogsController @Inject constructor(
             }
             val newPreview = if (!isContentMutation || msg.code == CODE_CHAT_UPDATE)
                 parseContentPreview(msg.content) else dm.lastMessageContent
-            val newTimestamp = if (!isContentMutation) msg.createTimeSeconds.toLong() else dm.lastMessageTimestamp
 
             val newSentMessageId = if (!isContentMutation) msg.messageId else dm.lastSentMessageId
 
             val newLastSeenId = if (isFromMe && !isContentMutation && msg.messageId > dm.lastSeenMessageId)
                 msg.messageId else dm.lastSeenMessageId
 
+            val newSentTs = if (!isContentMutation && msg.createTimeSeconds > 0) {
+                maxOf(dm.lastSentMessageTs, msg.createTimeSeconds.toLong() and 0xFFFF_FFFFL)
+            } else dm.lastSentMessageTs
             val result = dm.copy(
                 lastMessageContent = newPreview.ifBlank { dm.lastMessageContent },
-                lastMessageTimestamp = newTimestamp.takeIf { it > 0 } ?: dm.lastMessageTimestamp,
                 lastSentMessageId = newSentMessageId.takeIf { it > 0 } ?: dm.lastSentMessageId,
+                lastSentMessageTs = newSentTs,
                 lastSeenMessageId = newLastSeenId,
                 unreadCount = newUnread
             )
@@ -212,11 +252,21 @@ class DialogsController @Inject constructor(
             dialogsDict.put(msg.channelId, result)
             val idx = dialogs.indexOfFirst { it.channelId == msg.channelId }
             if (idx >= 0) dialogs[idx] = result
-            if (!isContentMutation) dialogs.sortByDescending { it.lastMessageTimestamp }
+            if (!isContentMutation) dialogs.sortByDescending { it.lastSentMessageTs }
         }
         updatedDm?.let { dm ->
             appScope.launch { directMessageDao.upsert(dm) }
             notificationCenter.postNotificationOnMainThread(NotificationCenter.dialogsNeedReload)
+        }
+    }
+
+    private fun mergeDmUnreadFromList(cachedUnread: Int, api: DirectMessage): Int {
+        val listSignalsReadState =
+            api.lastSeenMessageTs != 0L || api.lastSentMessageTs != 0L
+        return when {
+            api.unreadCount != 0 -> api.unreadCount
+            listSignalsReadState -> api.unreadCount
+            else -> cachedUnread
         }
     }
 
@@ -228,8 +278,17 @@ class DialogsController @Inject constructor(
                     dialogsDict.put(dm.channelId, dm)
                 } else {
                     val merged = dm.copy(
+                        label = dm.label.ifBlank { existing.label },
+                        avatarUrl = dm.avatarUrl.ifBlank { existing.avatarUrl },
+                        displayName = dm.displayName.ifBlank { existing.displayName },
+                        lastMessageContent = dm.lastMessageContent.ifBlank { existing.lastMessageContent },
+                        isOnline = existing.isOnline,
+                        otherUserId = if (dm.otherUserId != 0L) dm.otherUserId else existing.otherUserId,
                         lastSeenMessageId = maxOf(existing.lastSeenMessageId, dm.lastSeenMessageId),
-                        unreadCount = if (dm.lastMessageTimestamp >= existing.lastMessageTimestamp) dm.unreadCount else existing.unreadCount
+                        lastSentMessageId = maxOf(existing.lastSentMessageId, dm.lastSentMessageId),
+                        lastSeenMessageTs = maxOf(existing.lastSeenMessageTs, dm.lastSeenMessageTs),
+                        lastSentMessageTs = maxOf(existing.lastSentMessageTs, dm.lastSentMessageTs),
+                        unreadCount = mergeDmUnreadFromList(existing.unreadCount, dm)
                     )
                     dialogsDict.put(dm.channelId, merged)
                 }
@@ -242,9 +301,96 @@ class DialogsController @Inject constructor(
             for (id in toRemove) dialogsDict.remove(id)
             dialogs.clear()
             for (i in 0 until dialogsDict.size()) dialogs.add(dialogsDict.valueAt(i))
-            dialogs.sortByDescending { it.lastMessageTimestamp }
+            dialogs.sortByDescending { it.lastSentMessageTs }
         }
-        appScope.launch { directMessageDao.upsertAll(list) }
+        appScope.launch(ioDispatcher) {
+            val snapshot = synchronized(this@DialogsController) { ArrayList(dialogs) }
+            directMessageDao.upsertAll(snapshot)
+        }
+    }
+
+    private fun patchDmRowReadStateFromSparseBadge(
+        row: DirectMessage,
+        p: ChannelDescription
+    ): Pair<DirectMessage, Boolean> {
+        var next = row
+        var changed = false
+        if (p.countMessUnread != next.unreadCount) {
+            changed = true
+            next = next.copy(unreadCount = p.countMessUnread)
+        }
+        if (p.hasLastSentMessage()) {
+            val m = p.lastSentMessage
+            if (m.id != 0L) {
+                val merged = maxOf(next.lastSentMessageId, m.id)
+                if (merged != next.lastSentMessageId) {
+                    changed = true
+                    next = next.copy(lastSentMessageId = merged)
+                }
+            }
+            val ts = m.timestampSeconds.toLong() and 0xFFFF_FFFFL
+            if (ts > 0L) {
+                val mergedTs = maxOf(next.lastSentMessageTs, ts)
+                if (mergedTs != next.lastSentMessageTs) {
+                    changed = true
+                    next = next.copy(lastSentMessageTs = mergedTs)
+                }
+            }
+        }
+        if (p.hasLastSeenMessage()) {
+            val m = p.lastSeenMessage
+            if (m.id != 0L) {
+                val merged = maxOf(next.lastSeenMessageId, m.id)
+                if (merged != next.lastSeenMessageId) {
+                    changed = true
+                    next = next.copy(lastSeenMessageId = merged)
+                }
+            }
+            val ts = m.timestampSeconds.toLong() and 0xFFFF_FFFFL
+            if (ts > 0L) {
+                val mergedTs = maxOf(next.lastSeenMessageTs, ts)
+                if (mergedTs != next.lastSeenMessageTs) {
+                    changed = true
+                    next = next.copy(lastSeenMessageTs = mergedTs)
+                }
+            }
+        }
+        return Pair(next, changed)
+    }
+
+    private fun applyDmReadStatePatchFromSocket(badgeDescs: List<ChannelDescription>) {
+        if (badgeDescs.isEmpty()) return
+        val byId = badgeDescs.associateBy { it.channelId }
+        var changed = false
+        synchronized(this) {
+            val newList = ArrayList<DirectMessage>(dialogs.size)
+            for (row in dialogs) {
+                val p = byId[row.channelId]
+                if (p == null) {
+                    newList.add(row)
+                } else {
+                    val (next, rowChanged) = patchDmRowReadStateFromSparseBadge(row, p)
+                    if (rowChanged) {
+                        changed = true
+                        dialogsDict.put(next.channelId, next)
+                    }
+                    newList.add(next)
+                }
+            }
+            if (changed) {
+                dialogs.clear()
+                dialogs.addAll(newList.sortedByDescending { it.lastSentMessageTs })
+            }
+        }
+        if (!changed) return
+        appScope.launch(ioDispatcher) {
+            val snapshot = synchronized(this@DialogsController) { ArrayList(dialogs) }
+            directMessageDao.upsertAll(snapshot)
+        }
+        notificationCenter.postNotificationOnMainThread(NotificationCenter.dialogsNeedReload)
+        notificationCenter.postNotificationOnMainThread(
+            NotificationCenter.updateInterfaces, NotificationCenter.UPDATE_MASK_BADGE
+        )
     }
 
     private suspend fun loadDialogsFromDb() {
@@ -252,23 +398,17 @@ class DialogsController @Inject constructor(
         val cached = withContext(ioDispatcher) { directMessageDao.getAll() }
         Log.d(TAG, "loadDialogsFromDb: Room returned ${cached.size} items")
         if (cached.isNotEmpty()) {
-            var staleReadStateCount = 0
             synchronized(this) {
                 dialogs.clear()
                 dialogsDict.clear()
-                val sorted = cached.sortedByDescending { it.lastMessageTimestamp }
+                val sorted = cached.sortedByDescending { it.lastSentMessageTs }
                 dialogs.addAll(sorted)
                 for (dm in sorted) {
                     dialogsDict.put(dm.channelId, dm)
-                    if (dm.lastSeenMessageId == 0L && dm.lastSentMessageId != 0L) staleReadStateCount++
                 }
             }
-            Log.d(TAG, "loadDialogsFromDb: done, posting dialogsNeedReload (staleReadState=$staleReadStateCount)")
+            Log.d(TAG, "loadDialogsFromDb: done, posting dialogsNeedReload")
             notificationCenter.postNotificationOnMainThread(NotificationCenter.dialogsNeedReload)
-            if (staleReadStateCount > 0) {
-                Log.d(TAG, "loadDialogsFromDb: $staleReadStateCount dialogs with stale read state, scheduling API refresh")
-                loadDialogs()
-            }
         } else {
             Log.d(TAG, "loadDialogsFromDb: empty cache, no notification")
         }
@@ -317,27 +457,73 @@ class DialogsController @Inject constructor(
 
     private suspend fun observeLastSeenMessages() {
         socketEventDispatcher.lastSeenMessageEvents.collect { event ->
-            if (event.channelId == 0L || event.messageId == 0L) return@collect
-            if (event.clanId != 0L) return@collect
-            updateLastSeen(event.channelId, event.messageId)
+            applyLastSeenDmFromSocket(event)
         }
     }
 
-    fun updateLastSeen(channelId: Long, messageId: Long) {
+    private fun applyLastSeenDmFromSocket(event: LastSeenMessageEvent) {
+        if (event.channelId == 0L) return
+        if (event.clanId != 0L) return
+        val ts = event.timestampSeconds
+        when {
+            event.messageId != 0L && event.badgeCount == 0 ->
+                updateLastSeen(event.channelId, event.messageId, ts)
+            event.messageId != 0L ->
+                updateDialogLastSeen(event.channelId, event.messageId, event.badgeCount, ts)
+            ts != 0 ->
+                applyLastSeenTsOnlyDm(event.channelId, ts, event.badgeCount)
+        }
+    }
+
+    private fun applyLastSeenTsOnlyDm(channelId: Long, timestampSeconds: Int, badgeCount: Int) {
+        val tsLong = timestampSeconds.toLong() and 0xFFFF_FFFFL
+        if (tsLong == 0L) return
+        var updated: DirectMessage? = null
+        synchronized(this) {
+            val dm = dialogsDict[channelId] ?: return
+            val newSeenTs = maxOf(dm.lastSeenMessageTs, tsLong)
+            val newUnread = badgeCount.coerceAtLeast(0)
+            if (newSeenTs == dm.lastSeenMessageTs && newUnread == dm.unreadCount) return
+            val u = dm.copy(
+                lastSeenMessageTs = newSeenTs,
+                unreadCount = newUnread
+            )
+            dialogsDict.put(channelId, u)
+            val idx = dialogs.indexOfFirst { it.channelId == channelId }
+            if (idx >= 0) dialogs[idx] = u
+            updated = u
+        }
+        updated?.let { appScope.launch(ioDispatcher) { directMessageDao.upsert(it) } }
+        notificationCenter.postNotificationOnMainThread(NotificationCenter.dialogsNeedReload)
+        notificationCenter.postNotificationOnMainThread(
+            NotificationCenter.updateInterfaces, NotificationCenter.UPDATE_MASK_READ_DIALOG_MESSAGE
+        )
+    }
+
+    fun updateLastSeen(channelId: Long, messageId: Long, timestampSeconds: Int = 0) {
         var changed = false
+        var updated: DirectMessage? = null
         synchronized(this) {
             val dm = dialogsDict[channelId] ?: return
             if (messageId <= dm.lastSeenMessageId) return
-            val updated = dm.copy(
+            val tsLong = timestampSeconds.toLong() and 0xFFFF_FFFFL
+            val newSeenTs = maxOf(dm.lastSeenMessageTs, dm.lastSentMessageTs, tsLong)
+            val u = dm.copy(
                 lastSeenMessageId = messageId,
-                unreadCount = 0
+                unreadCount = 0,
+                lastSeenMessageTs = newSeenTs
             )
-            dialogsDict.put(channelId, updated)
+            dialogsDict.put(channelId, u)
             val idx = dialogs.indexOfFirst { it.channelId == channelId }
-            if (idx >= 0) { dialogs[idx] = updated; changed = true }
+            if (idx >= 0) {
+                dialogs[idx] = u
+                changed = true
+            }
+            updated = u
         }
-        if (changed) {
-            appScope.launch { directMessageDao.updateLastSeen(channelId, messageId) }
+        if (changed && updated != null) {
+            val row = updated!!
+            appScope.launch(ioDispatcher) { directMessageDao.upsert(row) }
             notificationCenter.postNotificationOnMainThread(NotificationCenter.dialogsNeedReload)
             notificationCenter.postNotificationOnMainThread(
                 NotificationCenter.updateInterfaces, NotificationCenter.UPDATE_MASK_READ_DIALOG_MESSAGE

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -1948,7 +1948,7 @@ class ChatFragment : BaseFragment() {
             refType = 0
             messageSenderId = target.senderId
             messageSenderUsername = target.senderName
-            mesagesSenderAvatar = target.senderAvatar
+            messageSenderAvatar = target.senderAvatar
             messageSenderDisplayName = target.senderName
             content = target.content
             hasAttachment = target.hasMedia || target.isFileAttachment

--- a/app/src/main/java/com/mezon/mobile/home/chat/ImageReceiver.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ImageReceiver.kt
@@ -34,6 +34,8 @@ class ImageReceiver(private val parentView: View) {
     private var requestH = 0
     private val roundRadius = IntArray(4)
 
+    private var pendingLocalUri: android.net.Uri? = null
+
     private var crossfadeAlpha = 255
     private var crossfadeStartTime = 0L
     private val crossfadeDuration = 200L
@@ -91,6 +93,10 @@ class ImageReceiver(private val parentView: View) {
             currentThumbUrl = null
             setImage(url, thumbUrl, parentView.context)
         }
+        pendingLocalUri?.let { uri ->
+            pendingLocalUri = null
+            setLocalUri(uri, parentView.context)
+        }
     }
 
     fun onDetachedFromWindow() {
@@ -100,6 +106,7 @@ class ImageReceiver(private val parentView: View) {
         mainCancellable = null
         thumbCancellable?.cancel()
         thumbCancellable = null
+        pendingLocalUri = null
     }
 
     fun setImage(url: String?, thumbUrl: String?, context: Context) {
@@ -408,6 +415,29 @@ class ImageReceiver(private val parentView: View) {
         currentUrl = null
         currentThumbUrl = null
         pendingLoad = null
+        pendingLocalUri = null
+    }
+
+    fun setLocalUri(uri: android.net.Uri, context: Context) {
+        if (!attached) {
+            pendingLocalUri = uri
+            return
+        }
+        mainCancellable?.cancel()
+        val loader = MezonImageLoader.getInstance(context)
+        val rw = if (requestW > 0) requestW else 800
+        val rh = if (requestH > 0) requestH else 800
+        mainCancellable = loader.loadFromUri(uri, rw, rh,
+            onSuccess = { bmp ->
+                imageBitmap = bmp
+                animatedDrawable = null
+                cachedShader = null
+                cachedShaderBitmap = null
+                crossfadeAlpha = 255
+                thumbBitmap = null
+                parentView.invalidate()
+            }
+        )
     }
 
     fun setBitmapDirectly(bmp: Bitmap) {

--- a/app/src/main/java/com/mezon/mobile/home/chat/MessageEntity.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/MessageEntity.kt
@@ -49,10 +49,15 @@ data class MessageEntity(
     val hideEditted: Boolean = true,
     val isForwarded: Boolean = false,
     val isError: Boolean = false,
-    val extraAttachmentsJson: String = ""
+    val extraAttachmentsJson: String = "",
+    val sendState: Int = SEND_STATE_SENT
 ) {
     companion object {
         const val UNREAD_DIVIDER_ID = Long.MIN_VALUE
+
+        const val SEND_STATE_SENT = 0
+        const val SEND_STATE_SENDING = 1
+        const val SEND_STATE_ERROR = 2
 
         const val TYPE_TEXT = 0
         const val TYPE_PHOTO = 1
@@ -100,6 +105,9 @@ data class MessageEntity(
 
     val isRenderable: Boolean
         get() = isNormalMessage || isSystemMessage
+
+    val isSending: Boolean
+        get() = sendState == SEND_STATE_SENDING
 
     val isEdited: Boolean
         get() = updateTimeSeconds > 0 && updateTimeSeconds > timestampSeconds && !isError
@@ -282,10 +290,10 @@ private fun mergeReferencesIntoContent(content: String, referencesBytes: com.goo
             item.put("ref_type", ref.refType)
             item.put("message_sender_id", ref.messageSenderId.toString())
             item.put("message_sender_username", ref.messageSenderUsername)
-            item.put("mesages_sender_avatar", ref.mesagesSenderAvatar)
+            item.put("mesages_sender_avatar", ref.messageSenderAvatar)
             item.put("message_sender_clan_nick", ref.messageSenderClanNick)
             item.put("message_sender_display_name", ref.messageSenderDisplayName)
-            Log.d("ReplyAvatar", "mergeRef: senderId=${ref.messageSenderId} name=${ref.messageSenderDisplayName} avatar=[${ref.mesagesSenderAvatar}]")
+            Log.d("ReplyAvatar", "mergeRef: senderId=${ref.messageSenderId} name=${ref.messageSenderDisplayName} avatar=[${ref.messageSenderAvatar}]")
             item.put("content", ref.content)
             item.put("has_attachment", ref.hasAttachment)
             arr.put(item)

--- a/app/src/main/java/com/mezon/mobile/home/clans/ChannelController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ChannelController.kt
@@ -8,10 +8,13 @@ import com.mezon.mobile.network.ApiCacheTracker
 import com.mezon.mobile.network.CODE_CHAT_REMOVE
 import com.mezon.mobile.network.CODE_CHAT_UPDATE
 import com.mezon.mobile.network.MezonApi
+import com.mezon.mobile.network.MezonSocket
 import com.mezon.mobile.network.STREAM_MODE_DM
 import com.mezon.mobile.network.SocketEventDispatcher
 import com.mezon.mobile.network.apiCacheKey
 import com.mezon.mobile.session.SessionManager
+import com.mezon.mezon.api.ChannelDescription
+import com.mezon.mezon.rtapi.LastSeenMessageEvent
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -21,6 +24,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -37,61 +41,81 @@ class ChannelController @Inject constructor(
     private val notificationCenter: NotificationCenter,
     private val cacheTracker: ApiCacheTracker,
     private val clansController: dagger.Lazy<ClansController>,
+    private val badgeCoordinator: dagger.Lazy<com.mezon.mobile.home.BadgeCoordinator>,
+    private val mezonSocket: MezonSocket,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     @ApplicationScope private val appScope: CoroutineScope
 ) {
     private val _channelsByClan = MutableStateFlow<Map<Long, List<ClanChannelEntity>>>(emptyMap())
     val channelsByClan: StateFlow<Map<Long, List<ClanChannelEntity>>> = _channelsByClan.asStateFlow()
 
+    private val channelListLoading = ConcurrentHashMap<Long, Boolean>()
+
     init {
         observeSocketEvents()
     }
+
+    fun isChannelListLoading(clanId: Long): Boolean = channelListLoading[clanId] == true
 
     fun cleanup() {
         _channelsByClan.value = emptyMap()
         currentOpenChannelId = 0L
         processedBadgeKeys.clear()
+        channelListLoading.clear()
     }
 
     fun loadChannelsForClan(clanId: Long, force: Boolean = false) {
+        appScope.launch { loadChannelsForClanNow(clanId, force) }
+    }
+
+    internal suspend fun loadChannelsForClanNow(clanId: Long, force: Boolean = false) {
         val cacheKey = apiCacheKey("listChannelsByClan", clanId.toString())
-        appScope.launch {
-            var hasStaleReadState = false
-            val inMemory = _channelsByClan.value[clanId]
-            if (!inMemory.isNullOrEmpty()) {
+        val inMemory = _channelsByClan.value[clanId]
+        if (!inMemory.isNullOrEmpty()) {
+            notificationCenter.postNotificationOnMainThread(NotificationCenter.channelsDidLoad, clanId)
+        } else {
+            val cached = withContext(ioDispatcher) { clanChannelDao.getByClan(clanId) }
+            if (cached.isNotEmpty()) {
+                updateCache(clanId, cached)
                 notificationCenter.postNotificationOnMainThread(NotificationCenter.channelsDidLoad, clanId)
-            } else {
-                val cached = withContext(ioDispatcher) { clanChannelDao.getByClan(clanId) }
-                if (cached.isNotEmpty()) {
-                    updateCache(clanId, cached)
-                    notificationCenter.postNotificationOnMainThread(NotificationCenter.channelsDidLoad, clanId)
-                    hasStaleReadState = cached.any { it.lastSeenMessageId == 0L && it.lastSentMessageId != 0L }
-                }
             }
-            val shouldForce = force || hasStaleReadState
-            if (!shouldForce && cacheTracker.shouldCall(cacheKey) == ApiCacheTracker.ShouldCall.SKIP) {
-                return@launch
+        }
+        val shouldForce = force
+        if (!shouldForce && cacheTracker.shouldCall(cacheKey) == ApiCacheTracker.ShouldCall.SKIP) {
+            return
+        }
+        channelListLoading[clanId] = true
+        try {
+            val session = sessionManager.sessionFlow.first() ?: return
+            val result = withContext(ioDispatcher) {
+                api.listChannelsByClan(session.apiUrl, session.token, clanId)
             }
-            try {
-                val session = sessionManager.sessionFlow.first() ?: return@launch
-                val result = withContext(ioDispatcher) {
-                    api.listChannelsByClan(session.apiUrl, session.token, clanId)
-                }
-                val categoryOrderMap = LinkedHashMap<Long, Int>()
-                result.channeldescList.forEach { ch ->
-                    categoryOrderMap.putIfAbsent(ch.categoryId, categoryOrderMap.size)
-                }
-                val entities = result.channeldescList.map { ch ->
+            val categoryOrderMap = LinkedHashMap<Long, Int>()
+            result.channeldescList.forEach { ch ->
+                categoryOrderMap.putIfAbsent(ch.categoryId, categoryOrderMap.size)
+            }
+            val entities = result.channeldescList.map { ch ->
+                withClanIdFromContext(
+                    clanId,
                     ch.toClanChannelEntity().copy(categoryOrder = categoryOrderMap[ch.categoryId] ?: 0)
-                }
-                mergeCache(clanId, entities)
-                cacheTracker.markCalled(cacheKey)
-                withContext(ioDispatcher) { clanChannelDao.upsertAll(entities) }
-                val merged = _channelsByClan.value[clanId] ?: entities
-                clansController.get().syncClanBadgeFromChannels(clanId, merged)
-                notificationCenter.postNotificationOnMainThread(NotificationCenter.channelsDidLoad, clanId)
-            } catch (_: Exception) {
+                )
             }
+            mergeCache(clanId, entities)
+            runCatching {
+                if (!mezonSocket.awaitConnected()) return@runCatching
+                val badge = mezonSocket.fetchListChannelBadgeCountSocket(clanId)
+                if (badge.channeldescList.isNotEmpty()) {
+                    applyChannelBadgeReadStatePatch(clanId, badge.channeldescList)
+                }
+            }
+            cacheTracker.markCalled(cacheKey)
+            val merged = _channelsByClan.value[clanId] ?: entities
+            withContext(ioDispatcher) { clanChannelDao.upsertAll(merged) }
+            notificationCenter.postNotificationOnMainThread(NotificationCenter.channelsDidLoad, clanId)
+        } catch (_: Exception) {
+        } finally {
+            channelListLoading.remove(clanId)
+            badgeCoordinator.get().processDeferredQueue()
         }
     }
 
@@ -114,7 +138,9 @@ class ChannelController @Inject constructor(
             val result = runCatching {
                 withContext(ioDispatcher) { api.listChannelsByClan(session.apiUrl, session.token, clanId) }
             }.getOrNull() ?: return ""
-            val entities = result.channeldescList.map { it.toClanChannelEntity() }
+            val entities = result.channeldescList.map { ch ->
+                withClanIdFromContext(clanId, ch.toClanChannelEntity())
+            }
             updateCache(clanId, entities)
             withContext(ioDispatcher) { clanChannelDao.upsertAll(entities) }
         }
@@ -151,17 +177,110 @@ class ChannelController @Inject constructor(
         _channelsByClan.value = updated
     }
 
+    private fun withClanIdFromContext(contextClanId: Long, entity: ClanChannelEntity): ClanChannelEntity =
+        if (entity.clanId != 0L) entity else entity.copy(clanId = contextClanId)
+
+    private fun applyChannelBadgeReadStatePatch(clanId: Long, badgeDescs: List<ChannelDescription>) {
+        val existing = _channelsByClan.value[clanId] ?: return
+        if (badgeDescs.isEmpty()) return
+        val byId = badgeDescs.associateBy { it.channelId }
+        var changed = false
+        val updated = existing.map { row ->
+            val p = byId[row.channelId] ?: return@map row
+            val (next, rowChanged) = patchChannelRowReadStateFromSparseBadge(row, p)
+            if (rowChanged) changed = true
+            next
+        }
+        if (!changed) return
+        updateCache(clanId, updated)
+    }
+
+    private fun patchChannelRowReadStateFromSparseBadge(
+        row: ClanChannelEntity,
+        p: ChannelDescription
+    ): Pair<ClanChannelEntity, Boolean> {
+        var next = row
+        var changed = false
+        if (p.countMessUnread != next.unreadCount) {
+            changed = true
+            next = next.copy(unreadCount = p.countMessUnread)
+        }
+        if (p.hasLastSentMessage()) {
+            val m = p.lastSentMessage
+            if (m.id != 0L) {
+                val merged = maxOf(next.lastSentMessageId, m.id)
+                if (merged != next.lastSentMessageId) {
+                    changed = true
+                    next = next.copy(lastSentMessageId = merged)
+                }
+            }
+            val ts = m.timestampSeconds.toLong() and 0xFFFF_FFFFL
+            if (ts > 0L) {
+                val mergedTs = maxOf(next.lastSentMessageTs, ts)
+                if (mergedTs != next.lastSentMessageTs) {
+                    changed = true
+                    next = next.copy(lastSentMessageTs = mergedTs)
+                }
+            }
+        }
+        if (p.hasLastSeenMessage()) {
+            val m = p.lastSeenMessage
+            if (m.id != 0L) {
+                val merged = maxOf(next.lastSeenMessageId, m.id)
+                if (merged != next.lastSeenMessageId) {
+                    changed = true
+                    next = next.copy(lastSeenMessageId = merged)
+                }
+            }
+            val ts = m.timestampSeconds.toLong() and 0xFFFF_FFFFL
+            if (ts > 0L) {
+                val mergedTs = maxOf(next.lastSeenMessageTs, ts)
+                if (mergedTs != next.lastSeenMessageTs) {
+                    changed = true
+                    next = next.copy(lastSeenMessageTs = mergedTs)
+                }
+            }
+        }
+        return Pair(next, changed)
+    }
+
+    private fun mergeUnreadFromChannelList(cachedUnread: Int, apiNorm: ClanChannelEntity): Int {
+        val listSignalsReadState =
+            apiNorm.lastSeenMessageTs != 0L || apiNorm.lastSentMessageTs != 0L
+        return when {
+            apiNorm.unreadCount != 0 -> apiNorm.unreadCount
+            listSignalsReadState -> apiNorm.unreadCount
+            else -> cachedUnread
+        }
+    }
+
     private fun mergeCache(clanId: Long, apiChannels: List<ClanChannelEntity>) {
         val existing = _channelsByClan.value[clanId] ?: emptyList()
         val existingMap = existing.associateBy { it.channelId }
         val merged = apiChannels.map { apiCh ->
-            val cached = existingMap[apiCh.channelId]
+            val apiNorm = withClanIdFromContext(clanId, apiCh)
+            val cached = existingMap[apiNorm.channelId]
             if (cached == null) {
-                apiCh
+                apiNorm
             } else {
-                apiCh.copy(
-                    lastSeenMessageId = maxOf(cached.lastSeenMessageId, apiCh.lastSeenMessageId),
-                    unreadCount = if (apiCh.lastSentMessageId >= cached.lastSentMessageId) apiCh.unreadCount else cached.unreadCount
+                apiNorm.copy(
+                    clanId = when {
+                        apiNorm.clanId != 0L -> apiNorm.clanId
+                        cached.clanId != 0L -> cached.clanId
+                        else -> clanId
+                    },
+                    channelLabel = apiNorm.channelLabel.ifBlank { cached.channelLabel },
+                    categoryName = apiNorm.categoryName.ifBlank { cached.categoryName },
+                    topic = apiNorm.topic.ifBlank { cached.topic },
+                    type = if (apiNorm.type != 0) apiNorm.type else cached.type,
+                    parentId = if (apiNorm.parentId != 0L) apiNorm.parentId else cached.parentId,
+                    categoryId = if (apiNorm.categoryId != 0L) apiNorm.categoryId else cached.categoryId,
+                    isPrivate = if (apiNorm.type != 0) apiNorm.isPrivate else cached.isPrivate,
+                    lastSeenMessageId = maxOf(cached.lastSeenMessageId, apiNorm.lastSeenMessageId),
+                    lastSentMessageId = maxOf(cached.lastSentMessageId, apiNorm.lastSentMessageId),
+                    lastSeenMessageTs = maxOf(cached.lastSeenMessageTs, apiNorm.lastSeenMessageTs),
+                    lastSentMessageTs = maxOf(cached.lastSentMessageTs, apiNorm.lastSentMessageTs),
+                    unreadCount = mergeUnreadFromChannelList(cached.unreadCount, apiNorm)
                 )
             }
         }.sortedWith(compareBy<ClanChannelEntity> { it.categoryOrder }
@@ -200,14 +319,16 @@ class ChannelController @Inject constructor(
         return 0L
     }
 
-    fun updateLastSentMessage(channelId: Long, messageId: Long) {
+    fun updateLastSentMessage(channelId: Long, messageId: Long, createTimeSeconds: Long = 0L) {
         for ((clanId, channels) in _channelsByClan.value) {
             val idx = channels.indexOfFirst { it.channelId == channelId }
             if (idx >= 0) {
                 val ch = channels[idx]
                 if (messageId <= ch.lastSentMessageId) return
+                val ts = createTimeSeconds and 0xFFFF_FFFFL
+                val newSentTs = if (ts > 0L) maxOf(ch.lastSentMessageTs, ts) else ch.lastSentMessageTs
                 val updated = channels.toMutableList()
-                updated[idx] = ch.copy(lastSentMessageId = messageId)
+                updated[idx] = ch.copy(lastSentMessageId = messageId, lastSentMessageTs = newSentTs)
                 val map = _channelsByClan.value.toMutableMap()
                 map[clanId] = updated
                 _channelsByClan.value = map
@@ -236,7 +357,12 @@ class ChannelController @Inject constructor(
         }
     }
 
-    fun updateChannelLastSeen(channelId: Long, messageId: Long, remainingUnread: Int) {
+    fun updateChannelLastSeen(
+        channelId: Long,
+        messageId: Long,
+        remainingUnread: Int,
+        timestampSeconds: Int = 0
+    ) {
         for ((clanId, channels) in _channelsByClan.value) {
             val idx = channels.indexOfFirst { it.channelId == channelId }
             if (idx >= 0) {
@@ -245,23 +371,31 @@ class ChannelController @Inject constructor(
                 val oldUnread = ch.unreadCount
                 val newUnread = remainingUnread.coerceAtLeast(0)
                 if (newUnread == oldUnread && messageId == ch.lastSeenMessageId) return
-                val updated = channels.toMutableList()
-                updated[idx] = ch.copy(
+                val tsLong = timestampSeconds.toLong() and 0xFFFF_FFFFL
+                val syncTs = when {
+                    newUnread == 0 -> maxOf(ch.lastSeenMessageTs, ch.lastSentMessageTs, tsLong)
+                    tsLong > 0L -> maxOf(ch.lastSeenMessageTs, tsLong)
+                    else -> ch.lastSeenMessageTs
+                }
+                val newRow = ch.copy(
                     lastSeenMessageId = messageId,
-                    unreadCount = newUnread
+                    unreadCount = newUnread,
+                    lastSeenMessageTs = syncTs
                 )
+                val updated = channels.toMutableList()
+                updated[idx] = newRow
                 val map = _channelsByClan.value.toMutableMap()
                 map[clanId] = updated
                 _channelsByClan.value = map
                 val delta = newUnread - oldUnread
                 if (delta != 0) clansController.get().updateClanBadgeCount(clanId, delta)
-                appScope.launch(ioDispatcher) { clanChannelDao.updateLastSeen(channelId, messageId) }
+                appScope.launch(ioDispatcher) { clanChannelDao.upsert(newRow) }
                 return
             }
         }
     }
 
-    fun markChannelAsRead(channelId: Long) {
+    fun markChannelAsRead(channelId: Long, seenTimestampSeconds: Int = 0) {
         for ((clanId, channels) in _channelsByClan.value) {
             val idx = channels.indexOfFirst { it.channelId == channelId }
             if (idx >= 0) {
@@ -269,44 +403,95 @@ class ChannelController @Inject constructor(
                 if (!ch.hasUnread && ch.unreadCount == 0) return
                 val oldUnread = ch.unreadCount
                 val newSeenId = maxOf(ch.lastSeenMessageId, ch.lastSentMessageId)
-                val updated = channels.toMutableList()
-                updated[idx] = ch.copy(
+                val tsLong = seenTimestampSeconds.toLong() and 0xFFFF_FFFFL
+                val newSeenTs = maxOf(ch.lastSeenMessageTs, ch.lastSentMessageTs, tsLong)
+                val newRow = ch.copy(
                     unreadCount = 0,
-                    lastSeenMessageId = newSeenId
+                    lastSeenMessageId = newSeenId,
+                    lastSeenMessageTs = newSeenTs
                 )
+                val updated = channels.toMutableList()
+                updated[idx] = newRow
                 val map = _channelsByClan.value.toMutableMap()
                 map[clanId] = updated
                 _channelsByClan.value = map
                 if (oldUnread > 0) clansController.get().updateClanBadgeCount(clanId, -oldUnread)
-                appScope.launch(ioDispatcher) { clanChannelDao.updateLastSeen(channelId, newSeenId) }
+                appScope.launch(ioDispatcher) { clanChannelDao.upsert(newRow) }
                 notificationCenter.postNotificationOnMainThread(NotificationCenter.channelsDidLoad, clanId)
                 return
             }
         }
     }
 
-    fun updateLastSeen(channelId: Long, messageId: Long) {
+    fun updateLastSeen(channelId: Long, messageId: Long, timestampSeconds: Int = 0) {
         for ((clanId, channels) in _channelsByClan.value) {
             val idx = channels.indexOfFirst { it.channelId == channelId }
             if (idx >= 0) {
                 val ch = channels[idx]
                 if (messageId <= ch.lastSeenMessageId) return
                 val oldUnread = ch.unreadCount
-                val updated = channels.toMutableList()
-                updated[idx] = ch.copy(
+                val tsLong = timestampSeconds.toLong() and 0xFFFF_FFFFL
+                val newSeenTs = maxOf(ch.lastSeenMessageTs, ch.lastSentMessageTs, tsLong)
+                val newRow = ch.copy(
                     lastSeenMessageId = messageId,
-                    unreadCount = 0
+                    unreadCount = 0,
+                    lastSeenMessageTs = newSeenTs
                 )
+                val updated = channels.toMutableList()
+                updated[idx] = newRow
                 val map = _channelsByClan.value.toMutableMap()
                 map[clanId] = updated
                 _channelsByClan.value = map
                 if (oldUnread > 0) clansController.get().updateClanBadgeCount(clanId, -oldUnread)
-                appScope.launch(ioDispatcher) { clanChannelDao.updateLastSeen(channelId, messageId) }
+                appScope.launch(ioDispatcher) { clanChannelDao.upsert(newRow) }
                 notificationCenter.postNotificationOnMainThread(
                     NotificationCenter.updateInterfaces, NotificationCenter.UPDATE_MASK_BADGE
                 )
                 return
             }
+        }
+    }
+
+    private fun applyLastSeenMessageSocketEvent(event: LastSeenMessageEvent) {
+        if (event.channelId == 0L || event.clanId == 0L) return
+        val ts = event.timestampSeconds
+        when {
+            event.messageId != 0L && event.badgeCount == 0 ->
+                updateLastSeen(event.channelId, event.messageId, ts)
+            event.messageId != 0L ->
+                updateChannelLastSeen(event.channelId, event.messageId, event.badgeCount, ts)
+            ts != 0 ->
+                applyLastSeenTsOnlyFromSocket(event.channelId, ts, event.badgeCount)
+        }
+    }
+
+    private fun applyLastSeenTsOnlyFromSocket(channelId: Long, timestampSeconds: Int, badgeCount: Int) {
+        val tsLong = timestampSeconds.toLong() and 0xFFFF_FFFFL
+        if (tsLong == 0L) return
+        for ((clanId, channels) in _channelsByClan.value) {
+            val idx = channels.indexOfFirst { it.channelId == channelId }
+            if (idx < 0) return
+            val ch = channels[idx]
+            val newSeenTs = maxOf(ch.lastSeenMessageTs, tsLong)
+            val newUnread = badgeCount.coerceAtLeast(0)
+            if (newSeenTs == ch.lastSeenMessageTs && newUnread == ch.unreadCount) return
+            val oldUnread = ch.unreadCount
+            val newRow = ch.copy(
+                lastSeenMessageTs = newSeenTs,
+                unreadCount = newUnread
+            )
+            val updated = channels.toMutableList()
+            updated[idx] = newRow
+            val map = _channelsByClan.value.toMutableMap()
+            map[clanId] = updated
+            _channelsByClan.value = map
+            val delta = newUnread - oldUnread
+            if (delta != 0) clansController.get().updateClanBadgeCount(clanId, delta)
+            appScope.launch(ioDispatcher) { clanChannelDao.upsert(newRow) }
+            notificationCenter.postNotificationOnMainThread(
+                NotificationCenter.updateInterfaces, NotificationCenter.UPDATE_MASK_BADGE
+            )
+            return
         }
     }
 
@@ -353,14 +538,16 @@ class ChannelController @Inject constructor(
                 if (msg.code == CODE_CHAT_UPDATE || msg.code == CODE_CHAT_REMOVE) return@collect
                 if (msg.senderId == currentUserId) return@collect
                 if (msg.channelId == currentOpenChannelId) return@collect
-                updateLastSentMessage(msg.channelId, msg.messageId)
+                val msgTs = msg.createTimeSeconds.toLong() and 0xFFFF_FFFFL
                 val clanId = findClanIdForChannel(msg.channelId)
                 if (clanId != 0L) {
-                    clansController.get().setHasUnread(clanId)
+                    badgeCoordinator.get().onIncomingUnreadChannelSignal(clanId, msg.channelId, msg.messageId, msgTs)
+                } else {
+                    updateLastSentMessage(msg.channelId, msg.messageId, msgTs)
+                    notificationCenter.postNotificationOnMainThread(
+                        NotificationCenter.updateInterfaces, NotificationCenter.UPDATE_MASK_BADGE
+                    )
                 }
-                notificationCenter.postNotificationOnMainThread(
-                    NotificationCenter.updateInterfaces, NotificationCenter.UPDATE_MASK_BADGE
-                )
             }
         }
 
@@ -414,9 +601,7 @@ class ChannelController @Inject constructor(
 
         appScope.launch {
             dispatcher.lastSeenMessageEvents.collect { event ->
-                if (event.channelId == 0L || event.messageId == 0L) return@collect
-                if (event.clanId == 0L) return@collect
-                updateLastSeen(event.channelId, event.messageId)
+                applyLastSeenMessageSocketEvent(event)
             }
         }
 

--- a/app/src/main/java/com/mezon/mobile/home/clans/ChannelItemCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ChannelItemCell.kt
@@ -85,7 +85,7 @@ class ChannelItemCell(
         var needInvalidate = false
 
         if ((mask and NotificationCenter.UPDATE_MASK_BADGE) != 0) {
-            if (channel?.unreadCount != ch.unreadCount) {
+            if (channel?.unreadCount != ch.unreadCount || channel?.hasUnread != ch.hasUnread) {
                 needInvalidate = true
                 truncatedName = ""
             }

--- a/app/src/main/java/com/mezon/mobile/home/clans/ChannelThreadCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ChannelThreadCell.kt
@@ -77,7 +77,7 @@ class ChannelThreadCell(
         var needInvalidate = false
 
         if ((mask and NotificationCenter.UPDATE_MASK_BADGE) != 0) {
-            if (thread?.unreadCount != th.unreadCount) {
+            if (thread?.unreadCount != th.unreadCount || thread?.hasUnread != th.hasUnread) {
                 truncatedName = ""
                 needInvalidate = true
             }

--- a/app/src/main/java/com/mezon/mobile/home/clans/ClanChannelEntity.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ClanChannelEntity.kt
@@ -3,6 +3,10 @@ package com.mezon.mobile.home.clans
 import androidx.room.Entity
 import androidx.room.Index
 import com.mezon.mezon.api.ChannelDescription
+import com.mezon.mobile.home.extractLastSeenMessageId
+import com.mezon.mobile.home.extractLastSeenMessageTs
+import com.mezon.mobile.home.extractLastSentMessageId
+import com.mezon.mobile.home.extractLastSentMessageTs
 
 const val CHANNEL_TYPE_VOICE = 10
 const val CHANNEL_TYPE_FORUM = 5
@@ -28,11 +32,20 @@ data class ClanChannelEntity(
     val isMuted: Boolean,
     val lastSeenMessageId: Long = 0L,
     val lastSentMessageId: Long = 0L,
+    val lastSeenMessageTs: Long = 0L,
+    val lastSentMessageTs: Long = 0L,
     val active: Int = 0,
     val categoryOrder: Int = 0
 ) {
     val isThread: Boolean get() = type == 7 && parentId != 0L
-    val hasUnread: Boolean get() = lastSentMessageId != 0L && lastSeenMessageId < lastSentMessageId
+    val hasUnread: Boolean get() {
+        if (unreadCount > 0) return true
+        if (lastSentMessageId != 0L && lastSeenMessageId < lastSentMessageId) return true
+        if (lastSentMessageId == 0L && lastSeenMessageId == 0L &&
+            lastSentMessageTs > lastSeenMessageTs && lastSentMessageTs != 0L
+        ) return true
+        return false
+    }
 }
 
 fun ChannelDescription.toClanChannelEntity(): ClanChannelEntity = ClanChannelEntity(
@@ -47,7 +60,9 @@ fun ChannelDescription.toClanChannelEntity(): ClanChannelEntity = ClanChannelEnt
     topic = topic,
     unreadCount = countMessUnread,
     isMuted = isMute,
-    lastSeenMessageId = if (hasLastSeenMessage()) lastSeenMessage.id else 0L,
-    lastSentMessageId = if (hasLastSentMessage()) lastSentMessage.id else 0L,
+    lastSeenMessageId = extractLastSeenMessageId(),
+    lastSentMessageId = extractLastSentMessageId(),
+    lastSeenMessageTs = extractLastSeenMessageTs(),
+    lastSentMessageTs = extractLastSentMessageTs(fallbackToCreateTime = false),
     active = active
 )

--- a/app/src/main/java/com/mezon/mobile/home/clans/ClansController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ClansController.kt
@@ -9,11 +9,15 @@ import com.mezon.mobile.home.chat.MezonImageLoader
 import com.mezon.mobile.di.ApplicationScope
 import com.mezon.mobile.di.IoDispatcher
 import com.mezon.mobile.network.ApiCacheTracker
+import com.mezon.mezon.api.ClanBadgeCount
 import com.mezon.mobile.network.MezonApi
+import com.mezon.mobile.network.MezonSocket
 import com.mezon.mobile.network.SocketEventDispatcher
 import com.mezon.mobile.network.apiCacheKey
 import com.mezon.mobile.session.SessionManager
 import com.mezon.mobile.util.createImgproxyUrl
+import com.mezon.mobile.home.BadgeCoordinator
+import dagger.Lazy
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -39,6 +43,8 @@ class ClansController @Inject constructor(
     private val notificationCenter: NotificationCenter,
     private val cacheTracker: ApiCacheTracker,
     private val channelController: ChannelController,
+    private val mezonSocket: MezonSocket,
+    private val badgeCoordinator: Lazy<BadgeCoordinator>,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     @ApplicationScope private val appScope: CoroutineScope
 ) {
@@ -60,9 +66,8 @@ class ClansController @Inject constructor(
                 clansLoaded = true
                 preWarmLogos(cached)
                 notificationCenter.postNotificationOnMainThread(NotificationCenter.clansDidLoad)
-                val firstClanId = cached.first().clanId
-                _selectedClanId.value = firstClanId
-                channelController.loadChannelsForClan(firstClanId)
+                selectClan(cached.first().clanId)
+                badgeCoordinator.get().processDeferredQueue()
             }
         }
         observeSocketEvents()
@@ -78,6 +83,15 @@ class ClansController @Inject constructor(
         if (_selectedClanId.value == clanId) return
         _selectedClanId.value = clanId
         channelController.loadChannelsForClan(clanId)
+        appScope.launch {
+            try {
+                if (clanId != 0L && mezonSocket.awaitConnected()) {
+                    mezonSocket.joinClanChat(clanId)
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "joinClanChat($clanId) failed", e)
+            }
+        }
         notificationCenter.postNotificationOnMainThread(NotificationCenter.selectedClanChanged, clanId)
     }
 
@@ -87,12 +101,16 @@ class ClansController @Inject constructor(
             try {
                 val session = sessionManager.sessionFlow.first() ?: return@launch
                 if (!force && cacheTracker.shouldCall(cacheKey) == ApiCacheTracker.ShouldCall.SKIP) {
+                    Log.d(TAG, "loadClans: SKIP listClanDescs cache (still may fetch badges)")
                     if (_clans.value.isNotEmpty()) {
                         notificationCenter.postNotificationOnMainThread(NotificationCenter.clansDidLoad)
                         val selectedId = _selectedClanId.value
                         if (selectedId != 0L) {
                             notificationCenter.postNotificationOnMainThread(NotificationCenter.channelsDidLoad, selectedId)
+                            channelController.loadChannelsForClanNow(selectedId, force)
                         }
+                        fetchClanBadgeCountsIfNeeded(force)
+                        badgeCoordinator.get().processDeferredQueue()
                     }
                     return@launch
                 }
@@ -119,16 +137,99 @@ class ClansController @Inject constructor(
                 preWarmLogos(sorted)
                 withContext(ioDispatcher) { clanDao.upsertAll(sorted) }
                 notificationCenter.postNotificationOnMainThread(NotificationCenter.clansDidLoad)
+                badgeCoordinator.get().processDeferredQueue()
 
-                if (_selectedClanId.value == 0L && sorted.isNotEmpty()) {
-                    selectClan(sorted.first().clanId)
-                } else if (_selectedClanId.value != 0L) {
-                    channelController.loadChannelsForClan(_selectedClanId.value)
+                val previousSelected = _selectedClanId.value
+                if (previousSelected == 0L && sorted.isNotEmpty()) {
+                    _selectedClanId.value = sorted.first().clanId
                 }
+                val sel = _selectedClanId.value
+                if (sel != 0L) {
+                    channelController.loadChannelsForClanNow(sel, force)
+                    if (previousSelected == 0L && sorted.isNotEmpty()) {
+                        notificationCenter.postNotificationOnMainThread(NotificationCenter.selectedClanChanged, sel)
+                        appScope.launch {
+                            try {
+                                if (mezonSocket.awaitConnected()) {
+                                    mezonSocket.joinClanChat(sel)
+                                }
+                            } catch (e: Exception) {
+                                Log.e(TAG, "joinClanChat($sel) failed", e)
+                            }
+                        }
+                    }
+                }
+
+                fetchClanBadgeCountsIfNeeded(force)
             } catch (e: Exception) {
                 Log.e(TAG, "loadClans failed", e)
             }
         }
+    }
+
+    private suspend fun fetchClanBadgeCountsIfNeeded(force: Boolean) {
+        val badgeKey = apiCacheKey("listClanBadgeCount")
+        if (!force && cacheTracker.shouldCall(badgeKey) == ApiCacheTracker.ShouldCall.SKIP) {
+            return
+        }
+        runCatching {
+            if (!mezonSocket.awaitConnected()) {
+                return@runCatching
+            }
+            val badgeResponse = mezonSocket.fetchListClanBadgeCountSocket()
+            cacheTracker.markCalled(badgeKey)
+            val list = badgeResponse.listBadgeList
+            applyClanBadgeList(list)
+        }.onFailure { Log.e(TAG, "listClanBadgeCount: request failed", it) }
+    }
+
+    private fun applyClanBadgeList(badges: List<ClanBadgeCount>) {
+        if (badges.isEmpty()) {
+            return
+        }
+        val byClanId = badges.associateBy { it.clanId }
+        val list = _clans.value
+        var changed = false
+        var matched = 0
+        val updated = list.map { clan ->
+            val b = byClanId[clan.clanId] ?: return@map clan
+            matched++
+            val newBadge = b.badge.coerceAtLeast(0)
+            val newHasUnread = b.hasUnread || newBadge > 0
+            if (clan.badgeCount == newBadge && clan.hasUnread == newHasUnread) clan
+            else {
+                changed = true
+                clan.copy(badgeCount = newBadge, hasUnread = newHasUnread)
+            }
+        }
+        if (!changed) return
+        _clans.value = updated
+        appScope.launch(ioDispatcher) {
+            for (c in updated) {
+                if (byClanId.containsKey(c.clanId)) clanDao.upsert(c)
+            }
+        }
+        notificationCenter.postNotificationOnMainThread(
+            NotificationCenter.updateInterfaces, NotificationCenter.UPDATE_MASK_BADGE
+        )
+    }
+
+    fun reconcileClanBadgeFromChannels(clanId: Long) {
+        if (clanId == 0L) return
+        val channels = channelController.getChannels(clanId)
+        val total = channels.sumOf { it.unreadCount.coerceAtLeast(0) }
+        val anyUnread = channels.any { it.hasUnread }
+        val list = _clans.value
+        val idx = list.indexOfFirst { it.clanId == clanId }
+        if (idx < 0) return
+        val clan = list[idx]
+        if (clan.badgeCount == total && clan.hasUnread == anyUnread) return
+        val updated = clan.copy(badgeCount = total, hasUnread = anyUnread)
+        _clans.value = list.toMutableList().also { it[idx] = updated }
+        appScope.launch(ioDispatcher) { clanDao.upsert(updated) }
+        notificationCenter.postNotificationOnMainThread(
+            NotificationCenter.updateInterfaces, NotificationCenter.UPDATE_MASK_BADGE
+        )
     }
 
     fun setHasUnread(clanId: Long) {
@@ -153,21 +254,6 @@ class ClansController @Inject constructor(
         val newCount = (clan.badgeCount + delta).coerceAtLeast(0)
         if (newCount == clan.badgeCount) return
         val updated = clan.copy(badgeCount = newCount)
-        _clans.value = list.toMutableList().also { it[idx] = updated }
-        appScope.launch(ioDispatcher) { clanDao.upsert(updated) }
-        notificationCenter.postNotificationOnMainThread(
-            NotificationCenter.updateInterfaces, NotificationCenter.UPDATE_MASK_BADGE
-        )
-    }
-
-    fun syncClanBadgeFromChannels(clanId: Long, channels: List<ClanChannelEntity>) {
-        val list = _clans.value
-        val idx = list.indexOfFirst { it.clanId == clanId }
-        if (idx < 0) return
-        val clan = list[idx]
-        val totalUnread = channels.sumOf { it.unreadCount }
-        if (totalUnread == clan.badgeCount) return
-        val updated = clan.copy(badgeCount = totalUnread)
         _clans.value = list.toMutableList().also { it[idx] = updated }
         appScope.launch(ioDispatcher) { clanDao.upsert(updated) }
         notificationCenter.postNotificationOnMainThread(

--- a/app/src/main/java/com/mezon/mobile/home/clans/ClansFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ClansFragment.kt
@@ -130,6 +130,7 @@ class ClansFragment : BaseFragment() {
             layoutManager = LinearLayoutManager(context)
             setBackgroundColor(themeColors.serverRailBg)
             isVerticalScrollBarEnabled = false
+            itemAnimator = null
             setSelectorType(RecyclerListView.SELECTOR_CIRCLE_TO_BOUND)
         }
         serverAdapter = ServerRailAdapter()
@@ -498,8 +499,9 @@ class ClansFragment : BaseFragment() {
     }
 
     private fun onChannelSelected(channel: ClanChannelEntity) {
-        chatController.openChannel(channel.channelId, channel.clanId, channel.type, channel.isPrivate)
-        onOpenChat?.invoke(channel.channelId, channel.channelLabel, channel.clanId, channel.type)
+        val clanIdForJoin = if (channel.clanId != 0L) channel.clanId else clansController.selectedClanId.value
+        chatController.openChannel(channel.channelId, clanIdForJoin, channel.type, channel.isPrivate, channel.parentId)
+        onOpenChat?.invoke(channel.channelId, channel.channelLabel, clanIdForJoin, channel.type)
     }
 
     inner class ServerRailAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {

--- a/app/src/main/java/com/mezon/mobile/home/messages/DialogCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/messages/DialogCell.kt
@@ -124,7 +124,7 @@ class DialogCell(context: Context, private val theme: ThemeColors) : BaseCell(co
             (mask and NotificationCenter.UPDATE_MASK_MESSAGE_TEXT) != 0
         ) {
             if (directMessage?.lastMessageContent != dm.lastMessageContent ||
-                directMessage?.lastMessageTimestamp != dm.lastMessageTimestamp
+                directMessage?.lastSentMessageTs != dm.lastSentMessageTs
             ) {
                 rebuildLayout = true
             }
@@ -166,7 +166,7 @@ class DialogCell(context: Context, private val theme: ThemeColors) : BaseCell(co
         val timePaint = theme.dialogTimePaint
         timePaint.color = if (isUnread) theme.primary else theme.onSurfaceVariant
 
-        val timeText = formatRelativeTime(dm.lastMessageTimestamp)
+        val timeText = if (dm.lastSentMessageTs > 0) formatRelativeTime(dm.lastSentMessageTs) else ""
         timeLayout = StaticLayout.Builder.obtain(timeText, 0, timeText.length, timePaint, contentWidth)
             .setMaxLines(1)
             .setEllipsize(TextUtils.TruncateAt.END)

--- a/app/src/main/java/com/mezon/mobile/home/messages/DirectMessage.kt
+++ b/app/src/main/java/com/mezon/mobile/home/messages/DirectMessage.kt
@@ -5,10 +5,14 @@ import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
 import com.mezon.mezon.api.ChannelDescription
+import com.mezon.mobile.home.extractLastSeenMessageId
+import com.mezon.mobile.home.extractLastSeenMessageTs
+import com.mezon.mobile.home.extractLastSentMessageId
+import com.mezon.mobile.home.extractLastSentMessageTs
 
 @Entity(
     tableName = "direct_messages",
-    indices = [Index(value = ["lastMessageTimestamp"])]
+    indices = [Index(value = ["lastSentMessageTs"])]
 )
 data class DirectMessage(
     @PrimaryKey val channelId: Long,
@@ -17,13 +21,14 @@ data class DirectMessage(
     val avatarUrl: String,
     val displayName: String,
     val lastMessageContent: String,
-    val lastMessageTimestamp: Long,
     val unreadCount: Int,
     val isOnline: Boolean,
     val isMute: Boolean,
     val otherUserId: Long = 0L,
     val lastSeenMessageId: Long = 0L,
-    val lastSentMessageId: Long = 0L
+    val lastSentMessageId: Long = 0L,
+    val lastSeenMessageTs: Long = 0L,
+    val lastSentMessageTs: Long = 0L
 )
 
 
@@ -46,12 +51,6 @@ fun ChannelDescription.toDirectMessage(currentUserId: Long): DirectMessage {
         parseContentPreview(lastSentMessage.content)
     } else ""
 
-    val lastMsgTimestamp = if (hasLastSentMessage()) {
-        lastSentMessage.timestampSeconds.toLong()
-    } else {
-        createTimeSeconds.toLong()
-    }
-
     val otherUserId = userIdsList.getOrElse(otherIndex) { 0L }
 
     return DirectMessage(
@@ -61,13 +60,14 @@ fun ChannelDescription.toDirectMessage(currentUserId: Long): DirectMessage {
         avatarUrl = avatarUrl,
         displayName = displayName,
         lastMessageContent = lastMsgContent,
-        lastMessageTimestamp = lastMsgTimestamp,
         unreadCount = countMessUnread,
         isOnline = isOnline,
         isMute = isMute,
         otherUserId = otherUserId,
-        lastSeenMessageId = if (hasLastSeenMessage()) lastSeenMessage.id else 0L,
-        lastSentMessageId = if (hasLastSentMessage()) lastSentMessage.id else 0L
+        lastSeenMessageId = extractLastSeenMessageId(),
+        lastSentMessageId = extractLastSentMessageId(),
+        lastSeenMessageTs = extractLastSeenMessageTs(),
+        lastSentMessageTs = extractLastSentMessageTs()
     )
 }
 

--- a/app/src/main/java/com/mezon/mobile/network/MezonApi.kt
+++ b/app/src/main/java/com/mezon/mobile/network/MezonApi.kt
@@ -243,14 +243,14 @@ class MezonApi @Inject constructor(
         apiUrl: String,
         token: String,
         clanId: Long,
-        limit: Int = 200
+        limit: Int = 500
     ): ChannelDescList {
         val request = listChannelDescsRequest {
             this.clanId = clanId
             this.limit = limit
             this.state = 1
-            this.page = 1
-            this.channelType = 0
+            this.page = 0
+            this.channelType = CHANNEL_TYPE_CHANNEL
             this.isMobile = true
         }
         val bytes = rpc(apiUrl, token, "ListChannelDescs", request.toByteArray())
@@ -388,6 +388,16 @@ class MezonApi @Inject constructor(
             this.usernames.addAll(usernames)
         }
         return rpc(apiUrl, token, "DeleteFriends", request.toByteArray())
+    }
+
+    suspend fun sendChannelMessage(
+        apiUrl: String,
+        token: String,
+        request: com.mezon.mezon.rtapi.ChannelMessageSend
+    ): com.mezon.mezon.rtapi.ChannelMessageAck {
+        val body = request.toByteArray()
+        val bytes = rpc(apiUrl, token, "SendChannelMessage", body)
+        return com.mezon.mezon.rtapi.ChannelMessageAck.parseFrom(bytes)
     }
 
     suspend fun listChannelMessages(

--- a/app/src/main/java/com/mezon/mobile/network/MezonSocket.kt
+++ b/app/src/main/java/com/mezon/mobile/network/MezonSocket.kt
@@ -4,9 +4,12 @@ import com.mezon.mobile.di.ApplicationScope
 import com.mezon.mobile.session.SessionManager
 import android.util.Log
 import com.google.protobuf.StringValue
+import com.mezon.mezon.api.ListClanBadgeCountResponse
+import com.mezon.mezon.api.ListChannelBadgeCountResponse
 import com.mezon.mezon.api.MessageAttachment
 import com.mezon.mezon.api.MessageMention
 import com.mezon.mezon.api.MessageRef
+import com.mezon.mezon.api.listChannelBadgeCountRequest
 import com.mezon.mezon.api.messageReaction
 import com.mezon.mezon.rtapi.EnvelopeKt
 import com.mezon.mezon.rtapi.Envelope
@@ -22,6 +25,7 @@ import com.mezon.mezon.rtapi.envelope
 import com.mezon.mezon.rtapi.incomingCallPush
 import com.mezon.mezon.rtapi.lastPinMessageEvent
 import com.mezon.mezon.rtapi.lastSeenMessageEvent
+import com.mezon.mezon.rtapi.listDataSocket
 import com.mezon.mezon.rtapi.markAsRead
 import com.mezon.mezon.rtapi.messageTypingEvent
 import com.mezon.mezon.rtapi.ping
@@ -33,14 +37,16 @@ import com.mezon.mezon.rtapi.webrtcSignalingFwd
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlin.random.Random
 import okhttp3.OkHttpClient
@@ -186,6 +192,45 @@ class MezonSocket @Inject constructor(
 
     suspend fun joinClanChat(clanId: Long): Envelope = send {
         this.clanJoin = clanJoin { this.clanId = clanId }
+    }
+
+    suspend fun awaitConnected(timeoutMs: Long = 15_000L): Boolean {
+        if (_connectionState.value == ConnectionState.CONNECTED) return true
+        return try {
+            withTimeout(timeoutMs) {
+                _connectionState.first { it == ConnectionState.CONNECTED }
+            }
+            true
+        } catch (_: TimeoutCancellationException) {
+            Log.w(TAG, "awaitConnected: timeout ${timeoutMs}ms")
+            false
+        }
+    }
+
+    suspend fun fetchListClanBadgeCountSocket(): ListClanBadgeCountResponse {
+        val env = send {
+            this.listDataSocket = listDataSocket { apiName = "ListClanBadgeCount" }
+        }
+        require(env.messageCase == Envelope.MessageCase.LIST_DATA_SOCKET) {
+            "ListClanBadgeCount: expected LIST_DATA_SOCKET, got ${env.messageCase}"
+        }
+        val data = env.listDataSocket
+        return if (data.hasClanBadgeCount()) data.clanBadgeCount else ListClanBadgeCountResponse.getDefaultInstance()
+    }
+
+    suspend fun fetchListChannelBadgeCountSocket(clanId: Long): ListChannelBadgeCountResponse {
+        val env = send {
+            this.listDataSocket = listDataSocket {
+                apiName = "ListChannelBadgeCount"
+                listChannelBadgeCountReq = listChannelBadgeCountRequest { this.clanId = clanId }
+            }
+        }
+        require(env.messageCase == Envelope.MessageCase.LIST_DATA_SOCKET) {
+            "ListChannelBadgeCount: expected LIST_DATA_SOCKET, got ${env.messageCase}"
+        }
+        val data = env.listDataSocket
+        return if (data.hasChannelBadgeCount()) data.channelBadgeCount
+        else ListChannelBadgeCountResponse.getDefaultInstance()
     }
 
     suspend fun joinChat(


### PR DESCRIPTION
- Add BadgeCoordinator singleton for debounced last-seen writes, deferred queue when controllers not yet loaded, and clan badge reconciliation
- Add ChannelDescriptionReadState entity for per-channel unread tracking
- Expand ChannelController with unread count management and channel list loading state
- Expand DialogsController with DM read state and badge count fields
- Update DirectMessage, ClanChannelEntity, MessageEntity with read state fields
- Add lastSeenMessage API calls in MezonApi and socket events in MezonSocket
- Wire NC events: UPDATE_MASK_BADGE, unreadCountChanged, channelReadStateChanged
- Update DAOs and MezonDatabase for new read state fields