### PR TITLE
feat(chat): add emoji, sticker, and GIF picker panel

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,6 +86,7 @@ android {
         buildConfigField("String", "MEZON_TENOR_URL_CATEGORIES", "\"https://tenor.googleapis.com/v2/categories?key=\"")
         buildConfigField("String", "MEZON_TENOR_URL_SEARCH", "\"https://tenor.googleapis.com/v2/search?q=\"")
         buildConfigField("String", "MEZON_TENOR_URL_FEATURED", "\"https://tenor.googleapis.com/v2/featured?key=\"")
+        buildConfigField("String", "TENOR_API_KEY", "\"AIzaSyAyimkuYQYF_FXVALexPuGQctUWRURdCYQ\"")
 
         // Sentry
         buildConfigField("String", "MEZON_SENTRY_DSN", "\"https://7aad12a70a52b6598fa5847153a13781@o4509763792404480.ingest.us.sentry.io/4509767257751552\"")

--- a/app/src/main/java/com/mezon/mobile/core/NotificationCenter.kt
+++ b/app/src/main/java/com/mezon/mobile/core/NotificationCenter.kt
@@ -106,6 +106,9 @@ class NotificationCenter(val currentAccount: Int) {
         val searchMembersDidLoad = nextId()
         val searchChannelsDidLoad = nextId()
         val searchMessagesDidLoad = nextId()
+        val emojisNeedReload = nextId()
+        val stickersNeedReload = nextId()
+        val gifsNeedReload = nextId()
 
         const val UPDATE_MASK_NAME = 1
         const val UPDATE_MASK_AVATAR = 2

--- a/app/src/main/java/com/mezon/mobile/core/SharedConfig.kt
+++ b/app/src/main/java/com/mezon/mobile/core/SharedConfig.kt
@@ -35,6 +35,11 @@ object SharedConfig {
     @JvmField var mediaColumnsCount = 3
     @JvmField var chatBubbles = true
 
+    @Volatile var keyboardHeight = 0
+        private set
+    @Volatile var keyboardHeightLand = 0
+        private set
+
     private var prefs: SharedPreferences? = null
 
     private val LOW_SOC = intArrayOf(
@@ -69,6 +74,8 @@ object SharedConfig {
         }
 
         liteModeValue = prefs?.getInt("lite_mode", LITE_FLAGS_ALL) ?: LITE_FLAGS_ALL
+        keyboardHeight = prefs?.getInt("kbd_height", 0) ?: 0
+        keyboardHeightLand = prefs?.getInt("kbd_height_land", 0) ?: 0
 
         animationsEnabledCached = prefs?.getBoolean("view_animations", false) ?: false
     }
@@ -227,5 +234,23 @@ object SharedConfig {
         prefs?.edit()?.putInt("bubble_radius", bubbleRadius)?.apply()
         NotificationCenter.getGlobalInstance()
             .postNotificationName(NotificationCenter.themeChanged)
+    }
+
+    fun saveKeyboardHeight(height: Int, isLandscape: Boolean) {
+        if (isLandscape) {
+            keyboardHeightLand = height
+            prefs?.edit()?.putInt("kbd_height_land", height)?.apply()
+        } else {
+            keyboardHeight = height
+            prefs?.edit()?.putInt("kbd_height", height)?.apply()
+        }
+    }
+
+    fun getEmojiPanelHeight(): Int {
+        val isLandscape = android.content.res.Resources.getSystem().displayMetrics.let {
+            it.widthPixels > it.heightPixels
+        }
+        val saved = if (isLandscape) keyboardHeightLand else keyboardHeight
+        return if (saved > 0) saved else com.mezon.mobile.core.LayoutHelper.dp(200f)
     }
 }

--- a/app/src/main/java/com/mezon/mobile/core/SizeNotifierFrameLayout.kt
+++ b/app/src/main/java/com/mezon/mobile/core/SizeNotifierFrameLayout.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
+import android.view.Gravity
 import android.view.View
 import android.widget.FrameLayout
 
@@ -29,6 +30,7 @@ open class SizeNotifierFrameLayout @JvmOverloads constructor(
     private var emojiHeight = 0
     private var emojiOffset = 0f
     private var animationInProgress = false
+    var isSearchExpanded = false
     private var skipBackgroundDrawing = false
     var useSmoothKeyboard = false
     var paused = true
@@ -77,8 +79,66 @@ open class SizeNotifierFrameLayout @JvmOverloads constructor(
         paused = false
     }
 
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val totalWidth = MeasureSpec.getSize(widthMeasureSpec)
+        val totalHeight = MeasureSpec.getSize(heightMeasureSpec)
+        measureKeyboardHeight()
+        val keyboardVisible = keyboardHeight > LayoutHelper.dp(20f)
+        val emojiPad = if (!keyboardVisible && emojiHeight > 0) emojiHeight else 0
+
+        for (i in 0 until childCount) {
+            val child = getChildAt(i)
+            if (child.visibility == View.GONE) continue
+            val lp = child.layoutParams as LayoutParams
+
+            if (isPopupView(child)) {
+                val popupH = if (isSearchExpanded) totalHeight else lp.height.coerceAtLeast(0)
+                child.measure(
+                    MeasureSpec.makeMeasureSpec(totalWidth, MeasureSpec.EXACTLY),
+                    MeasureSpec.makeMeasureSpec(popupH, MeasureSpec.EXACTLY)
+                )
+            } else {
+                val contentH = if (isSearchExpanded) 0 else (totalHeight - emojiPad).coerceAtLeast(0)
+                child.measure(
+                    getChildMeasureSpec(widthMeasureSpec, lp.leftMargin + lp.rightMargin, lp.width),
+                    MeasureSpec.makeMeasureSpec(contentH, MeasureSpec.EXACTLY)
+                )
+            }
+        }
+        setMeasuredDimension(totalWidth, totalHeight)
+    }
+
+    private fun isPopupView(child: View): Boolean {
+        val lp = child.layoutParams as? LayoutParams ?: return false
+        return (lp.gravity and Gravity.BOTTOM) == Gravity.BOTTOM && lp.height > 0
+    }
+
     override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
         super.onLayout(changed, l, t, r, b)
+
+        val parentHeight = b - t
+
+        if (isSearchExpanded) {
+            for (i in 0 until childCount) {
+                val child = getChildAt(i)
+                if (child.visibility == View.GONE) continue
+                if (isPopupView(child)) {
+                    child.layout(child.left, 0, child.right, parentHeight)
+                }
+            }
+        } else if (emojiHeight > 0) {
+            val keyboardVisible = keyboardHeight > LayoutHelper.dp(20f)
+            val contentBottom = if (keyboardVisible) parentHeight else parentHeight - emojiHeight
+
+            for (i in 0 until childCount) {
+                val child = getChildAt(i)
+                if (child.visibility == View.GONE) continue
+                if (isPopupView(child)) {
+                    child.layout(child.left, contentBottom, child.right, contentBottom + child.measuredHeight)
+                }
+            }
+        }
+
         notifyHeightChanged()
     }
 

--- a/app/src/main/java/com/mezon/mobile/di/FragmentEntryPoint.kt
+++ b/app/src/main/java/com/mezon/mobile/di/FragmentEntryPoint.kt
@@ -3,6 +3,7 @@ package com.mezon.mobile.di
 import com.mezon.mobile.auth.AuthRepository
 import com.mezon.mobile.home.ChatController
 import com.mezon.mobile.home.ConnectionController
+import com.mezon.mobile.home.chat.EmojiController
 import com.mezon.mobile.home.DialogsController
 import com.mezon.mobile.home.UserClanController
 import com.mezon.mobile.home.chat.MediaController
@@ -39,6 +40,7 @@ interface FragmentEntryPoint {
     fun mediaController(): MediaController
     fun searchController(): SearchController
     fun userClanController(): UserClanController
+    fun emojiController(): EmojiController
 
     @IoDispatcher
     fun ioDispatcher(): CoroutineDispatcher

--- a/app/src/main/java/com/mezon/mobile/home/ChatController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChatController.kt
@@ -29,6 +29,8 @@ import com.mezon.mobile.BuildConfig
 import com.mezon.mobile.util.MentionData
 import com.mezon.mobile.util.buildTextContent
 import com.mezon.mobile.util.buildTextContentWithMentions
+import com.mezon.mobile.util.EmojiMarker
+import com.mezon.mobile.util.buildTextContentWithEmojis
 import com.mezon.mezon.api.MessageAttachment
 import com.mezon.mezon.api.messageAttachment
 import com.mezon.mezon.api.messageMention
@@ -402,12 +404,13 @@ class ChatController @Inject constructor(
         isChannelPrivate: Boolean,
         text: String,
         references: List<com.mezon.mezon.api.MessageRef>? = null,
-        mentions: List<MentionData>? = null
+        mentions: List<MentionData>? = null,
+        emojiMarkers: List<EmojiMarker>? = null
     ) {
         val mode = channelTypeToStreamMode(channelType)
         val isPublic = !isChannelPrivate
-        val content = if (mentions.isNullOrEmpty()) buildTextContent(text)
-            else buildTextContentWithMentions(text, mentions)
+        val content = if (emojiMarkers.isNullOrEmpty() && mentions.isNullOrEmpty()) buildTextContent(text)
+            else buildTextContentWithEmojis(text, mentions, emojiMarkers)
         val mentionEveryone = mentions?.any { it.userId == ID_MENTION_HERE } == true
         val protoMentions = mentions?.mapNotNull { m ->
             if (m.userId == ID_MENTION_HERE) return@mapNotNull null
@@ -456,6 +459,82 @@ class ChatController @Inject constructor(
                     NotificationCenter.pendingMessageSent, channelId, tempId, ack.messageId
                 )
             } catch (e: Exception) {
+                notificationCenter.postNotificationOnMainThread(
+                    NotificationCenter.pendingMessageError, channelId, tempId
+                )
+            }
+        }
+    }
+
+    fun sendDirectAttachment(
+        channelId: Long,
+        clanId: Long,
+        channelType: Int,
+        isChannelPrivate: Boolean,
+        url: String,
+        filetype: String,
+        filename: String? = null,
+        references: List<com.mezon.mezon.api.MessageRef>? = null
+    ) {
+        val mode = channelTypeToStreamMode(channelType)
+        val isPublic = !isChannelPrivate
+        val baseContent = "{\"t\":\"\"}"
+        val content = mergeRefsIntoOptimisticContent(baseContent, references)
+        val attachment = messageAttachment {
+            this.url = url
+            this.filetype = filetype
+            if (filename != null) this.filename = filename
+        }
+
+        val tempId = generateTempId()
+        val uc = userController.get()
+        val msgType = when {
+            filetype.startsWith("image/gif") || filetype.endsWith("gif") -> MessageEntity.TYPE_GIF
+            filetype.startsWith("image/") -> MessageEntity.TYPE_PHOTO
+            filetype.startsWith("audio/") -> MessageEntity.TYPE_FILE
+            else -> MessageEntity.TYPE_GIF
+        }
+        val optimistic = MessageEntity(
+            id = tempId,
+            channelId = channelId,
+            senderId = uc.userId,
+            senderName = uc.displayName.ifBlank { uc.username },
+            senderAvatar = uc.avatarUrl,
+            content = content,
+            timestampSeconds = System.currentTimeMillis() / 1000,
+            code = MessageEntity.CODE_CHAT,
+            isMe = true,
+            messageType = msgType,
+            attachmentUrl = url,
+            attachmentFiletype = filetype,
+            attachmentFilename = filename.orEmpty(),
+            sendState = MessageEntity.SEND_STATE_SENDING
+        )
+        notificationCenter.postNotificationOnMainThread(
+            NotificationCenter.didReceiveNewMessages, channelId, optimistic
+        )
+
+        appScope.launch {
+            try {
+                val session = sessionManager.sessionFlow.first() ?: throw RuntimeException("No session")
+                val request = channelMessageSend {
+                    this.clanId = clanId
+                    this.channelId = channelId
+                    this.mode = mode
+                    this.isPublic = isPublic
+                    this.content = baseContent
+                    this.attachments.add(attachment)
+                    references?.let { this.references.addAll(it) }
+                }
+                val ack = withContext(ioDispatcher) {
+                    api.sendChannelMessage(session.apiUrl, session.token, request)
+                }
+                notificationCenter.postNotificationOnMainThread(
+                    NotificationCenter.pendingMessageSent, channelId, tempId, ack.messageId
+                )
+                Log.d(TAG, "Direct attachment sent: channelId=$channelId url=${url.take(60)}")
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to send direct attachment", e)
                 notificationCenter.postNotificationOnMainThread(
                     NotificationCenter.pendingMessageError, channelId, tempId
                 )

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -45,8 +45,13 @@ import com.mezon.mobile.network.CHANNEL_TYPE_GROUP
 import com.mezon.mobile.ui.cells.ActionBarView
 import com.mezon.mobile.ui.cells.MezonIcon
 import com.mezon.mobile.ui.cells.PageDownButton
+import com.mezon.mobile.util.EmojiMarker
 import com.mezon.mobile.util.MentionData
 import com.mezon.mobile.util.parseContentText
+import com.mezon.mobile.util.resolveStickerSourceUrl
+import com.mezon.mobile.core.SharedConfig
+import com.mezon.mobile.core.SizeNotifierFrameLayout
+import com.mezon.mobile.home.chat.emoji.EmojiView
 
 private const val TAG = "ChatFragment"
 
@@ -96,13 +101,22 @@ class ChatFragment : BaseFragment() {
     private lateinit var attachButton: ImageButton
     private lateinit var emojiButton: ImageButton
     private lateinit var adapter: ChatAdapter
-    private lateinit var rootView: LinearLayout
+    private lateinit var rootView: FrameLayout
     private lateinit var inputBar: LinearLayout
     private lateinit var inputWrapper: FrameLayout
     private lateinit var pageDownButton: PageDownButton
     private lateinit var unreadDecoration: UnreadDividerDecoration
     private var attachmentPreviewStrip: LinearLayout? = null
     private var attachmentPreviewScroll: HorizontalScrollView? = null
+
+    private lateinit var emojiController: EmojiController
+    private var emojiView: EmojiView? = null
+    private var emojiViewVisible = false
+    private var emojiPadding = 0
+    private var emojiSearchExpanded = false
+    private var searchKeyboardWasVisible = false
+    private val emojiObjPicked = HashMap<String, String>()
+    private lateinit var sizeNotifierRoot: SizeNotifierFrameLayout
 
     private val pendingAttachments = ArrayList<AttachmentPickerItem>()
     private val pendingAttachmentThumbTasks = ArrayList<Runnable?>()
@@ -752,23 +766,33 @@ class ChatFragment : BaseFragment() {
         channelController = entryPoint.channelController()
         mediaController = entryPoint.mediaController()
         userClanController = entryPoint.userClanController()
+        emojiController = entryPoint.emojiController()
     }
 
     override fun createView(context: Context): View {
-        rootView = LinearLayout(context).apply {
+        sizeNotifierRoot = SizeNotifierFrameLayout(context, parentLayout)
+        sizeNotifierRoot.setBackgroundColor(themeColors.background)
+        rootView = sizeNotifierRoot
+
+        val innerLayout = LinearLayout(context).apply {
             orientation = LinearLayout.VERTICAL
-            setBackgroundColor(themeColors.background)
         }
 
         val chatActionBar = ActionBarView(context, themeColors).apply {
             setTitle(channelName)
-            setBackClickListener { finishFragment() }
+            setBackClickListener {
+                if (emojiViewVisible) {
+                    hideEmojiView()
+                } else {
+                    finishFragment()
+                }
+            }
         }
         actionBar = chatActionBar
-        rootView.addView(chatActionBar, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, 56))
+        innerLayout.addView(chatActionBar, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, 56))
 
         val contentFrame = FrameLayout(context)
-        rootView.addView(contentFrame, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, 0, 1f))
+        innerLayout.addView(contentFrame, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, 0, 1f))
 
         recyclerView = RecyclerListView(context).apply {
             val lm = LinearLayoutManager(context)
@@ -833,7 +857,7 @@ class ChatFragment : BaseFragment() {
         attachmentPreviewScroll!!.addView(attachmentPreviewStrip, LinearLayout.LayoutParams(
             LinearLayout.LayoutParams.WRAP_CONTENT, LayoutHelper.dp(56f)
         ))
-        rootView.addView(attachmentPreviewScroll, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT))
+        innerLayout.addView(attachmentPreviewScroll, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT))
 
         replyBar = LinearLayout(context).apply {
             orientation = LinearLayout.HORIZONTAL
@@ -874,7 +898,7 @@ class ChatFragment : BaseFragment() {
             LayoutHelper.dp(32f), LayoutHelper.dp(32f)
         ).also { it.gravity = android.view.Gravity.CENTER_VERTICAL })
 
-        rootView.addView(replyBar, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT))
+        innerLayout.addView(replyBar, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT))
 
         val blurple = 0xFF5865F2.toInt()
 
@@ -917,7 +941,7 @@ class ChatFragment : BaseFragment() {
             LayoutHelper.dp(32f), LayoutHelper.dp(32f)
         ).also { it.gravity = android.view.Gravity.CENTER_VERTICAL })
 
-        rootView.addView(editBar, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT))
+        innerLayout.addView(editBar, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT))
 
         inputBar = LinearLayout(context).apply {
             orientation = LinearLayout.HORIZONTAL
@@ -925,7 +949,7 @@ class ChatFragment : BaseFragment() {
             setBackgroundColor(themeColors.surface)
             setPadding(LayoutHelper.dp(6f), LayoutHelper.dp(10f), LayoutHelper.dp(2f), LayoutHelper.dp(10f))
         }
-        rootView.addView(inputBar, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT))
+        innerLayout.addView(inputBar, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT))
 
         val btnPad = LayoutHelper.dp(8f)
         attachButton = ImageButton(context).apply {
@@ -971,6 +995,13 @@ class ChatFragment : BaseFragment() {
             setColorFilter(PorterDuffColorFilter(themeColors.getColor(com.mezon.mobile.core.ThemeColors.key_icon_secondary), PorterDuff.Mode.SRC_IN))
             setBackgroundColor(android.graphics.Color.TRANSPARENT)
             scaleType = ImageView.ScaleType.CENTER
+            setOnClickListener {
+                if (emojiViewVisible) {
+                    openKeyboardFromEmoji()
+                } else {
+                    showEmojiView()
+                }
+            }
         }
         inputWrapper.addView(emojiButton, FrameLayout.LayoutParams(
             LayoutHelper.dp(24f), LayoutHelper.dp(24f),
@@ -1013,6 +1044,12 @@ class ChatFragment : BaseFragment() {
                 checkMentionTrigger()
             }
         })
+
+        inputField.setOnKeyListener { _, keyCode, event ->
+            if (keyCode == android.view.KeyEvent.KEYCODE_DEL && event.action == android.view.KeyEvent.ACTION_DOWN) {
+                deleteEmojiTokenAtCursor()
+            } else false
+        }
 
         inputField.setOnEditorActionListener { _, actionId, _ ->
             if (actionId == EditorInfo.IME_ACTION_SEND) { sendMessage(); true } else false
@@ -1144,6 +1181,50 @@ class ChatFragment : BaseFragment() {
             }
         }
 
+        rootView.addView(innerLayout, FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            FrameLayout.LayoutParams.MATCH_PARENT
+        ))
+
+        sizeNotifierRoot.setDelegate(object : SizeNotifierFrameLayout.SizeNotifierFrameLayoutDelegate {
+            override fun onSizeChanged(keyboardHeight: Int, isWidthGreater: Boolean) {
+                if (emojiSearchExpanded) {
+                    if (keyboardHeight > LayoutHelper.dp(50f)) {
+                        SharedConfig.saveKeyboardHeight(keyboardHeight, isWidthGreater)
+                        searchKeyboardWasVisible = true
+                    }
+                    if (keyboardHeight <= LayoutHelper.dp(20f) && searchKeyboardWasVisible) {
+                        collapseEmojiSearch()
+                    }
+                    return
+                }
+                if (keyboardHeight > LayoutHelper.dp(50f)) {
+                    SharedConfig.saveKeyboardHeight(keyboardHeight, isWidthGreater)
+                    if (emojiViewVisible) {
+                        dismissEmojiSilently()
+                    }
+                }
+                if (keyboardHeight <= LayoutHelper.dp(20f) && !emojiViewVisible && emojiPadding != 0) {
+                    emojiPadding = 0
+                    sizeNotifierRoot.setEmojiKeyboardHeight(0)
+                    sizeNotifierRoot.requestLayout()
+                }
+            }
+        })
+
+        observe(NotificationCenter.emojisNeedReload) { _, _, _ ->
+            emojiView?.onEmojisReloaded()
+        }
+
+        observe(NotificationCenter.stickersNeedReload) { _, _, _ ->
+            emojiView?.onStickersReloaded()
+        }
+
+        observe(NotificationCenter.gifsNeedReload) { _, _, _ ->
+            emojiView?.onGifsReloaded()
+        }
+
+        fragmentView = rootView
         return rootView
     }
 
@@ -1191,6 +1272,18 @@ class ChatFragment : BaseFragment() {
         super.onPause()
         if (::recyclerView.isInitialized) recyclerView.stopScroll()
         saveScrollPosition()
+    }
+
+    override fun onBackPressed(): Boolean {
+        if (emojiSearchExpanded) {
+            collapseEmojiSearch()
+            return false
+        }
+        if (emojiViewVisible) {
+            hideEmojiView()
+            return false
+        }
+        return super.onBackPressed()
     }
 
     private fun saveScrollPosition() {
@@ -1252,6 +1345,195 @@ class ChatFragment : BaseFragment() {
         }
     }
 
+    private fun showEmojiView() {
+        if (emojiView == null) createEmojiView()
+        emojiView!!.visibility = View.VISIBLE
+        emojiViewVisible = true
+
+        val panelHeight = SharedConfig.getEmojiPanelHeight()
+        emojiView!!.layoutParams = FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT, panelHeight, Gravity.BOTTOM
+        )
+        emojiPadding = panelHeight
+        sizeNotifierRoot.setEmojiKeyboardHeight(panelHeight)
+        sizeNotifierRoot.requestLayout()
+
+        AndroidUtilities.hideKeyboard(inputField)
+        emojiView!!.onOpen()
+        updateEmojiButtonIcon(showingEmoji = true)
+    }
+
+    private fun openKeyboardFromEmoji() {
+        inputField.requestFocus()
+        AndroidUtilities.showKeyboard(inputField)
+        updateEmojiButtonIcon(showingEmoji = false)
+    }
+
+    private fun dismissEmojiSilently() {
+        emojiSearchExpanded = false
+        searchKeyboardWasVisible = false
+        sizeNotifierRoot.isSearchExpanded = false
+        emojiViewVisible = false
+        emojiView?.visibility = View.GONE
+        emojiPadding = 0
+        sizeNotifierRoot.setEmojiKeyboardHeight(0)
+        updateEmojiButtonIcon(showingEmoji = false)
+    }
+
+    private fun hideEmojiView() {
+        emojiSearchExpanded = false
+        searchKeyboardWasVisible = false
+        sizeNotifierRoot.isSearchExpanded = false
+        emojiViewVisible = false
+        emojiView?.clearSearchFocus()
+        emojiView?.visibility = View.GONE
+        emojiPadding = 0
+        sizeNotifierRoot.setEmojiKeyboardHeight(0)
+        sizeNotifierRoot.requestLayout()
+        updateEmojiButtonIcon(showingEmoji = false)
+    }
+
+    private class EmojiTokenSpan
+
+    private fun deleteEmojiTokenAtCursor(): Boolean {
+        val editable = inputField.text ?: return false
+        val sel = inputField.selectionStart
+        if (sel <= 0 || sel != inputField.selectionEnd) return false
+
+        val spans = editable.getSpans(sel - 1, sel, EmojiTokenSpan::class.java)
+        if (spans.isEmpty()) return false
+
+        val span = spans[0]
+        var start = editable.getSpanStart(span)
+        var end = editable.getSpanEnd(span)
+        if (end < editable.length && editable[end] == ' ') end++
+        if (start < 0) start = 0
+        val token = editable.subSequence(editable.getSpanStart(span), editable.getSpanEnd(span)).toString()
+        editable.removeSpan(span)
+        editable.delete(start, end)
+        emojiObjPicked.remove(token)
+        return true
+    }
+
+    private fun expandEmojiSearch() {
+        if (emojiSearchExpanded || !emojiViewVisible) return
+        emojiSearchExpanded = true
+        searchKeyboardWasVisible = false
+        sizeNotifierRoot.isSearchExpanded = true
+        sizeNotifierRoot.requestLayout()
+    }
+
+    private fun collapseEmojiSearch() {
+        if (!emojiSearchExpanded) return
+        emojiSearchExpanded = false
+        searchKeyboardWasVisible = false
+        sizeNotifierRoot.isSearchExpanded = false
+        emojiView?.clearSearchFocus()
+        AndroidUtilities.hideKeyboard(emojiView)
+        if (!emojiViewVisible) return
+        val panelHeight = SharedConfig.getEmojiPanelHeight()
+        emojiView?.layoutParams = FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT, panelHeight, Gravity.BOTTOM
+        )
+        emojiPadding = panelHeight
+        sizeNotifierRoot.setEmojiKeyboardHeight(panelHeight)
+        sizeNotifierRoot.requestLayout()
+    }
+
+    private fun updateEmojiButtonIcon(showingEmoji: Boolean) {
+        if (showingEmoji) {
+            emojiButton.setImageDrawable(
+                MezonIcon.keyboardIcon.getDrawable(getContext()!!).also {
+                    it.colorFilter = PorterDuffColorFilter(
+                        themeColors.getColor(com.mezon.mobile.core.ThemeColors.key_icon_secondary), PorterDuff.Mode.SRC_IN
+                    )
+                }
+            )
+        } else {
+            emojiButton.setImageResource(R.drawable.ic_emoji_icon)
+            emojiButton.setColorFilter(PorterDuffColorFilter(
+                themeColors.getColor(com.mezon.mobile.core.ThemeColors.key_icon_secondary), PorterDuff.Mode.SRC_IN
+            ))
+        }
+    }
+
+    private fun createEmojiView() {
+        val ctx = getContext() ?: return
+        emojiView = EmojiView(ctx, themeColors).apply {
+            init(emojiController)
+            delegate = object : EmojiView.EmojiViewDelegate {
+                override fun onEmojiSelected(emoji: EmojiItem) {
+                    val editable = inputField.text ?: return
+                    val cursor = inputField.selectionEnd.coerceAtLeast(0)
+                    val cleanName = emoji.shortname.replace(":", "")
+                    val token = ":$cleanName:"
+                    val insertText = "$token "
+                    emojiObjPicked[token] = emoji.id
+                    editable.insert(cursor, insertText)
+                    val spanStart = cursor
+                    val spanEnd = cursor + token.length
+                    editable.setSpan(
+                        EmojiTokenSpan(),
+                        spanStart, spanEnd,
+                        android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                    )
+                    editable.setSpan(
+                        android.text.style.ForegroundColorSpan(0xFF5A62F4.toInt()),
+                        spanStart, spanEnd,
+                        android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                    )
+                    editable.setSpan(
+                        android.text.style.StyleSpan(android.graphics.Typeface.BOLD),
+                        spanStart, spanEnd,
+                        android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                    )
+                    inputField.setSelection(cursor + insertText.length)
+                }
+
+                override fun onStickerSelected(sticker: StickerItem, isAudio: Boolean) {
+                    if (sticker.isForSale && sticker.src.isBlank()) return
+                    val url = resolveStickerSourceUrl(sticker.id, sticker.src)
+                    if (url.isBlank()) return
+                    val filetype = if (isAudio) "audio/mpeg" else "image/gif"
+                    val references = buildReplyReferences()
+                    chatController.sendDirectAttachment(
+                        channelId, clanId, channelType, resolveChannelPrivate(),
+                        url, filetype, sticker.id, references
+                    )
+                    clearReplyState()
+                    hideEmojiView()
+                }
+
+                override fun onGifSelected(gifUrl: String) {
+                    val references = buildReplyReferences()
+                    chatController.sendDirectAttachment(
+                        channelId, clanId, channelType, resolveChannelPrivate(),
+                        gifUrl, "image/gif", references = references
+                    )
+                    clearReplyState()
+                    hideEmojiView()
+                }
+
+                override fun onBackspace() {
+                    inputField.dispatchKeyEvent(
+                        android.view.KeyEvent(android.view.KeyEvent.ACTION_DOWN, android.view.KeyEvent.KEYCODE_DEL)
+                    )
+                }
+
+                override fun onSearchFocusChanged(focused: Boolean) {
+                    if (focused) {
+                        expandEmojiSearch()
+                    } else {
+                        collapseEmojiSearch()
+                    }
+                }
+            }
+        }
+        rootView.addView(emojiView, FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT, 0, Gravity.BOTTOM
+        ))
+    }
+
     override fun onFragmentDestroy() {
         notificationCenter.removePostponeNotificationsCallback(postponeNewMessagesCallback)
         notificationCenter.onAnimationFinish(transitionAnimationIndex)
@@ -1276,6 +1558,8 @@ class ChatFragment : BaseFragment() {
         pendingHighlightMessageId = 0L
         chatAdjustPanHelper?.onDetach()
         chatAdjustPanHelper = null
+        emojiView = null
+        emojiObjPicked.clear()
         super.onFragmentDestroy()
     }
 
@@ -1681,11 +1965,28 @@ class ChatFragment : BaseFragment() {
             )
             clearPendingAttachments()
         } else {
-            chatController.sendMessage(channelId, clanId, channelType, isPrivate, text, references, mentions)
+            val emojiMarkers = buildEmojiMarkers(text)
+            chatController.sendMessage(channelId, clanId, channelType, isPrivate, text, references, mentions, emojiMarkers)
         }
         inputField.text?.clear()
+        emojiObjPicked.clear()
         mentionTrackers.clear()
         clearReplyState()
+    }
+
+    private fun buildEmojiMarkers(text: String): List<EmojiMarker>? {
+        if (emojiObjPicked.isEmpty()) return null
+        val markers = ArrayList<EmojiMarker>()
+        for ((shortname, emojiId) in emojiObjPicked) {
+            var searchFrom = 0
+            while (true) {
+                val idx = text.indexOf(shortname, searchFrom)
+                if (idx < 0) break
+                markers.add(EmojiMarker(emojiId, idx, idx + shortname.length))
+                searchFrom = idx + shortname.length
+            }
+        }
+        return markers.ifEmpty { null }
     }
 
     private fun showAttachmentPicker() {

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
@@ -414,10 +414,12 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
                 allReceivers[i].setRoundRadius(MEDIA_RADIUS.toInt())
                 allReceivers[i].setRequestedSize(pw, ph)
                 val isLocalUri = att.url.startsWith("content://") || att.url.startsWith("file://")
-                if (isLocalUri) {
+                val isVideo = att.filetype.startsWith("video/")
+                if (isLocalUri && isVideo) {
+                    allReceivers[i].recycle()
+                    if (i == 0) loadLocalVideoThumbnail(att.url)
+                } else if (isLocalUri) {
                     allReceivers[i].setLocalUri(android.net.Uri.parse(att.url), context)
-                } else if (allReceivers[i].hasMainImage()) {
-                    // Keep existing local preview — don't reload CDN to avoid flash
                 } else if (isAnimated) {
                     allReceivers[i].setImage(att.url, att.thumb.ifEmpty { null }, context)
                 } else if (att.filetype.startsWith("video/")) {
@@ -484,6 +486,25 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             try {
                 val retriever = android.media.MediaMetadataRetriever()
                 retriever.setDataSource(videoUrl, HashMap<String, String>())
+                val frame = retriever.getFrameAtTime(100_000L, android.media.MediaMetadataRetriever.OPTION_CLOSEST_SYNC)
+                retriever.release()
+                if (frame != null) {
+                    withContext(Dispatchers.Main) {
+                        photoImage.setBitmapDirectly(frame)
+                        invalidate()
+                    }
+                }
+            } catch (_: Exception) {}
+        }
+    }
+
+    private fun loadLocalVideoThumbnail(localUrl: String) {
+        videoThumbJob?.cancel()
+        videoThumbJob = videoThumbScope.launch {
+            try {
+                val uri = android.net.Uri.parse(localUrl)
+                val retriever = android.media.MediaMetadataRetriever()
+                retriever.setDataSource(context, uri)
                 val frame = retriever.getFrameAtTime(100_000L, android.media.MediaMetadataRetriever.OPTION_CLOSEST_SYNC)
                 retriever.release()
                 if (frame != null) {

--- a/app/src/main/java/com/mezon/mobile/home/chat/EmojiController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/EmojiController.kt
@@ -1,0 +1,268 @@
+package com.mezon.mobile.home.chat
+
+import android.util.Log
+import com.mezon.mobile.BuildConfig
+import com.mezon.mobile.core.NotificationCenter
+import com.mezon.mobile.di.ApplicationScope
+import com.mezon.mobile.di.IoDispatcher
+import com.mezon.mobile.network.ApiCacheTracker
+import com.mezon.mobile.network.MezonApi
+import com.mezon.mobile.network.SocketEventDispatcher
+import com.mezon.mobile.network.TenorApi
+import com.mezon.mobile.network.TenorCategory
+import com.mezon.mobile.network.TenorGif
+import com.mezon.mobile.session.SessionManager
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+data class EmojiItem(
+    val id: String,
+    val shortname: String,
+    val src: String,
+    val category: String,
+    val clanId: String,
+    val clanName: String,
+    val clanLogo: String,
+    val isForSale: Boolean,
+    val creatorId: String
+)
+
+data class StickerItem(
+    val id: String,
+    val shortname: String,
+    val src: String,
+    val category: String,
+    val clanId: String,
+    val clanName: String,
+    val clanLogo: String,
+    val isForSale: Boolean,
+    val creatorId: String,
+    val mediaType: Int
+) {
+    val isAudio: Boolean get() = mediaType == MEDIA_TYPE_AUDIO ||
+        src.endsWith(".mp3", true) || src.endsWith(".wav", true) || src.contains("/sounds/")
+
+    companion object {
+        const val MEDIA_TYPE_STICKER = 0
+        const val MEDIA_TYPE_AUDIO = 1
+    }
+}
+
+data class EmojiCategory(
+    val name: String,
+    val clanId: String,
+    val clanLogo: String
+)
+
+private const val TAG = "EmojiController"
+
+val PREDEFINED_CATEGORIES = listOf(
+    "Recent", "Frequently", "People", "Nature", "Food",
+    "Activities", "Travel", "Objects", "Symbols", "Flags"
+)
+
+@Singleton
+class EmojiController @Inject constructor(
+    private val api: MezonApi,
+    private val tenorApi: TenorApi,
+    private val dispatcher: SocketEventDispatcher,
+    private val notificationCenter: NotificationCenter,
+    private val sessionManager: SessionManager,
+    private val cacheTracker: ApiCacheTracker,
+    @ApplicationScope private val appScope: CoroutineScope,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
+) {
+    val emojis = ArrayList<EmojiItem>()
+    val emojisDict = HashMap<String, EmojiItem>()
+    val stickers = ArrayList<StickerItem>()
+    val stickersDict = HashMap<String, StickerItem>()
+
+    val gifCategories = ArrayList<TenorCategory>()
+    val featuredGifs = ArrayList<TenorGif>()
+    val searchGifResults = ArrayList<TenorGif>()
+
+    @Volatile
+    private var emojisLoaded = false
+    @Volatile
+    private var stickersLoaded = false
+
+    init {
+        appScope.launch { observeEmojiEvents() }
+        appScope.launch { observeStickerEvents() }
+    }
+
+    fun getEmojiById(id: String): EmojiItem? = synchronized(this) { emojisDict[id] }
+
+    fun getCategories(): List<EmojiCategory> {
+        val clanCategories = ArrayList<EmojiCategory>()
+        val seen = HashSet<String>()
+        synchronized(this) {
+            for (emoji in emojis) {
+                if (emoji.clanId != "0" && emoji.clanId.isNotBlank() && seen.add(emoji.clanId)) {
+                    clanCategories.add(EmojiCategory(emoji.clanName, emoji.clanId, emoji.clanLogo))
+                }
+            }
+        }
+        val result = ArrayList<EmojiCategory>()
+        result.add(EmojiCategory("Recent", "", ""))
+        result.add(EmojiCategory("Frequently", "", ""))
+        result.addAll(clanCategories)
+        for (cat in PREDEFINED_CATEGORIES) {
+            if (cat != "Recent" && cat != "Frequently") {
+                result.add(EmojiCategory(cat, "0", ""))
+            }
+        }
+        return result
+    }
+
+    fun getEmojisByCategory(category: String): List<EmojiItem> {
+        return synchronized(this) {
+            when (category) {
+                "Recent", "Frequently" -> emojis.take(20)
+                else -> {
+                    val catEmojis = emojis.filter { it.category == category }
+                    if (catEmojis.isNotEmpty()) return@synchronized catEmojis
+                    emojis.filter { it.clanName == category }
+                }
+            }
+        }
+    }
+
+    fun searchEmojis(query: String): List<EmojiItem> {
+        val lower = query.lowercase()
+        return synchronized(this) {
+            emojis.filter { it.shortname.lowercase().contains(lower) }
+        }
+    }
+
+    fun searchStickers(query: String, excludeAudio: Boolean = true): List<StickerItem> {
+        val lower = query.lowercase()
+        return synchronized(this) {
+            stickers.filter {
+                it.shortname.lowercase().contains(lower) && (!excludeAudio || !it.isAudio)
+            }
+        }
+    }
+
+    fun loadEmojis() {
+        if (emojisLoaded && cacheTracker.shouldCall("emojis_by_user") == ApiCacheTracker.ShouldCall.SKIP) return
+        appScope.launch(ioDispatcher) {
+            try {
+                val session = sessionManager.sessionFlow.first() ?: return@launch
+                val response = api.listEmojisByUserId(session.apiUrl, session.token)
+                val items = response.emojiListList.map { proto ->
+                    EmojiItem(
+                        id = proto.id.toString(),
+                        shortname = proto.shortname,
+                        src = proto.src,
+                        category = proto.category,
+                        clanId = proto.clanId.toString(),
+                        clanName = proto.clanName,
+                        clanLogo = proto.logo,
+                        isForSale = proto.isForSale,
+                        creatorId = proto.creatorId.toString()
+                    )
+                }
+                synchronized(this@EmojiController) {
+                    emojis.clear()
+                    emojisDict.clear()
+                    emojis.addAll(items)
+                    for (item in items) emojisDict[item.id] = item
+                    emojisLoaded = true
+                }
+                cacheTracker.markCalled("emojis_by_user")
+                Log.d(TAG, "Loaded ${items.size} emojis")
+                notificationCenter.postNotificationOnMainThread(NotificationCenter.emojisNeedReload)
+            } catch (e: Exception) {
+                Log.e(TAG, "loadEmojis failed", e)
+            }
+        }
+    }
+
+    fun loadStickers() {
+        if (stickersLoaded && cacheTracker.shouldCall("stickers_by_user") == ApiCacheTracker.ShouldCall.SKIP) return
+        appScope.launch(ioDispatcher) {
+            try {
+                val session = sessionManager.sessionFlow.first() ?: return@launch
+                val response = api.listStickersByUserId(session.apiUrl, session.token)
+                val items = response.stickersList.map { proto ->
+                    StickerItem(
+                        id = proto.id.toString(),
+                        shortname = proto.shortname,
+                        src = proto.source,
+                        category = proto.category,
+                        clanId = proto.clanId.toString(),
+                        clanName = proto.clanName,
+                        clanLogo = proto.logo,
+                        isForSale = proto.isForSale,
+                        creatorId = proto.creatorId.toString(),
+                        mediaType = proto.mediaType
+                    )
+                }
+                synchronized(this@EmojiController) {
+                    stickers.clear()
+                    stickersDict.clear()
+                    stickers.addAll(items)
+                    for (item in items) stickersDict[item.id] = item
+                    stickersLoaded = true
+                }
+                cacheTracker.markCalled("stickers_by_user")
+                Log.d(TAG, "Loaded ${items.size} stickers")
+                notificationCenter.postNotificationOnMainThread(NotificationCenter.stickersNeedReload)
+            } catch (e: Exception) {
+                Log.e(TAG, "loadStickers failed", e)
+            }
+        }
+    }
+
+    fun loadGifCategories() {
+        appScope.launch(ioDispatcher) {
+            val cats = tenorApi.fetchCategories(BuildConfig.TENOR_API_KEY)
+            synchronized(this@EmojiController) {
+                gifCategories.clear()
+                gifCategories.addAll(cats)
+            }
+            notificationCenter.postNotificationOnMainThread(NotificationCenter.gifsNeedReload)
+        }
+    }
+
+    fun loadFeaturedGifs() {
+        appScope.launch(ioDispatcher) {
+            val gifs = tenorApi.fetchFeatured(BuildConfig.TENOR_API_KEY)
+            synchronized(this@EmojiController) {
+                featuredGifs.clear()
+                featuredGifs.addAll(gifs)
+            }
+            notificationCenter.postNotificationOnMainThread(NotificationCenter.gifsNeedReload)
+        }
+    }
+
+    fun searchGifs(query: String) {
+        appScope.launch(ioDispatcher) {
+            val gifs = tenorApi.searchGifs(BuildConfig.TENOR_API_KEY, query)
+            synchronized(this@EmojiController) {
+                searchGifResults.clear()
+                searchGifResults.addAll(gifs)
+            }
+            notificationCenter.postNotificationOnMainThread(NotificationCenter.gifsNeedReload)
+        }
+    }
+
+    private suspend fun observeEmojiEvents() {
+        dispatcher.emojiEvents.collect { event ->
+            Log.d(TAG, "EmojiEvent: id=${event.id} action=${event.action}")
+            loadEmojis()
+        }
+    }
+
+    private suspend fun observeStickerEvents() {
+        dispatcher.stickerCreateEvents.collect {
+            Log.d(TAG, "StickerCreateEvent: ${it.clanId}")
+            loadStickers()
+        }
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/home/chat/ImageReceiver.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ImageReceiver.kt
@@ -86,7 +86,10 @@ class ImageReceiver(private val parentView: View) {
     fun onAttachedToWindow() {
         if (attached) return
         attached = true
-        if (allowStartAnimation) (animatedDrawable as? Animatable)?.start()
+        val hasPending = pendingLoad != null || pendingLocalUri != null
+        if (!hasPending && allowStartAnimation) {
+            (animatedDrawable as? Animatable)?.start()
+        }
         pendingLoad?.let { (url, thumbUrl) ->
             pendingLoad = null
             currentUrl = null
@@ -116,6 +119,7 @@ class ImageReceiver(private val parentView: View) {
         if (!urlChanged && !thumbChanged) return
 
         if (!attached) {
+            recycle()
             pendingLoad = Pair(url, thumbUrl)
             return
         }
@@ -145,19 +149,22 @@ class ImageReceiver(private val parentView: View) {
                 (url.contains(".webp", true) && !url.endsWith("@webp"))
 
             if (isAnimatedRequest) {
-                // Use cached first-frame bitmap as instant placeholder (no flicker)
-                val cachedFirstFrame = loader.getBitmapFromMemory(url, rw, rh)
-                if (cachedFirstFrame != null && thumbBitmap == null) {
-                    thumbBitmap = cachedFirstFrame
-                    parentView.invalidate()
-                }
-                // Keep existing animatedDrawable visible until new one arrives
+                stopAnimation()
+                animatedDrawable = null
+                imageBitmap = null
+                cachedShader = null
+                cachedShaderBitmap = null
 
+                val cachedFirstFrame = loader.getBitmapFromMemory(url, rw, rh)
+                thumbBitmap = cachedFirstFrame
+                parentView.invalidate()
+
+                val expectedUrl = url
                 mainCancellable = loader.loadDrawable(url, rw, rh,
                     onSuccess = { drawable ->
+                        if (currentUrl != expectedUrl) return@loadDrawable
                         if (drawable is Animatable) {
                             imageBitmap = null
-                            // Keep thumbBitmap — draw() prefers animated over thumb naturally
                             cachedShader = null
                             cachedShaderBitmap = null
                             animatedDrawable = drawable
@@ -172,10 +179,11 @@ class ImageReceiver(private val parentView: View) {
                         }
                         parentView.invalidate()
                     },
-                    onError = { onLoadError(url, rw, rh, loader) }
+                    onError = {
+                        if (currentUrl == expectedUrl) onLoadError(url, rw, rh, loader)
+                    }
                 )
             } else {
-                // Static image path — existing anti-flicker logic
                 val cached = loader.getBitmapFromMemory(url, rw, rh)
                 if (cached != null) {
                     imageBitmap = cached
@@ -194,8 +202,10 @@ class ImageReceiver(private val parentView: View) {
                 cachedShader = null
                 cachedShaderBitmap = null
 
+                val expectedUrl = url
                 mainCancellable = loader.load(url, rw, rh,
                     onSuccess = { bmp ->
+                        if (currentUrl != expectedUrl) return@load
                         val hadThumb = thumbBitmap != null
                         imageBitmap = bmp
                         animatedDrawable = null
@@ -210,7 +220,9 @@ class ImageReceiver(private val parentView: View) {
                         }
                         parentView.invalidate()
                     },
-                    onError = { onLoadError(url, rw, rh, loader) }
+                    onError = {
+                        if (currentUrl == expectedUrl) onLoadError(url, rw, rh, loader)
+                    }
                 )
             }
         }
@@ -280,31 +292,6 @@ class ImageReceiver(private val parentView: View) {
     private fun drawAnimated(canvas: Canvas, drawable: Drawable): Boolean {
         val hasRound = roundRadius.any { it > 0 }
 
-        val intrW = drawable.intrinsicWidth.toFloat()
-        val intrH = drawable.intrinsicHeight.toFloat()
-
-        val drawLeft: Int
-        val drawTop: Int
-        val drawRight: Int
-        val drawBottom: Int
-
-        if (intrW > 0f && intrH > 0f) {
-            val scaleW = intrW / imageW
-            val scaleH = intrH / imageH
-            val scale = 1f / minOf(scaleW, scaleH)
-            val scaledW = intrW * scale
-            val scaledH = intrH * scale
-            drawLeft = (imageX - (scaledW - imageW) / 2f).toInt()
-            drawTop = (imageY - (scaledH - imageH) / 2f).toInt()
-            drawRight = (drawLeft + scaledW).toInt()
-            drawBottom = (drawTop + scaledH).toInt()
-        } else {
-            drawLeft = imageX.toInt()
-            drawTop = imageY.toInt()
-            drawRight = (imageX + imageW).toInt()
-            drawBottom = (imageY + imageH).toInt()
-        }
-
         if (hasRound) {
             roundRect.set(imageX, imageY, imageX + imageW, imageY + imageH)
             for (i in roundRadius.indices) {
@@ -320,7 +307,20 @@ class ImageReceiver(private val parentView: View) {
             canvas.clipRect(imageX, imageY, imageX + imageW, imageY + imageH)
         }
 
-        drawable.setBounds(drawLeft, drawTop, drawRight, drawBottom)
+        val iw = drawable.intrinsicWidth
+        val ih = drawable.intrinsicHeight
+        if (iw > 0 && ih > 0) {
+            val scale = maxOf(imageW / iw.toFloat(), imageH / ih.toFloat())
+            val dx = imageX + (imageW - iw * scale) / 2f
+            val dy = imageY + (imageH - ih * scale) / 2f
+            canvas.translate(dx, dy)
+            canvas.scale(scale, scale)
+            drawable.setBounds(0, 0, iw, ih)
+        } else {
+            drawable.setBounds(imageX.toInt(), imageY.toInt(),
+                (imageX + imageW).toInt(), (imageY + imageH).toInt())
+        }
+
         drawable.draw(canvas)
         canvas.restore()
         return true
@@ -419,22 +419,39 @@ class ImageReceiver(private val parentView: View) {
     }
 
     fun setLocalUri(uri: android.net.Uri, context: Context) {
+        val uriString = uri.toString()
         if (!attached) {
+            recycle()
             pendingLocalUri = uri
+            currentUrl = uriString
             return
         }
-        mainCancellable?.cancel()
+        if (uriString == currentUrl && hasMainImage()) return
+
+        recycle()
+        currentUrl = uriString
+
         val loader = MezonImageLoader.getInstance(context)
         val rw = if (requestW > 0) requestW else 800
         val rh = if (requestH > 0) requestH else 800
+
+        val cached = loader.getBitmapFromMemory(uriString, rw, rh)
+        if (cached != null) {
+            imageBitmap = cached
+            crossfadeAlpha = 255
+            parentView.invalidate()
+            return
+        }
+
+        parentView.invalidate()
+
         mainCancellable = loader.loadFromUri(uri, rw, rh,
             onSuccess = { bmp ->
+                if (currentUrl != uriString) return@loadFromUri
                 imageBitmap = bmp
-                animatedDrawable = null
                 cachedShader = null
                 cachedShaderBitmap = null
                 crossfadeAlpha = 255
-                thumbBitmap = null
                 parentView.invalidate()
             }
         )

--- a/app/src/main/java/com/mezon/mobile/home/chat/emoji/CollapsibleHeaderCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/emoji/CollapsibleHeaderCell.kt
@@ -1,0 +1,79 @@
+package com.mezon.mobile.home.chat.emoji
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
+import android.graphics.drawable.Drawable
+import android.view.Gravity
+import android.view.View
+import android.widget.FrameLayout
+import com.mezon.mobile.core.LayoutHelper
+import com.mezon.mobile.core.ThemeColors
+import com.mezon.mobile.ui.cells.MezonIcon
+
+private val CELL_HEIGHT = LayoutHelper.dp(32f)
+private val TEXT_LEFT = LayoutHelper.dp(12f)
+private val CHEVRON_SIZE = LayoutHelper.dp(16f)
+private val CHEVRON_RIGHT = LayoutHelper.dp(12f)
+
+class CollapsibleHeaderCell(context: Context, private val themeColors: ThemeColors) : View(context) {
+
+    var title: String = ""
+        private set
+    var isExpanded: Boolean = true
+        private set
+    var onToggle: (() -> Unit)? = null
+
+    private var chevronDown: Drawable? = null
+    private var chevronRight: Drawable? = null
+
+    init {
+        layoutParams = FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT, CELL_HEIGHT, Gravity.TOP
+        )
+        setOnClickListener { onToggle?.invoke() }
+    }
+
+    fun bind(title: String, expanded: Boolean) {
+        this.title = title
+        this.isExpanded = expanded
+        invalidate()
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        setMeasuredDimension(MeasureSpec.getSize(widthMeasureSpec), CELL_HEIGHT)
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        val cy = measuredHeight / 2f
+        canvas.drawText(title, TEXT_LEFT.toFloat(), cy - (textPaint.ascent() + textPaint.descent()) / 2f, textPaint)
+
+        val chevron = if (isExpanded) {
+            chevronDown ?: MezonIcon.chevronDownSmallIcon.getDrawable(context).mutate().also {
+                it.colorFilter = PorterDuffColorFilter(themeColors.onSurfaceVariant, PorterDuff.Mode.SRC_IN)
+                chevronDown = it
+            }
+        } else {
+            chevronRight ?: MezonIcon.chevronSmallRightIcon.getDrawable(context).mutate().also {
+                it.colorFilter = PorterDuffColorFilter(themeColors.onSurfaceVariant, PorterDuff.Mode.SRC_IN)
+                chevronRight = it
+            }
+        }
+        val cx = measuredWidth - CHEVRON_RIGHT - CHEVRON_SIZE
+        val ct = (measuredHeight - CHEVRON_SIZE) / 2
+        chevron.setBounds(cx, ct, cx + CHEVRON_SIZE, ct + CHEVRON_SIZE)
+        chevron.draw(canvas)
+    }
+
+    companion object {
+        private val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            textSize = LayoutHelper.dp(13f).toFloat()
+        }
+
+        fun applyTheme(themeColors: ThemeColors) {
+            textPaint.color = themeColors.onSurfaceVariant
+        }
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/home/chat/emoji/EmojiCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/emoji/EmojiCell.kt
@@ -1,0 +1,107 @@
+package com.mezon.mobile.home.chat.emoji
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
+import android.graphics.Rect
+import android.graphics.drawable.Drawable
+import android.view.Gravity
+import android.view.View
+import android.widget.FrameLayout
+import com.mezon.mobile.core.LayoutHelper
+import com.mezon.mobile.core.ThemeColors
+import com.mezon.mobile.home.chat.EmojiItem
+import com.mezon.mobile.home.chat.MezonImageLoader
+import com.mezon.mobile.ui.cells.MezonIcon
+import com.mezon.mobile.util.getEmojiUrl
+
+private val CELL_SIZE = LayoutHelper.dp(38f)
+private val IMAGE_SIZE = LayoutHelper.dp(32f)
+private val IMAGE_REQ = IMAGE_SIZE * 2
+private val LOCK_SIZE = LayoutHelper.dp(12f)
+private val LOCK_PAD = LayoutHelper.dp(2f)
+
+class EmojiCell(context: Context, private val themeColors: ThemeColors) : View(context) {
+
+    private var emoji: EmojiItem? = null
+    private var bitmap: Bitmap? = null
+    private var isLocked = false
+    private var cancellable: MezonImageLoader.Cancellable? = null
+    private var lockDrawable: Drawable? = null
+    private val loader = MezonImageLoader.getInstance(context)
+
+    private val srcRect = Rect()
+    private val dstRect = Rect()
+
+    init {
+        layoutParams = FrameLayout.LayoutParams(CELL_SIZE, CELL_SIZE, Gravity.CENTER)
+    }
+
+    fun setEmoji(item: EmojiItem) {
+        if (emoji?.id == item.id) return
+        cancellable?.cancel()
+        bitmap = null
+        emoji = item
+        isLocked = item.isForSale && item.src.isBlank()
+
+        if (item.id.isNotBlank()) {
+            val url = getEmojiUrl(item.id)
+            if (url != null) {
+                val cached = loader.getBitmapFromMemory(url, IMAGE_REQ, IMAGE_REQ)
+                if (cached != null) {
+                    bitmap = cached
+                } else {
+                    cancellable = loader.load(url, IMAGE_REQ, IMAGE_REQ, onSuccess = { bmp ->
+                        bitmap = bmp
+                        invalidate()
+                    })
+                }
+            }
+        }
+        invalidate()
+    }
+
+    override fun invalidate() {
+        if (emoji == null) return
+        super.invalidate()
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        setMeasuredDimension(CELL_SIZE, CELL_SIZE)
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        val bmp = bitmap ?: return
+        val left = (measuredWidth - IMAGE_SIZE) / 2
+        val top = (measuredHeight - IMAGE_SIZE) / 2
+        srcRect.set(0, 0, bmp.width, bmp.height)
+        dstRect.set(left, top, left + IMAGE_SIZE, top + IMAGE_SIZE)
+        canvas.drawBitmap(bmp, srcRect, dstRect, bitmapPaint)
+
+        if (isLocked) {
+            val ld = lockDrawable ?: run {
+                MezonIcon.lockIcon.getDrawable(context).mutate().also {
+                    it.colorFilter = PorterDuffColorFilter(themeColors.onSurfaceVariant, PorterDuff.Mode.SRC_IN)
+                    lockDrawable = it
+                }
+            }
+            val lx = left + IMAGE_SIZE - LOCK_SIZE - LOCK_PAD
+            val ly = top + IMAGE_SIZE - LOCK_SIZE - LOCK_PAD
+            ld.setBounds(lx, ly, lx + LOCK_SIZE, ly + LOCK_SIZE)
+            ld.draw(canvas)
+        }
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        cancellable?.cancel()
+        cancellable = null
+    }
+
+    companion object {
+        private val bitmapPaint = Paint(Paint.FILTER_BITMAP_FLAG or Paint.ANTI_ALIAS_FLAG)
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/home/chat/emoji/EmojiGridAdapter.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/emoji/EmojiGridAdapter.kt
@@ -1,0 +1,173 @@
+package com.mezon.mobile.home.chat.emoji
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import com.mezon.mobile.core.ThemeColors
+import com.mezon.mobile.home.chat.EmojiItem
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class EmojiGridAdapter(
+    private val themeColors: ThemeColors,
+    private val onEmojiClick: (EmojiItem) -> Unit
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+    companion object {
+        const val VIEW_TYPE_HEADER = 0
+        const val VIEW_TYPE_EMOJI = 1
+    }
+
+    sealed class ListItem {
+        abstract val stableId: Long
+        data class Header(val title: String, val expanded: Boolean) : ListItem() {
+            override val stableId: Long get() = title.hashCode().toLong() or (1L shl 62)
+        }
+        data class Emoji(val item: EmojiItem) : ListItem() {
+            override val stableId: Long get() = item.id.hashCode().toLong()
+        }
+    }
+
+    private data class CategoryData(val name: String, val emojis: List<EmojiItem>)
+
+    private val items = ArrayList<ListItem>()
+    private val categories = ArrayList<CategoryData>()
+    private val collapsedSections = HashSet<String>()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var diffJob: Job? = null
+
+    init {
+        setHasStableIds(true)
+        CollapsibleHeaderCell.applyTheme(themeColors)
+    }
+
+    override fun getItemId(position: Int): Long =
+        if (position in items.indices) items[position].stableId else RecyclerView.NO_ID
+
+    fun setData(categoryList: List<Pair<String, List<EmojiItem>>>) {
+        categories.clear()
+        for ((name, emojis) in categoryList) {
+            if (emojis.isEmpty()) continue
+            categories.add(CategoryData(name, emojis))
+        }
+        rebuildItems()
+    }
+
+    fun setSearchResults(emojis: List<EmojiItem>) {
+        categories.clear()
+        val newItems = ArrayList<ListItem>(emojis.size)
+        for (emoji in emojis) {
+            newItems.add(ListItem.Emoji(emoji))
+        }
+        applyNewItems(newItems)
+    }
+
+    fun toggleSection(title: String) {
+        if (collapsedSections.contains(title)) {
+            collapsedSections.remove(title)
+        } else {
+            collapsedSections.add(title)
+        }
+        rebuildItems()
+    }
+
+    private fun rebuildItems() {
+        val newItems = ArrayList<ListItem>()
+        for (cat in categories) {
+            val expanded = !collapsedSections.contains(cat.name)
+            newItems.add(ListItem.Header(cat.name, expanded))
+            if (expanded) {
+                for (emoji in cat.emojis) {
+                    newItems.add(ListItem.Emoji(emoji))
+                }
+            }
+        }
+        applyNewItems(newItems)
+    }
+
+    private fun applyNewItems(newItems: ArrayList<ListItem>) {
+        diffJob?.cancel()
+        if (newItems.size < 50 && items.size < 50) {
+            val result = DiffUtil.calculateDiff(ItemDiffCallback(items, newItems))
+            items.clear(); items.addAll(newItems)
+            result.dispatchUpdatesTo(this)
+        } else {
+            val oldList = ArrayList(items)
+            diffJob = scope.launch {
+                val result = withContext(Dispatchers.Default) {
+                    DiffUtil.calculateDiff(ItemDiffCallback(oldList, newItems))
+                }
+                items.clear(); items.addAll(newItems)
+                result.dispatchUpdatesTo(this@EmojiGridAdapter)
+            }
+        }
+    }
+
+    fun isHeader(position: Int): Boolean = items.getOrNull(position) is ListItem.Header
+
+    override fun getItemViewType(position: Int): Int = when (items[position]) {
+        is ListItem.Header -> VIEW_TYPE_HEADER
+        is ListItem.Emoji -> VIEW_TYPE_EMOJI
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return when (viewType) {
+            VIEW_TYPE_HEADER -> {
+                val cell = CollapsibleHeaderCell(parent.context, themeColors)
+                val vh = HeaderViewHolder(cell)
+                cell.onToggle = {
+                    val pos = vh.bindingAdapterPosition
+                    if (pos != RecyclerView.NO_POSITION) {
+                        val item = items.getOrNull(pos)
+                        if (item is ListItem.Header) toggleSection(item.title)
+                    }
+                }
+                vh
+            }
+            else -> {
+                val cell = EmojiCell(parent.context, themeColors)
+                val vh = EmojiViewHolder(cell)
+                cell.setOnClickListener {
+                    val pos = vh.bindingAdapterPosition
+                    if (pos != RecyclerView.NO_POSITION) {
+                        val item = items.getOrNull(pos)
+                        if (item is ListItem.Emoji) onEmojiClick(item.item)
+                    }
+                }
+                vh
+            }
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (val item = items[position]) {
+            is ListItem.Header -> (holder as HeaderViewHolder).cell.bind(item.title, item.expanded)
+            is ListItem.Emoji -> (holder as EmojiViewHolder).cell.setEmoji(item.item)
+        }
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        diffJob?.cancel()
+        scope.cancel()
+    }
+
+    class HeaderViewHolder(val cell: CollapsibleHeaderCell) : RecyclerView.ViewHolder(cell)
+    class EmojiViewHolder(val cell: EmojiCell) : RecyclerView.ViewHolder(cell)
+
+    private class ItemDiffCallback(
+        private val old: List<ListItem>,
+        private val new: List<ListItem>
+    ) : DiffUtil.Callback() {
+        override fun getOldListSize() = old.size
+        override fun getNewListSize() = new.size
+        override fun areItemsTheSame(oldPos: Int, newPos: Int) = old[oldPos].stableId == new[newPos].stableId
+        override fun areContentsTheSame(oldPos: Int, newPos: Int) = old[oldPos] == new[newPos]
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/home/chat/emoji/EmojiView.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/emoji/EmojiView.kt
@@ -1,0 +1,440 @@
+package com.mezon.mobile.home.chat.emoji
+
+import android.content.Context
+import android.graphics.Color
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
+import android.os.Handler
+import android.os.Looper
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.Gravity
+import android.view.View
+import android.widget.EditText
+import android.widget.FrameLayout
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.SimpleItemAnimator
+import com.mezon.mobile.core.AndroidUtilities
+import com.mezon.mobile.core.LayoutHelper
+import com.mezon.mobile.core.RecyclerListView
+import com.mezon.mobile.core.ThemeColors
+import com.mezon.mobile.home.chat.EmojiController
+import com.mezon.mobile.home.chat.EmojiItem
+import com.mezon.mobile.home.chat.StickerItem
+import com.mezon.mobile.network.TenorCategory
+import com.mezon.mobile.network.TenorGif
+import com.mezon.mobile.ui.cells.MezonIcon
+
+private const val TAB_EMOJI = 0
+private const val TAB_GIF = 1
+private const val TAB_STICKER = 2
+private const val SEARCH_DEBOUNCE_MS = 300L
+private const val EMOJI_COLUMNS = 9
+private const val STICKER_COLUMNS = 5
+
+class EmojiView(context: Context, private val themeColors: ThemeColors) : FrameLayout(context) {
+
+    interface EmojiViewDelegate {
+        fun onEmojiSelected(emoji: EmojiItem)
+        fun onStickerSelected(sticker: StickerItem, isAudio: Boolean)
+        fun onGifSelected(gifUrl: String)
+        fun onBackspace()
+        fun onSearchFocusChanged(focused: Boolean) {}
+    }
+
+    var delegate: EmojiViewDelegate? = null
+    private var currentTab = TAB_EMOJI
+    private var emojiController: EmojiController? = null
+
+    private val handler = Handler(Looper.getMainLooper())
+    private var searchRunnable: Runnable? = null
+
+    private val tabBar: LinearLayout
+    private val tabEmoji: TextView
+    private val tabGif: TextView
+    private val tabSticker: TextView
+    private val searchField: EditText
+    private val contentContainer: FrameLayout
+    private val backspaceButton: ImageView
+
+    private var emojiGrid: RecyclerListView? = null
+    private var stickerGrid: RecyclerListView? = null
+    private var gifGrid: RecyclerListView? = null
+    private var gifCategoryGrid: RecyclerListView? = null
+    private var emojiAdapter: EmojiGridAdapter? = null
+    private var stickerAdapter: StickerGridAdapter? = null
+    private var gifCategoryAdapter: GifCategoryAdapter? = null
+    private var gifSearchActive = false
+    private var gifAdapter: GifGridAdapter? = null
+
+    init {
+        setBackgroundColor(themeColors.surface)
+
+        val root = LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+        }
+
+        tabBar = LinearLayout(context).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER
+            setBackgroundColor(themeColors.surface)
+            setPadding(0, LayoutHelper.dp(4f), 0, LayoutHelper.dp(4f))
+        }
+
+        tabEmoji = createTabButton("Emoji")
+        tabGif = createTabButton("GIF")
+        tabSticker = createTabButton("Sticker")
+
+        tabEmoji.setOnClickListener { switchTab(TAB_EMOJI) }
+        tabGif.setOnClickListener { switchTab(TAB_GIF) }
+        tabSticker.setOnClickListener { switchTab(TAB_STICKER) }
+
+        tabBar.addView(tabEmoji, LayoutHelper.createLinear(0, 36, 1f, leftMargin = 4f, rightMargin = 2f))
+        tabBar.addView(tabGif, LayoutHelper.createLinear(0, 36, 1f, leftMargin = 2f, rightMargin = 2f))
+        tabBar.addView(tabSticker, LayoutHelper.createLinear(0, 36, 1f, leftMargin = 2f, rightMargin = 4f))
+        root.addView(tabBar, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT))
+
+        val searchBar = FrameLayout(context).apply {
+            setPadding(LayoutHelper.dp(8f), LayoutHelper.dp(4f), LayoutHelper.dp(8f), LayoutHelper.dp(4f))
+        }
+
+        searchField = EditText(context).apply {
+            hint = "Search"
+            setHintTextColor(themeColors.onSurfaceVariant)
+            setTextColor(themeColors.onSurface)
+            textSize = 14f
+            maxLines = 1
+            isSingleLine = true
+            background = android.graphics.drawable.GradientDrawable().apply {
+                setColor(themeColors.tertiary)
+                cornerRadius = LayoutHelper.dp(16f).toFloat()
+            }
+            setPadding(LayoutHelper.dp(36f), LayoutHelper.dp(6f), LayoutHelper.dp(12f), LayoutHelper.dp(6f))
+        }
+
+        val searchIcon = ImageView(context).apply {
+            val d = MezonIcon.searchIcon.getDrawable(context)
+            d.colorFilter = PorterDuffColorFilter(themeColors.onSurfaceVariant, PorterDuff.Mode.SRC_IN)
+            setImageDrawable(d)
+            scaleType = ImageView.ScaleType.CENTER
+        }
+        searchBar.addView(searchField, FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT, LayoutHelper.dp(36f)
+        ))
+        searchBar.addView(searchIcon, FrameLayout.LayoutParams(
+            LayoutHelper.dp(36f), LayoutHelper.dp(36f), Gravity.START or Gravity.CENTER_VERTICAL
+        ))
+        root.addView(searchBar, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT))
+
+        searchField.setOnFocusChangeListener { _, hasFocus ->
+            delegate?.onSearchFocusChanged(hasFocus)
+        }
+
+        searchField.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+            override fun afterTextChanged(s: Editable?) {
+                val query = s?.toString()?.trim() ?: ""
+                searchRunnable?.let { handler.removeCallbacks(it) }
+                searchRunnable = Runnable { performSearch(query) }
+                handler.postDelayed(searchRunnable!!, SEARCH_DEBOUNCE_MS)
+            }
+        })
+
+        contentContainer = FrameLayout(context)
+        root.addView(contentContainer, LayoutHelper.createLinear(
+            LayoutHelper.MATCH_PARENT, 0, 1f
+        ))
+
+        val bottomBar = FrameLayout(context).apply {
+            setBackgroundColor(themeColors.surface)
+        }
+        backspaceButton = ImageView(context).apply {
+            val d = MezonIcon.backspaceIcon.getDrawable(context)
+            d.colorFilter = PorterDuffColorFilter(themeColors.onSurfaceVariant, PorterDuff.Mode.SRC_IN)
+            setImageDrawable(d)
+            scaleType = ImageView.ScaleType.CENTER
+            setOnClickListener { delegate?.onBackspace() }
+        }
+        bottomBar.addView(backspaceButton, FrameLayout.LayoutParams(
+            LayoutHelper.dp(40f), LayoutHelper.dp(40f), Gravity.END or Gravity.CENTER_VERTICAL
+        ).apply { rightMargin = LayoutHelper.dp(8f) })
+        root.addView(bottomBar, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, 44))
+
+        addView(root, FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            FrameLayout.LayoutParams.MATCH_PARENT
+        ))
+
+        updateTabSelection()
+    }
+
+    fun init(controller: EmojiController) {
+        emojiController = controller
+    }
+
+    fun onOpen(forceTab: Int = -1) {
+        if (forceTab >= 0) {
+            switchTab(forceTab)
+        } else {
+            ensureCurrentTabVisible()
+        }
+        emojiController?.loadEmojis()
+        emojiController?.loadStickers()
+    }
+
+    private fun ensureCurrentTabVisible() {
+        ensureGrid(currentTab)
+        updateGifGridVisibility()
+        emojiGrid?.visibility = if (currentTab == TAB_EMOJI) View.VISIBLE else View.GONE
+        stickerGrid?.visibility = if (currentTab == TAB_STICKER) View.VISIBLE else View.GONE
+        when (currentTab) {
+            TAB_EMOJI -> loadEmojiData()
+            TAB_STICKER -> loadStickerData()
+            TAB_GIF -> loadGifData()
+        }
+        backspaceButton.visibility = if (currentTab == TAB_EMOJI) View.VISIBLE else View.GONE
+    }
+
+    private fun switchTab(tab: Int) {
+        if (currentTab == tab) return
+        currentTab = tab
+        updateTabSelection()
+        searchField.text?.clear()
+        gifSearchActive = false
+
+        ensureGrid(tab)
+        updateGifGridVisibility()
+        emojiGrid?.visibility = if (tab == TAB_EMOJI) View.VISIBLE else View.GONE
+        stickerGrid?.visibility = if (tab == TAB_STICKER) View.VISIBLE else View.GONE
+
+        when (tab) {
+            TAB_EMOJI -> loadEmojiData()
+            TAB_STICKER -> loadStickerData()
+            TAB_GIF -> loadGifData()
+        }
+        backspaceButton.visibility = if (tab == TAB_EMOJI) View.VISIBLE else View.GONE
+    }
+
+    private fun updateGifGridVisibility() {
+        if (currentTab == TAB_GIF) {
+            gifCategoryGrid?.visibility = if (gifSearchActive) View.GONE else View.VISIBLE
+            gifGrid?.visibility = if (gifSearchActive) View.VISIBLE else View.GONE
+        } else {
+            gifCategoryGrid?.visibility = View.GONE
+            gifGrid?.visibility = View.GONE
+        }
+    }
+
+    private fun onGifCategoryTapped(category: TenorCategory) {
+        gifSearchActive = true
+        updateGifGridVisibility()
+        emojiController?.searchGifs(category.name)
+    }
+
+    private fun ensureGrid(tab: Int) {
+        val matchLp = FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT
+        )
+        when (tab) {
+            TAB_EMOJI -> if (emojiGrid == null) {
+                emojiAdapter = EmojiGridAdapter(themeColors) { emoji ->
+                    if (emoji.isForSale && emoji.src.isBlank()) return@EmojiGridAdapter
+                    delegate?.onEmojiSelected(emoji)
+                }
+                val lm = GridLayoutManager(context, EMOJI_COLUMNS)
+                lm.spanSizeLookup = object : GridLayoutManager.SpanSizeLookup() {
+                    override fun getSpanSize(position: Int): Int {
+                        return if (emojiAdapter?.isHeader(position) == true) EMOJI_COLUMNS else 1
+                    }
+                }
+                emojiGrid = RecyclerListView(context).apply {
+                    layoutManager = lm
+                    adapter = emojiAdapter
+                    setHasFixedSize(true)
+                    (itemAnimator as? SimpleItemAnimator)?.supportsChangeAnimations = false
+                    overScrollMode = OVER_SCROLL_NEVER
+                }
+                contentContainer.addView(emojiGrid, matchLp)
+            }
+            TAB_STICKER -> if (stickerGrid == null) {
+                stickerAdapter = StickerGridAdapter(themeColors) { sticker ->
+                    if (sticker.isForSale && sticker.src.isBlank()) return@StickerGridAdapter
+                    delegate?.onStickerSelected(sticker, sticker.isAudio)
+                }
+                val lm = GridLayoutManager(context, STICKER_COLUMNS)
+                lm.spanSizeLookup = object : GridLayoutManager.SpanSizeLookup() {
+                    override fun getSpanSize(position: Int): Int {
+                        return if (stickerAdapter?.isHeader(position) == true) STICKER_COLUMNS else 1
+                    }
+                }
+                stickerGrid = RecyclerListView(context).apply {
+                    layoutManager = lm
+                    adapter = stickerAdapter
+                    setHasFixedSize(true)
+                    (itemAnimator as? SimpleItemAnimator)?.supportsChangeAnimations = false
+                    overScrollMode = OVER_SCROLL_NEVER
+                }
+                contentContainer.addView(stickerGrid, matchLp)
+            }
+            TAB_GIF -> {
+                val gifSpacing = LayoutHelper.dp(5f)
+                if (gifCategoryGrid == null) {
+                    gifCategoryAdapter = GifCategoryAdapter(themeColors) { category ->
+                        onGifCategoryTapped(category)
+                    }
+                    gifCategoryGrid = RecyclerListView(context).apply {
+                        layoutManager = GridLayoutManager(context, 2)
+                        adapter = gifCategoryAdapter
+                        setHasFixedSize(true)
+                        (itemAnimator as? SimpleItemAnimator)?.supportsChangeAnimations = false
+                        overScrollMode = OVER_SCROLL_NEVER
+                        addItemDecoration(GifSpacingDecoration(gifSpacing))
+                        setPadding(gifSpacing, gifSpacing, gifSpacing, gifSpacing)
+                        clipToPadding = false
+                    }
+                    contentContainer.addView(gifCategoryGrid, matchLp)
+                }
+                if (gifGrid == null) {
+                    gifAdapter = GifGridAdapter(themeColors) { gif ->
+                        delegate?.onGifSelected(gif.gifUrl)
+                    }
+                    gifGrid = RecyclerListView(context).apply {
+                        layoutManager = GridLayoutManager(context, 2)
+                        adapter = gifAdapter
+                        setHasFixedSize(true)
+                        (itemAnimator as? SimpleItemAnimator)?.supportsChangeAnimations = false
+                        overScrollMode = OVER_SCROLL_NEVER
+                        addItemDecoration(GifSpacingDecoration(gifSpacing))
+                        setPadding(gifSpacing, gifSpacing, gifSpacing, gifSpacing)
+                        clipToPadding = false
+                        visibility = View.GONE
+                    }
+                    contentContainer.addView(gifGrid, matchLp)
+                }
+            }
+        }
+    }
+
+    private fun loadGifData() {
+        val ctrl = emojiController ?: return
+        ctrl.loadGifCategories()
+        val cats = synchronized(ctrl) { ArrayList(ctrl.gifCategories) }
+        if (cats.isNotEmpty()) {
+            gifCategoryAdapter?.setData(cats)
+        }
+    }
+
+    fun onEmojisReloaded() {
+        if (currentTab == TAB_EMOJI) loadEmojiData()
+    }
+
+    fun onStickersReloaded() {
+        if (currentTab == TAB_STICKER) loadStickerData()
+    }
+
+    fun onGifsReloaded() {
+        if (currentTab != TAB_GIF) return
+        val ctrl = emojiController ?: return
+        val cats = synchronized(ctrl) { ArrayList(ctrl.gifCategories) }
+        if (cats.isNotEmpty()) {
+            gifCategoryAdapter?.setData(cats)
+        }
+        if (gifSearchActive) {
+            val results = synchronized(ctrl) { ArrayList(ctrl.searchGifResults) }
+            gifAdapter?.setData(results)
+        }
+    }
+
+    private fun loadEmojiData() {
+        val ctrl = emojiController ?: return
+        val categories = ctrl.getCategories()
+        val data = categories.map { cat ->
+            cat.name to ctrl.getEmojisByCategory(cat.name)
+        }
+        emojiAdapter?.setData(data)
+    }
+
+    private fun loadStickerData() {
+        val ctrl = emojiController ?: return
+        val visualOnly = synchronized(ctrl) {
+            ctrl.stickers.filter { !it.isAudio }
+        }
+        stickerAdapter?.setData(visualOnly)
+    }
+
+    private fun performSearch(query: String) {
+        val ctrl = emojiController ?: return
+        if (query.isBlank()) {
+            when (currentTab) {
+                TAB_EMOJI -> loadEmojiData()
+                TAB_STICKER -> loadStickerData()
+                TAB_GIF -> {
+                    gifSearchActive = false
+                    updateGifGridVisibility()
+                    loadGifData()
+                }
+            }
+            return
+        }
+        when (currentTab) {
+            TAB_EMOJI -> emojiAdapter?.setSearchResults(ctrl.searchEmojis(query))
+            TAB_STICKER -> stickerAdapter?.setSearchResults(ctrl.searchStickers(query))
+            TAB_GIF -> {
+                gifSearchActive = true
+                updateGifGridVisibility()
+                ctrl.searchGifs(query)
+            }
+        }
+    }
+
+    private fun createTabButton(text: String): TextView {
+        return TextView(context).apply {
+            this.text = text
+            textSize = 14f
+            gravity = Gravity.CENTER
+            setPadding(LayoutHelper.dp(12f), LayoutHelper.dp(6f), LayoutHelper.dp(12f), LayoutHelper.dp(6f))
+            background = android.graphics.drawable.GradientDrawable().apply {
+                cornerRadius = LayoutHelper.dp(16f).toFloat()
+            }
+        }
+    }
+
+    private fun updateTabSelection() {
+        val tabs = listOf(tabEmoji, tabGif, tabSticker)
+        for ((i, tab) in tabs.withIndex()) {
+            val isSelected = i == currentTab
+            tab.setTextColor(if (isSelected) themeColors.onPrimary else themeColors.onSurfaceVariant)
+            (tab.background as? android.graphics.drawable.GradientDrawable)?.setColor(
+                if (isSelected) themeColors.primary else Color.TRANSPARENT
+            )
+        }
+    }
+
+    fun clearSearchFocus() {
+        searchField.clearFocus()
+        AndroidUtilities.hideKeyboard(searchField)
+    }
+
+    val isSearchFocused: Boolean get() = searchField.hasFocus()
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        searchRunnable?.let { handler.removeCallbacks(it) }
+    }
+
+    private class GifSpacingDecoration(private val spacing: Int) : RecyclerView.ItemDecoration() {
+        override fun getItemOffsets(
+            outRect: android.graphics.Rect,
+            view: View,
+            parent: RecyclerView,
+            state: RecyclerView.State
+        ) {
+            outRect.set(spacing, spacing, spacing, spacing)
+        }
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/home/chat/emoji/GifCategoryAdapter.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/emoji/GifCategoryAdapter.kt
@@ -1,0 +1,54 @@
+package com.mezon.mobile.home.chat.emoji
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import com.mezon.mobile.core.ThemeColors
+import com.mezon.mobile.network.TenorCategory
+
+class GifCategoryAdapter(
+    private val themeColors: ThemeColors,
+    private val onCategoryClick: (TenorCategory) -> Unit
+) : RecyclerView.Adapter<GifCategoryAdapter.CategoryViewHolder>() {
+
+    private val categories = ArrayList<TenorCategory>()
+
+    init { setHasStableIds(true) }
+
+    override fun getItemId(position: Int): Long =
+        if (position in categories.indices) categories[position].name.hashCode().toLong() else RecyclerView.NO_ID
+
+    fun setData(newCategories: List<TenorCategory>) {
+        val result = DiffUtil.calculateDiff(object : DiffUtil.Callback() {
+            override fun getOldListSize() = categories.size
+            override fun getNewListSize() = newCategories.size
+            override fun areItemsTheSame(oldPos: Int, newPos: Int) =
+                categories[oldPos].name == newCategories[newPos].name
+            override fun areContentsTheSame(oldPos: Int, newPos: Int) =
+                categories[oldPos] == newCategories[newPos]
+        })
+        categories.clear()
+        categories.addAll(newCategories)
+        result.dispatchUpdatesTo(this)
+    }
+
+    override fun getItemCount(): Int = categories.size
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CategoryViewHolder {
+        val cell = GifCategoryCell(parent.context, themeColors)
+        val vh = CategoryViewHolder(cell)
+        cell.setOnClickListener {
+            val pos = vh.bindingAdapterPosition
+            if (pos != RecyclerView.NO_POSITION) {
+                categories.getOrNull(pos)?.let { onCategoryClick(it) }
+            }
+        }
+        return vh
+    }
+
+    override fun onBindViewHolder(holder: CategoryViewHolder, position: Int) {
+        holder.cell.setCategory(categories[position])
+    }
+
+    class CategoryViewHolder(val cell: GifCategoryCell) : RecyclerView.ViewHolder(cell)
+}

--- a/app/src/main/java/com/mezon/mobile/home/chat/emoji/GifCategoryCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/emoji/GifCategoryCell.kt
@@ -1,0 +1,174 @@
+package com.mezon.mobile.home.chat.emoji
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Typeface
+import android.graphics.drawable.AnimatedImageDrawable
+import android.graphics.drawable.Drawable
+import android.os.Build
+import android.text.Layout
+import android.text.StaticLayout
+import android.text.TextPaint
+import android.view.View
+import com.mezon.mobile.core.LayoutHelper
+import com.mezon.mobile.core.ThemeColors
+import com.mezon.mobile.home.chat.MezonImageLoader
+import com.mezon.mobile.network.TenorCategory
+
+private val CELL_HEIGHT = LayoutHelper.dp(100f)
+private val CORNER_RADIUS = LayoutHelper.dp(10f).toFloat()
+
+class GifCategoryCell(context: Context, private val themeColors: ThemeColors) : View(context) {
+
+    private var category: TenorCategory? = null
+    private var drawable: Drawable? = null
+    private var cancellable: MezonImageLoader.Cancellable? = null
+    private val loader = MezonImageLoader.getInstance(context)
+    private var nameLayout: StaticLayout? = null
+    private val clipPath = android.graphics.Path()
+    private val clipRect = android.graphics.RectF()
+
+    private val drawableCallback = object : Drawable.Callback {
+        override fun invalidateDrawable(who: Drawable) { this@GifCategoryCell.invalidate() }
+        override fun scheduleDrawable(who: Drawable, what: Runnable, `when`: Long) {
+            this@GifCategoryCell.postDelayed(what, `when` - android.os.SystemClock.uptimeMillis())
+        }
+        override fun unscheduleDrawable(who: Drawable, what: Runnable) {
+            this@GifCategoryCell.removeCallbacks(what)
+        }
+    }
+
+    fun getCategory(): TenorCategory? = category
+
+    fun setCategory(item: TenorCategory) {
+        if (category?.name == item.name) return
+        stopAnimation()
+        cancellable?.cancel()
+        drawable = null
+        category = item
+
+        nameLayout = buildNameLayout(item.name, measuredWidth.coerceAtLeast(LayoutHelper.dp(100f)))
+
+        val reqW = if (measuredWidth > 0) measuredWidth else LayoutHelper.dp(170f)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            cancellable = loader.loadDrawable(item.imageUrl, reqW, CELL_HEIGHT,
+                onSuccess = { d ->
+                    drawable = d
+                    d.callback = drawableCallback
+                    if (d is AnimatedImageDrawable) d.start()
+                    invalidate()
+                })
+        } else {
+            cancellable = loader.load(item.imageUrl, reqW, CELL_HEIGHT, onSuccess = { bmp ->
+                drawable = android.graphics.drawable.BitmapDrawable(resources, bmp)
+                invalidate()
+            })
+        }
+        invalidate()
+    }
+
+    override fun invalidate() {
+        if (category == null) return
+        super.invalidate()
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val width = MeasureSpec.getSize(widthMeasureSpec)
+        setMeasuredDimension(width, CELL_HEIGHT)
+    }
+
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        val cat = category ?: return
+        nameLayout = buildNameLayout(cat.name, w)
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        val w = measuredWidth.toFloat()
+        val h = measuredHeight.toFloat()
+
+        canvas.save()
+        clipPath.reset()
+        clipRect.set(0f, 0f, w, h)
+        clipPath.addRoundRect(clipRect, CORNER_RADIUS, CORNER_RADIUS, android.graphics.Path.Direction.CW)
+        canvas.clipPath(clipPath)
+
+        val d = drawable
+        if (d != null) {
+            drawCover(canvas, d, measuredWidth, measuredHeight)
+        } else {
+            canvas.drawColor(0x1A000000)
+        }
+
+        canvas.drawRect(0f, 0f, w, h, overlayPaint)
+
+        val layout = nameLayout
+        if (layout != null) {
+            canvas.save()
+            val textX = (w - layout.width) / 2f
+            val textY = (h - layout.height) / 2f
+            canvas.translate(textX, textY)
+            layout.draw(canvas)
+            canvas.restore()
+        }
+
+        canvas.restore()
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        val d = drawable
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && d is AnimatedImageDrawable) d.start()
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        stopAnimation()
+        cancellable?.cancel()
+        cancellable = null
+    }
+
+    private fun stopAnimation() {
+        val d = drawable
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && d is AnimatedImageDrawable) d.stop()
+        d?.callback = null
+    }
+
+    private fun drawCover(canvas: Canvas, d: Drawable, viewW: Int, viewH: Int) {
+        val iw = d.intrinsicWidth
+        val ih = d.intrinsicHeight
+        if (iw <= 0 || ih <= 0) {
+            d.setBounds(0, 0, viewW, viewH)
+            d.draw(canvas)
+            return
+        }
+        val scale = maxOf(viewW.toFloat() / iw, viewH.toFloat() / ih)
+        val dx = (viewW - iw * scale) / 2f
+        val dy = (viewH - ih * scale) / 2f
+        canvas.save()
+        canvas.translate(dx, dy)
+        canvas.scale(scale, scale)
+        d.setBounds(0, 0, iw, ih)
+        d.draw(canvas)
+        canvas.restore()
+    }
+
+    private fun buildNameLayout(name: String, width: Int): StaticLayout {
+        val maxW = width.coerceAtLeast(1)
+        return StaticLayout.Builder.obtain(name, 0, name.length, namePaint, maxW)
+            .setAlignment(Layout.Alignment.ALIGN_CENTER)
+            .setMaxLines(2)
+            .build()
+    }
+
+    companion object {
+        private val overlayPaint = Paint().apply { color = 0x60000000 }
+        private val namePaint = TextPaint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = Color.WHITE
+            textSize = LayoutHelper.dp(14f).toFloat()
+            typeface = Typeface.DEFAULT_BOLD
+        }
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/home/chat/emoji/GifCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/emoji/GifCell.kt
@@ -1,0 +1,132 @@
+package com.mezon.mobile.home.chat.emoji
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.drawable.AnimatedImageDrawable
+import android.graphics.drawable.Drawable
+import android.os.Build
+import android.view.View
+import com.mezon.mobile.core.LayoutHelper
+import com.mezon.mobile.core.ThemeColors
+import com.mezon.mobile.home.chat.MezonImageLoader
+import com.mezon.mobile.network.TenorGif
+
+private val CELL_HEIGHT = LayoutHelper.dp(100f)
+private val CORNER_RADIUS = LayoutHelper.dp(10f).toFloat()
+
+class GifCell(context: Context, private val themeColors: ThemeColors) : View(context) {
+
+    private var gif: TenorGif? = null
+    private var animDrawable: Drawable? = null
+    private var cancellable: MezonImageLoader.Cancellable? = null
+    private val loader = MezonImageLoader.getInstance(context)
+    private val clipPath = android.graphics.Path()
+    private val clipRect = android.graphics.RectF()
+
+    private val drawableCallback = object : Drawable.Callback {
+        override fun invalidateDrawable(who: Drawable) { this@GifCell.invalidate() }
+        override fun scheduleDrawable(who: Drawable, what: Runnable, `when`: Long) {
+            this@GifCell.postDelayed(what, `when` - android.os.SystemClock.uptimeMillis())
+        }
+        override fun unscheduleDrawable(who: Drawable, what: Runnable) {
+            this@GifCell.removeCallbacks(what)
+        }
+    }
+
+    fun getGif(): TenorGif? = gif
+
+    fun setGif(item: TenorGif) {
+        if (gif?.id == item.id) return
+        stopAnimation()
+        cancellable?.cancel()
+        animDrawable = null
+        gif = item
+
+        val reqW = if (measuredWidth > 0) measuredWidth else LayoutHelper.dp(170f)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            cancellable = loader.loadDrawable(item.thumbnailUrl, reqW, CELL_HEIGHT,
+                onSuccess = { d ->
+                    animDrawable = d
+                    d.callback = drawableCallback
+                    if (d is AnimatedImageDrawable) d.start()
+                    invalidate()
+                })
+        } else {
+            cancellable = loader.load(item.thumbnailUrl, reqW, CELL_HEIGHT, onSuccess = { bmp ->
+                animDrawable = android.graphics.drawable.BitmapDrawable(resources, bmp)
+                invalidate()
+            })
+        }
+        invalidate()
+    }
+
+    override fun invalidate() {
+        if (gif == null) return
+        super.invalidate()
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val width = MeasureSpec.getSize(widthMeasureSpec)
+        setMeasuredDimension(width, CELL_HEIGHT)
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        val w = measuredWidth.toFloat()
+        val h = measuredHeight.toFloat()
+
+        canvas.save()
+        clipPath.reset()
+        clipRect.set(0f, 0f, w, h)
+        clipPath.addRoundRect(clipRect, CORNER_RADIUS, CORNER_RADIUS, android.graphics.Path.Direction.CW)
+        canvas.clipPath(clipPath)
+
+        val d = animDrawable
+        if (d != null) {
+            drawCover(canvas, d, w.toInt(), h.toInt())
+        } else {
+            canvas.drawColor(Color.BLACK)
+        }
+
+        canvas.restore()
+    }
+
+    private fun drawCover(canvas: Canvas, d: Drawable, viewW: Int, viewH: Int) {
+        val iw = d.intrinsicWidth
+        val ih = d.intrinsicHeight
+        if (iw <= 0 || ih <= 0) {
+            d.setBounds(0, 0, viewW, viewH)
+            d.draw(canvas)
+            return
+        }
+        val scale = maxOf(viewW.toFloat() / iw, viewH.toFloat() / ih)
+        val dx = (viewW - iw * scale) / 2f
+        val dy = (viewH - ih * scale) / 2f
+        canvas.save()
+        canvas.translate(dx, dy)
+        canvas.scale(scale, scale)
+        d.setBounds(0, 0, iw, ih)
+        d.draw(canvas)
+        canvas.restore()
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        val d = animDrawable
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && d is AnimatedImageDrawable) d.start()
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        stopAnimation()
+        cancellable?.cancel()
+        cancellable = null
+    }
+
+    private fun stopAnimation() {
+        val d = animDrawable
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && d is AnimatedImageDrawable) d.stop()
+        d?.callback = null
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/home/chat/emoji/GifGridAdapter.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/emoji/GifGridAdapter.kt
@@ -1,0 +1,82 @@
+package com.mezon.mobile.home.chat.emoji
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import com.mezon.mobile.core.ThemeColors
+import com.mezon.mobile.network.TenorGif
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class GifGridAdapter(
+    private val themeColors: ThemeColors,
+    private val onGifClick: (TenorGif) -> Unit
+) : RecyclerView.Adapter<GifGridAdapter.GifViewHolder>() {
+
+    private val gifs = ArrayList<TenorGif>()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var diffJob: Job? = null
+
+    init { setHasStableIds(true) }
+
+    override fun getItemId(position: Int): Long =
+        if (position in gifs.indices) gifs[position].id.hashCode().toLong() else RecyclerView.NO_ID
+
+    fun setData(newGifs: List<TenorGif>) {
+        diffJob?.cancel()
+        if (newGifs.size < 50 && gifs.size < 50) {
+            val result = DiffUtil.calculateDiff(GifDiffCallback(gifs, newGifs))
+            gifs.clear(); gifs.addAll(newGifs)
+            result.dispatchUpdatesTo(this)
+        } else {
+            val oldList = ArrayList(gifs)
+            diffJob = scope.launch {
+                val result = withContext(Dispatchers.Default) {
+                    DiffUtil.calculateDiff(GifDiffCallback(oldList, newGifs))
+                }
+                gifs.clear(); gifs.addAll(newGifs)
+                result.dispatchUpdatesTo(this@GifGridAdapter)
+            }
+        }
+    }
+
+    override fun getItemCount(): Int = gifs.size
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): GifViewHolder {
+        val cell = GifCell(parent.context, themeColors)
+        val vh = GifViewHolder(cell)
+        cell.setOnClickListener {
+            val pos = vh.bindingAdapterPosition
+            if (pos != RecyclerView.NO_POSITION) {
+                gifs.getOrNull(pos)?.let { onGifClick(it) }
+            }
+        }
+        return vh
+    }
+
+    override fun onBindViewHolder(holder: GifViewHolder, position: Int) {
+        holder.cell.setGif(gifs[position])
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        diffJob?.cancel()
+        scope.cancel()
+    }
+
+    class GifViewHolder(val cell: GifCell) : RecyclerView.ViewHolder(cell)
+
+    private class GifDiffCallback(
+        private val old: List<TenorGif>,
+        private val new: List<TenorGif>
+    ) : DiffUtil.Callback() {
+        override fun getOldListSize() = old.size
+        override fun getNewListSize() = new.size
+        override fun areItemsTheSame(oldPos: Int, newPos: Int) = old[oldPos].id == new[newPos].id
+        override fun areContentsTheSame(oldPos: Int, newPos: Int) = old[oldPos] == new[newPos]
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/home/chat/emoji/StickerCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/emoji/StickerCell.kt
@@ -1,0 +1,102 @@
+package com.mezon.mobile.home.chat.emoji
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
+import android.graphics.Rect
+import android.graphics.drawable.Drawable
+import android.view.View
+import com.mezon.mobile.core.LayoutHelper
+import com.mezon.mobile.core.ThemeColors
+import com.mezon.mobile.home.chat.MezonImageLoader
+import com.mezon.mobile.home.chat.StickerItem
+import com.mezon.mobile.ui.cells.MezonIcon
+import com.mezon.mobile.util.getStickerImageUrl
+
+private val CELL_SIZE = LayoutHelper.dp(72f)
+private val IMAGE_SIZE = LayoutHelper.dp(64f)
+private val IMAGE_REQ = IMAGE_SIZE * 2
+private val LOCK_SIZE = LayoutHelper.dp(14f)
+private val LOCK_PAD = LayoutHelper.dp(4f)
+
+class StickerCell(context: Context, private val themeColors: ThemeColors) : View(context) {
+
+    private var sticker: StickerItem? = null
+    private var bitmap: Bitmap? = null
+    private var isLocked = false
+    private var cancellable: MezonImageLoader.Cancellable? = null
+    private var lockDrawable: Drawable? = null
+    private val loader = MezonImageLoader.getInstance(context)
+
+    private val srcRect = Rect()
+    private val dstRect = Rect()
+
+    fun getSticker(): StickerItem? = sticker
+
+    fun setSticker(item: StickerItem) {
+        if (sticker?.id == item.id) return
+        cancellable?.cancel()
+        bitmap = null
+        sticker = item
+        isLocked = item.isForSale && item.src.isBlank()
+
+        val url = getStickerImageUrl(item.id, item.src)
+        if (url != null) {
+            val cached = loader.getBitmapFromMemory(url, IMAGE_REQ, IMAGE_REQ)
+            if (cached != null) {
+                bitmap = cached
+            } else {
+                cancellable = loader.load(url, IMAGE_REQ, IMAGE_REQ, onSuccess = { bmp ->
+                    bitmap = bmp
+                    invalidate()
+                })
+            }
+        }
+        invalidate()
+    }
+
+    override fun invalidate() {
+        if (sticker == null) return
+        super.invalidate()
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val size = MeasureSpec.getSize(widthMeasureSpec)
+        setMeasuredDimension(size, CELL_SIZE)
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        val bmp = bitmap ?: return
+        val left = (measuredWidth - IMAGE_SIZE) / 2
+        val top = (measuredHeight - IMAGE_SIZE) / 2
+        srcRect.set(0, 0, bmp.width, bmp.height)
+        dstRect.set(left, top, left + IMAGE_SIZE, top + IMAGE_SIZE)
+        canvas.drawBitmap(bmp, srcRect, dstRect, bitmapPaint)
+
+        if (isLocked) {
+            val ld = lockDrawable ?: run {
+                MezonIcon.lockIcon.getDrawable(context).mutate().also {
+                    it.colorFilter = PorterDuffColorFilter(themeColors.onSurfaceVariant, PorterDuff.Mode.SRC_IN)
+                    lockDrawable = it
+                }
+            }
+            val lx = left + IMAGE_SIZE - LOCK_SIZE - LOCK_PAD
+            val ly = top + IMAGE_SIZE - LOCK_SIZE - LOCK_PAD
+            ld.setBounds(lx, ly, lx + LOCK_SIZE, ly + LOCK_SIZE)
+            ld.draw(canvas)
+        }
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        cancellable?.cancel()
+        cancellable = null
+    }
+
+    companion object {
+        private val bitmapPaint = Paint(Paint.FILTER_BITMAP_FLAG or Paint.ANTI_ALIAS_FLAG)
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/home/chat/emoji/StickerGridAdapter.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/emoji/StickerGridAdapter.kt
@@ -1,0 +1,184 @@
+package com.mezon.mobile.home.chat.emoji
+
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import com.mezon.mobile.core.ThemeColors
+import com.mezon.mobile.home.chat.StickerItem
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+private const val FOR_SALE_HEADER = "For Sale"
+
+class StickerGridAdapter(
+    private val themeColors: ThemeColors,
+    private val onStickerClick: (StickerItem) -> Unit
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+    companion object {
+        const val VIEW_TYPE_HEADER = 0
+        const val VIEW_TYPE_STICKER = 1
+    }
+
+    sealed class ListItem {
+        abstract val stableId: Long
+        data class Header(val title: String, val expanded: Boolean) : ListItem() {
+            override val stableId: Long get() = title.hashCode().toLong() or (1L shl 62)
+        }
+        data class Sticker(val item: StickerItem) : ListItem() {
+            override val stableId: Long get() = item.id.hashCode().toLong()
+        }
+    }
+
+    private data class GroupData(val name: String, val stickers: List<StickerItem>)
+
+    private val items = ArrayList<ListItem>()
+    private val groups = ArrayList<GroupData>()
+    private val collapsedSections = HashSet<String>()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var diffJob: Job? = null
+
+    init {
+        setHasStableIds(true)
+        collapsedSections.add(FOR_SALE_HEADER)
+        CollapsibleHeaderCell.applyTheme(themeColors)
+    }
+
+    override fun getItemId(position: Int): Long =
+        if (position in items.indices) items[position].stableId else RecyclerView.NO_ID
+
+    fun setData(stickers: List<StickerItem>) {
+        groups.clear()
+
+        val forSale = stickers.filter { it.isForSale }
+        if (forSale.isNotEmpty()) {
+            groups.add(GroupData(FOR_SALE_HEADER, forSale))
+        }
+
+        val owned = stickers.filter { !it.isForSale && it.src.isNotBlank() }
+        val byClan = LinkedHashMap<String, MutableList<StickerItem>>()
+        for (s in owned) {
+            val key = s.clanName.ifBlank { s.category.ifBlank { "Stickers" } }
+            byClan.getOrPut(key) { ArrayList() }.add(s)
+        }
+        for ((groupName, group) in byClan) {
+            groups.add(GroupData(groupName, group))
+        }
+
+        rebuildItems()
+    }
+
+    fun setSearchResults(stickers: List<StickerItem>) {
+        groups.clear()
+        val newItems = ArrayList<ListItem>(stickers.size)
+        for (s in stickers) newItems.add(ListItem.Sticker(s))
+        applyNewItems(newItems)
+    }
+
+    fun toggleSection(title: String) {
+        if (collapsedSections.contains(title)) {
+            collapsedSections.remove(title)
+        } else {
+            collapsedSections.add(title)
+        }
+        rebuildItems()
+    }
+
+    private fun rebuildItems() {
+        val newItems = ArrayList<ListItem>()
+        for (group in groups) {
+            val expanded = !collapsedSections.contains(group.name)
+            newItems.add(ListItem.Header(group.name, expanded))
+            if (expanded) {
+                for (s in group.stickers) newItems.add(ListItem.Sticker(s))
+            }
+        }
+        applyNewItems(newItems)
+    }
+
+    private fun applyNewItems(newItems: ArrayList<ListItem>) {
+        diffJob?.cancel()
+        if (newItems.size < 50 && items.size < 50) {
+            val result = DiffUtil.calculateDiff(ItemDiffCallback(items, newItems))
+            items.clear(); items.addAll(newItems)
+            result.dispatchUpdatesTo(this)
+        } else {
+            val oldList = ArrayList(items)
+            diffJob = scope.launch {
+                val result = withContext(Dispatchers.Default) {
+                    DiffUtil.calculateDiff(ItemDiffCallback(oldList, newItems))
+                }
+                items.clear(); items.addAll(newItems)
+                result.dispatchUpdatesTo(this@StickerGridAdapter)
+            }
+        }
+    }
+
+    fun isHeader(position: Int): Boolean = items.getOrNull(position) is ListItem.Header
+
+    override fun getItemViewType(position: Int): Int = when (items[position]) {
+        is ListItem.Header -> VIEW_TYPE_HEADER
+        is ListItem.Sticker -> VIEW_TYPE_STICKER
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return when (viewType) {
+            VIEW_TYPE_HEADER -> {
+                val cell = CollapsibleHeaderCell(parent.context, themeColors)
+                val vh = HeaderViewHolder(cell)
+                cell.onToggle = {
+                    val pos = vh.bindingAdapterPosition
+                    if (pos != RecyclerView.NO_POSITION) {
+                        val item = items.getOrNull(pos)
+                        if (item is ListItem.Header) toggleSection(item.title)
+                    }
+                }
+                vh
+            }
+            else -> {
+                val cell = StickerCell(parent.context, themeColors)
+                val vh = StickerViewHolder(cell)
+                cell.setOnClickListener {
+                    val pos = vh.bindingAdapterPosition
+                    if (pos != RecyclerView.NO_POSITION) {
+                        val item = items.getOrNull(pos)
+                        if (item is ListItem.Sticker) onStickerClick(item.item)
+                    }
+                }
+                vh
+            }
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (val item = items[position]) {
+            is ListItem.Header -> (holder as HeaderViewHolder).cell.bind(item.title, item.expanded)
+            is ListItem.Sticker -> (holder as StickerViewHolder).cell.setSticker(item.item)
+        }
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        diffJob?.cancel()
+        scope.cancel()
+    }
+
+    class HeaderViewHolder(val cell: CollapsibleHeaderCell) : RecyclerView.ViewHolder(cell)
+    class StickerViewHolder(val cell: StickerCell) : RecyclerView.ViewHolder(cell)
+
+    private class ItemDiffCallback(
+        private val old: List<ListItem>,
+        private val new: List<ListItem>
+    ) : DiffUtil.Callback() {
+        override fun getOldListSize() = old.size
+        override fun getNewListSize() = new.size
+        override fun areItemsTheSame(oldPos: Int, newPos: Int) = old[oldPos].stableId == new[newPos].stableId
+        override fun areContentsTheSame(oldPos: Int, newPos: Int) = old[oldPos] == new[newPos]
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/home/clans/ClansFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ClansFragment.kt
@@ -500,7 +500,7 @@ class ClansFragment : BaseFragment() {
 
     private fun onChannelSelected(channel: ClanChannelEntity) {
         val clanIdForJoin = if (channel.clanId != 0L) channel.clanId else clansController.selectedClanId.value
-        chatController.openChannel(channel.channelId, clanIdForJoin, channel.type, channel.isPrivate, channel.parentId)
+        chatController.openChannel(channel.channelId, clanIdForJoin, channel.type, channel.isPrivate)
         onOpenChat?.invoke(channel.channelId, channel.channelLabel, clanIdForJoin, channel.type)
     }
 

--- a/app/src/main/java/com/mezon/mobile/network/MezonApi.kt
+++ b/app/src/main/java/com/mezon/mobile/network/MezonApi.kt
@@ -6,6 +6,8 @@ import android.util.Log
 import com.mezon.mezon.api.Account
 import com.mezon.mezon.api.AccountEmail
 import com.mezon.mezon.api.AllUserClans
+import com.mezon.mezon.api.EmojiListedResponse
+import com.mezon.mezon.api.StickerListedResponse
 import com.mezon.mezon.api.BlockFriendsRequest
 import com.mezon.mezon.api.ChannelDescList
 import com.mezon.mezon.api.ChannelMessageList
@@ -547,6 +549,22 @@ class MezonApi @Inject constructor(
         }
         val bytes = rpc(apiUrl, token, "SearchMessage", request.toByteArray())
         return SearchMessageResponse.parseFrom(bytes)
+    }
+
+    suspend fun listEmojisByUserId(
+        apiUrl: String,
+        token: String
+    ): EmojiListedResponse {
+        val bytes = rpc(apiUrl, token, "GetListEmojisByUserId", ByteArray(0))
+        return EmojiListedResponse.parseFrom(bytes)
+    }
+
+    suspend fun listStickersByUserId(
+        apiUrl: String,
+        token: String
+    ): StickerListedResponse {
+        val bytes = rpc(apiUrl, token, "GetListStickersByUserId", ByteArray(0))
+        return StickerListedResponse.parseFrom(bytes)
     }
 
     suspend fun putFileToPresignedUrl(

--- a/app/src/main/java/com/mezon/mobile/network/SocketEventDispatcher.kt
+++ b/app/src/main/java/com/mezon/mobile/network/SocketEventDispatcher.kt
@@ -25,6 +25,7 @@ import com.mezon.mezon.rtapi.CustomStatusEvent
 import com.mezon.mezon.rtapi.DeleteAccountEvent
 import com.mezon.mezon.rtapi.DropdownBoxSelected
 import com.mezon.mezon.rtapi.Envelope
+import com.mezon.mezon.rtapi.EventEmoji
 import com.mezon.mezon.rtapi.LastPinMessageEvent
 import com.mezon.mezon.rtapi.LastSeenMessageEvent
 import com.mezon.mezon.rtapi.MeetParticipantEvent
@@ -239,6 +240,9 @@ class SocketEventDispatcher @Inject constructor(
     private val _aiagentEnabledEvents = MutableSharedFlow<AIAgentEnabledEvent>(extraBufferCapacity = 4)
     val aiagentEnabledEvents: SharedFlow<AIAgentEnabledEvent> = _aiagentEnabledEvents.asSharedFlow()
 
+    private val _emojiEvents = MutableSharedFlow<EventEmoji>(extraBufferCapacity = 8)
+    val emojiEvents: SharedFlow<EventEmoji> = _emojiEvents.asSharedFlow()
+
     init {
         scope.launch {
             mezonSocket.events.collect { envelope ->
@@ -365,6 +369,8 @@ class SocketEventDispatcher @Inject constructor(
                 _sdTopicEvents.emit(envelope.sdTopicEvent)
             Envelope.MessageCase.AIAGENT_ENABLED_EVENT ->
                 _aiagentEnabledEvents.emit(envelope.aiagentEnabledEvent)
+            Envelope.MessageCase.EVENT_EMOJI ->
+                _emojiEvents.emit(envelope.eventEmoji)
             else ->
                 Log.d(TAG, "Unhandled event: ${envelope.messageCase}")
         }

--- a/app/src/main/java/com/mezon/mobile/network/TenorApi.kt
+++ b/app/src/main/java/com/mezon/mobile/network/TenorApi.kt
@@ -1,0 +1,133 @@
+package com.mezon.mobile.network
+
+import android.util.Log
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.ktor.http.isSuccess
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TAG = "TenorApi"
+private const val BASE_URL = "https://tenor.googleapis.com/v2"
+
+@Serializable
+data class TenorCategoryResponse(
+    val tags: List<TenorCategoryTag> = emptyList()
+)
+
+@Serializable
+data class TenorCategoryTag(
+    @SerialName("searchterm") val searchTerm: String = "",
+    val image: String = ""
+)
+
+@Serializable
+data class TenorSearchResponse(
+    val results: List<TenorResult> = emptyList(),
+    val next: String = ""
+)
+
+@Serializable
+data class TenorResult(
+    val id: String = "",
+    @SerialName("media_formats") val mediaFormats: TenorMediaFormats = TenorMediaFormats()
+)
+
+@Serializable
+data class TenorMediaFormats(
+    val gif: TenorMediaFormat? = null,
+    val tinygif: TenorMediaFormat? = null,
+    val mp4: TenorMediaFormat? = null
+)
+
+@Serializable
+data class TenorMediaFormat(
+    val url: String = "",
+    @SerialName("dims") val dims: List<Int> = emptyList(),
+    val size: Long = 0L
+)
+
+data class TenorGif(
+    val id: String,
+    val gifUrl: String,
+    val thumbnailUrl: String,
+    val width: Int,
+    val height: Int
+)
+
+data class TenorCategory(
+    val name: String,
+    val imageUrl: String
+)
+
+@Singleton
+class TenorApi @Inject constructor(
+    private val httpClient: HttpClient
+) {
+    suspend fun fetchCategories(apiKey: String, clientKey: String = "mezon_android"): List<TenorCategory> {
+        return try {
+            val response = httpClient.get("$BASE_URL/categories") {
+                parameter("key", apiKey)
+                parameter("client_key", clientKey)
+            }
+            if (!response.status.isSuccess()) return emptyList()
+            val body: TenorCategoryResponse = response.body()
+            body.tags.map { TenorCategory(name = it.searchTerm, imageUrl = it.image) }
+        } catch (e: Exception) {
+            Log.e(TAG, "fetchCategories failed", e)
+            emptyList()
+        }
+    }
+
+    suspend fun searchGifs(apiKey: String, query: String, limit: Int = 30, clientKey: String = "mezon_android"): List<TenorGif> {
+        return try {
+            val response = httpClient.get("$BASE_URL/search") {
+                parameter("q", query)
+                parameter("key", apiKey)
+                parameter("client_key", clientKey)
+                parameter("limit", limit)
+                parameter("media_filter", "gif,tinygif")
+            }
+            if (!response.status.isSuccess()) return emptyList()
+            val body: TenorSearchResponse = response.body()
+            body.results.mapNotNull { it.toTenorGif() }
+        } catch (e: Exception) {
+            Log.e(TAG, "searchGifs failed", e)
+            emptyList()
+        }
+    }
+
+    suspend fun fetchFeatured(apiKey: String, limit: Int = 30, clientKey: String = "mezon_android"): List<TenorGif> {
+        return try {
+            val response = httpClient.get("$BASE_URL/featured") {
+                parameter("key", apiKey)
+                parameter("client_key", clientKey)
+                parameter("limit", limit)
+                parameter("media_filter", "gif,tinygif")
+            }
+            if (!response.status.isSuccess()) return emptyList()
+            val body: TenorSearchResponse = response.body()
+            body.results.mapNotNull { it.toTenorGif() }
+        } catch (e: Exception) {
+            Log.e(TAG, "fetchFeatured failed", e)
+            emptyList()
+        }
+    }
+
+    private fun TenorResult.toTenorGif(): TenorGif? {
+        val gif = mediaFormats.gif ?: return null
+        val thumb = mediaFormats.tinygif ?: gif
+        val dims = gif.dims
+        return TenorGif(
+            id = id,
+            gifUrl = gif.url,
+            thumbnailUrl = thumb.url,
+            width = dims.getOrElse(0) { 0 },
+            height = dims.getOrElse(1) { 0 }
+        )
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/ui/cells/MezonIcon.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/cells/MezonIcon.kt
@@ -218,7 +218,8 @@ enum class MezonIcon(@DrawableRes val resId: Int) {
     bgEmptyIcon(R.drawable.ic_bg_empty),
     devicesIcon(R.drawable.ic_devices),
     searchFriendIcon(R.drawable.ic_search_friend),
-    agentIcon(R.drawable.ic_agent);
+    agentIcon(R.drawable.ic_agent),
+    backspaceIcon(R.drawable.ic_backspace);
 
     fun getDrawable(context: Context): Drawable =
         ContextCompat.getDrawable(context, resId)!!.mutate()

--- a/app/src/main/java/com/mezon/mobile/util/ContentParser.kt
+++ b/app/src/main/java/com/mezon/mobile/util/ContentParser.kt
@@ -128,3 +128,38 @@ fun convertTimestampToTimeAgo(context: Context, timestampSeconds: Long): String 
     val minutes = (diff % (60 * 60)) / 60
     return context.getString(R.string.common_time_ago_minutes, minutes.toInt())
 }
+
+data class EmojiMarker(val emojiId: String, val startIndex: Int, val endIndex: Int)
+
+fun buildTextContentWithEmojis(
+    text: String,
+    mentions: List<MentionData>?,
+    emojis: List<EmojiMarker>?
+): String {
+    val escaped = text
+        .replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    val parts = mutableListOf("\"t\":\"$escaped\"")
+    if (!mentions.isNullOrEmpty()) {
+        val mentionsJson = StringBuilder("[")
+        mentions.forEachIndexed { i, m ->
+            if (i > 0) mentionsJson.append(",")
+            mentionsJson.append("{")
+            if (m.userId.isNotBlank()) mentionsJson.append("\"user_id\":\"${m.userId}\",")
+            if (m.roleId.isNotBlank()) mentionsJson.append("\"role_id\":\"${m.roleId}\",")
+            mentionsJson.append("\"s\":${m.startOffset},\"e\":${m.endOffset}}")
+        }
+        mentionsJson.append("]")
+        parts.add("\"mentions\":$mentionsJson")
+    }
+    if (!emojis.isNullOrEmpty()) {
+        val ejJson = emojis.joinToString(",") {
+            "{\"emojiid\":\"${it.emojiId}\",\"s\":${it.startIndex},\"e\":${it.endIndex}}"
+        }
+        parts.add("\"ej\":[$ejJson]")
+    }
+    return "{${parts.joinToString(",")}}"
+}

--- a/app/src/main/java/com/mezon/mobile/util/MessageContentParser.kt
+++ b/app/src/main/java/com/mezon/mobile/util/MessageContentParser.kt
@@ -296,6 +296,18 @@ fun getEmojiUrl(emojiId: String): String? {
     return createImgproxyUrl(sourceUrl, EMOJI_SIZE_DP * 4, EMOJI_SIZE_DP * 4, "fit")
 }
 
+fun resolveStickerSourceUrl(stickerId: String, src: String): String {
+    return if (src.isNotBlank()) src
+    else if (stickerId.isNotBlank()) "$BASE_IMG/stickers/$stickerId.webp"
+    else ""
+}
+
+fun getStickerImageUrl(stickerId: String, src: String): String? {
+    val sourceUrl = resolveStickerSourceUrl(stickerId, src)
+    if (sourceUrl.isBlank()) return null
+    return sourceUrl
+}
+
 data class EmbedField(
     val name: String,
     val value: String,

--- a/app/src/main/res/drawable/ic_backspace.xml
+++ b/app/src/main/res/drawable/ic_backspace.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M22,3H7c-0.69,0 -1.23,0.35 -1.59,0.88L0,12l5.41,8.11C5.77,20.64 6.31,21 7,21h15c1.1,0 2,-0.9 2,-2V5C24,3.9 23.1,3 22,3zM19,15.59L17.59,17L14,13.41L10.41,17L9,15.59L12.59,12L9,8.41L10.41,7L14,10.59L17.59,7L19,8.41L15.41,12L19,15.59z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -385,8 +385,9 @@
     <!-- sharing -->
     <string name="sharing_title">Share to…</string>
     <string name="sharing_search_placeholder">Search conversations</string>
-    <string name="sharing_sending">Sending…</string>
     <string name="sharing_sent">Sent!</string>
     <string name="sharing_failed">Failed to send</string>
-    <string name="sharing_no_conversations">No conversations found</string>
+    <!-- Sharing -->
+    <string name="sharing_no_conversations">No conversations</string>
+    <string name="sharing_sending">Sending…</string>
 </resources>


### PR DESCRIPTION
- Add EmojiView with tabbed panel (emoji/sticker/GIF)
- Add EmojiController for emoji data and sticker API
- Add TenorApi for Tenor GIF search and trending
- Add canvas cells: EmojiCell, StickerCell, GifCell, GifCategoryCell
- Add CollapsibleHeaderCell for section headers
- Wire picker into ChatFragment with keyboard-aware layout
- Update SizeNotifierFrameLayout for picker height tracking