### PR TITLE
feat(chat): clan link invite preview, join flow, and in-app toasts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ credentials/
 build/reports/configuration-cache
 mmn-client-kotlin/build/kotlin/compileDebugKotlin
 mmn-client-kotlin/build
+
+.idea/
+
+build/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -134,7 +134,8 @@ android {
             if (signingPropsFile.exists()) {
                 signingConfig = signingConfigs.getByName("release")
             }
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
@@ -216,6 +217,8 @@ dependencies {
 
     // LiveKit (voice/video channels)
     implementation(libs.livekit.android)
+    implementation(libs.photoview)
+    implementation(libs.androidx.appcompat)
     implementation("com.otaliastudios:zoomlayout:1.9.0")
 
     // Firebase

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,21 +1,11 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+-assumenosideeffects class android.util.Log {
+    public static int d(...);
+    public static int v(...);
+}
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
-
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+-keep class com.mezon.mezon.api.** { *; }
+-keep class com.mezon.mezon.rtapi.** { *; }
+-dontwarn com.google.protobuf.**

--- a/app/src/main/java/com/mezon/mobile/core/BottomSheet.kt
+++ b/app/src/main/java/com/mezon/mobile/core/BottomSheet.kt
@@ -112,6 +112,7 @@ open class BottomSheet(
     private var customView: View? = null
     protected var containerHeight = ViewGroup.LayoutParams.WRAP_CONTENT
     private var dismissed = false
+    private var openAnimationCompleted = false
     private var allowCustomAnimation = true
     @JvmField protected var canDismissWithSwipe = true
     private var canDismissWithTouchOutside = true
@@ -472,6 +473,7 @@ open class BottomSheet(
     override fun show() {
         super.show()
         dismissed = false
+        openAnimationCompleted = false
         cancelSheetAnimation()
 
         containerView?.let { cv ->
@@ -489,6 +491,7 @@ open class BottomSheet(
             delegate?.onOpenAnimationStart()
             delegate?.onOpenAnimationEnd()
             onOpenAnimationEnd()
+            openAnimationCompleted = true
             return
         }
 
@@ -567,6 +570,7 @@ open class BottomSheet(
                             currentSheetAnimation = null
                             currentSheetAnimationType = 0
                             finishHeavyOperationsAnimation()
+                            openAnimationCompleted = true
                             onOpenAnimationEnd()
                             delegate?.onOpenAnimationEnd()
                             if (useHardwareLayer) {
@@ -689,9 +693,16 @@ open class BottomSheet(
         cancelSheetAnimation()
         currentSheetAnimationType = 2
 
+        val cv = containerView
+        if (cv == null) {
+            itemClickListener?.onClick(this@BottomSheet, which)
+            onHideListener?.onDismiss(this@BottomSheet)
+            AndroidUtilities.runOnUIThread { dismissInternal() }
+            return
+        }
+
         beginHeavyOperationsAnimation()
         currentSheetAnimation = AnimatorSet().apply {
-            val cv = containerView ?: return
             val translationYAnim = ObjectAnimator.ofFloat(cv, View.TRANSLATION_Y,
                 (getContainerViewHeight() + keyboardHeight + LayoutHelper.dp(10) +
                         AndroidUtilities.navigationBarHeight.coerceAtMost(getBottomInsetInternal()).coerceAtLeast(0)
@@ -965,7 +976,9 @@ open class BottomSheet(
                 startedTrackingX = ev.x.toInt()
                 startedTrackingY = ev.y.toInt()
                 if (isTouchOutside(startedTrackingX.toFloat(), startedTrackingY.toFloat())) {
-                    onDismissWithTouchOutside()
+                    if (openAnimationCompleted) {
+                        onDismissWithTouchOutside()
+                    }
                     return true
                 }
                 onScrollUpBegin(swipeY)

--- a/app/src/main/java/com/mezon/mobile/home/ChatController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChatController.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.withContext
 
 import javax.inject.Inject
@@ -744,6 +745,7 @@ class ChatController @Inject constructor(
         private const val SEND_RETRY_DELAY_MS = 500L
         private const val SHARE_MAX_RETRIES = 5
         private const val SHARE_RETRY_DELAY_MS = 4000L
+        private const val PENDING_API_REACTION_DEDUP_MS = 5000L
     }
 
     private fun generateTempId(): Long {
@@ -1345,19 +1347,51 @@ class ChatController @Inject constructor(
         val remove: Boolean
     )
 
+    private val pendingApiReactions = ConcurrentHashMap<ReactionDedup, Long>()
+
     @Volatile
     private var lastApiReactionDedup: Pair<ReactionDedup, Long>? = null
 
+    private fun prunePendingApiReactions() {
+        val now = System.currentTimeMillis()
+        val it = pendingApiReactions.iterator()
+        while (it.hasNext()) {
+            val e = it.next()
+            if (now - e.value > PENDING_API_REACTION_DEDUP_MS) it.remove()
+        }
+    }
+
+    private fun registerPendingApiReaction(key: ReactionDedup) {
+        prunePendingApiReactions()
+        pendingApiReactions[key] = System.currentTimeMillis()
+    }
+
+    private fun clearPendingApiReaction(key: ReactionDedup) {
+        pendingApiReactions.remove(key)
+    }
+
     private fun shouldIgnoreSocketReactionAsDuplicate(reaction: com.mezon.mezon.api.MessageReaction): Boolean {
+        prunePendingApiReactions()
+        val key = ReactionDedup(
+            reaction.channelId,
+            reaction.messageId,
+            reaction.emojiId,
+            reaction.senderId,
+            reaction.action
+        )
+        val pendingAt = pendingApiReactions[key] ?: 0L
+        if (pendingAt != 0L && System.currentTimeMillis() - pendingAt <= PENDING_API_REACTION_DEDUP_MS) {
+            return true
+        }
         val now = System.currentTimeMillis()
         val last = lastApiReactionDedup ?: return false
-        val (key, t) = last
+        val (k, t) = last
         if (now - t > 4000L) return false
-        return key.channelId == reaction.channelId &&
-            key.messageId == reaction.messageId &&
-            key.emojiId == reaction.emojiId &&
-            key.senderId == reaction.senderId &&
-            key.remove == reaction.action
+        return k.channelId == reaction.channelId &&
+            k.messageId == reaction.messageId &&
+            k.emojiId == reaction.emojiId &&
+            k.senderId == reaction.senderId &&
+            k.remove == reaction.action
     }
 
     private fun handleReactionEvent(reaction: com.mezon.mezon.api.MessageReaction) {
@@ -1433,6 +1467,11 @@ class ChatController @Inject constructor(
         val mode = channelTypeToStreamMode(channelType)
         val isPublic = !isChannelPrivate
         val uc = userController.get()
+        val selfIdForDedup = uc.userId
+        val pendingKey = if (selfIdForDedup != 0L) {
+            ReactionDedup(channelId, messageId, emojiId, selfIdForDedup, actionDelete)
+        } else null
+        pendingKey?.let { registerPendingApiReaction(it) }
         val anon = isAnonymousSend(clanId)
         val (reactionSenderName, _) = optimisticSenderPresentation(uc, clanId, channelType, anon)
         appScope.launch {
@@ -1471,6 +1510,8 @@ class ChatController @Inject constructor(
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to send reaction", e)
+            } finally {
+                pendingKey?.let { clearPendingApiReaction(it) }
             }
         }
     }

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatAdapter.kt
@@ -5,6 +5,7 @@ import android.widget.ProgressBar
 import androidx.recyclerview.widget.RecyclerView
 import com.mezon.mobile.core.LayoutHelper
 import com.mezon.mobile.core.ThemeColors
+import com.mezon.mobile.network.LinkInvitePreview
 
 class ChatAdapter(
     private val themeColors: ThemeColors,
@@ -163,6 +164,7 @@ class ChatAdapter(
         when (holder) {
             is MessageViewHolder -> {
                 holder.cell.delegate = cellDelegate
+                holder.cell.loadLinkInvitePreview = loadLinkInvitePreview
                 holder.cell.isCombined = computeCombined(idx)
                 holder.cell.currentUserId = currentUserId.toLongOrNull() ?: 0L
                 val msg = messages[idx]
@@ -204,6 +206,7 @@ class ChatAdapter(
     var channelType = 0
     var clanId = 0L
     var isChannelPrivate = false
+    var loadLinkInvitePreview: (suspend (Long) -> LinkInvitePreview?)? = null
 
     class MessageViewHolder(val cell: ChatMessageCell) : RecyclerView.ViewHolder(cell)
     class WelcomeViewHolder(val cell: WelcomeMessageCell) : RecyclerView.ViewHolder(cell)

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatAttachAlert.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatAttachAlert.kt
@@ -317,6 +317,6 @@ class ChatAttachAlert(
     }
 
     companion object {
-        const val REQUEST_CODE_MEDIA_PERMISSION = 1001
+        const val REQUEST_CODE_MEDIA_PERMISSION = 1004
     }
 }

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -10,6 +10,8 @@ import android.graphics.PorterDuffColorFilter
 import android.graphics.Rect
 import android.os.Build
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.text.Editable
 import android.text.SpannableString
 import android.text.Spanned
@@ -35,6 +37,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.mezon.mobile.BuildConfig
 import com.mezon.mobile.R
 import com.mezon.mobile.core.AndroidUtilities
+import com.mezon.mobile.core.AlertDialog
 import com.mezon.mobile.core.BaseFragment
 import com.mezon.mobile.core.LayoutHelper
 import com.mezon.mobile.core.StartupCache
@@ -47,7 +50,9 @@ import com.mezon.mobile.home.LOAD_TYPE_INITIAL
 import com.mezon.mobile.home.DialogsController
 import com.mezon.mobile.home.MemberResolver
 import com.mezon.mobile.home.UserClanController
+import com.mezon.mobile.home.clans.CLAN_CREATE_LIMIT
 import com.mezon.mobile.home.clans.ChannelController
+import com.mezon.mobile.home.clans.ClansController
 import com.mezon.mobile.home.clans.ClanChannelEntity
 import com.mezon.mobile.home.clans.ClanRole
 import com.mezon.mobile.home.clans.RoleController
@@ -73,10 +78,12 @@ import com.mezon.mobile.network.CHANNEL_TYPE_GROUP
 import com.mezon.mobile.network.CHANNEL_TYPE_CHANNEL
 import com.mezon.mobile.network.MezonApi
 import com.mezon.mobile.session.SessionManager
+import com.mezon.mobile.ui.MezonToast
 import com.mezon.mobile.ui.cells.ActionBarView
 import com.mezon.mobile.ui.cells.ColoredImageSpan
 import com.mezon.mobile.ui.cells.MezonIcon
 import com.mezon.mobile.ui.cells.PageDownButton
+import com.mezon.mobile.ui.cells.ToastOverlay
 import com.mezon.mobile.util.FileUtils
 import com.mezon.mobile.util.EmojiMarker
 import com.mezon.mobile.util.HashtagData
@@ -88,6 +95,8 @@ import com.mezon.mobile.util.resolveStickerSourceUrl
 import com.mezon.mobile.core.SharedConfig
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import com.mezon.mobile.core.SizeNotifierFrameLayout
 import com.mezon.mobile.home.chat.emoji.EmojiView
 
@@ -107,7 +116,7 @@ class ChatFragment : BaseFragment() {
         private const val VIEWPORT_LIMIT = 300
         private const val PAGE_DOWN_SCROLL_THRESHOLD = 2
         private const val REQUEST_CODE_LOCATION_PERMISSION = 1002
-        private const val REQUEST_CODE_PICK_FILE = 1001
+        private const val REQUEST_CODE_PICK_FILE = 1005
         private const val REQUEST_CODE_RECORD_AUDIO = 1003
         private const val MAX_LENGTH_MESSAGE_BUZZ = 160
         private const val VOICE_LONG_PRESS_DELAY_MS = 400L
@@ -174,6 +183,7 @@ class ChatFragment : BaseFragment() {
     private lateinit var sizeNotifierRoot: SizeNotifierFrameLayout
 
     private val pendingAttachments = ArrayList<AttachmentPickerItem>()
+    private var mediaPermissionDeniedOnce = false
     private val pendingAttachmentThumbTasks = ArrayList<Runnable?>()
     private var buzzMediaPlayer: android.media.MediaPlayer? = null
 
@@ -240,6 +250,7 @@ class ChatFragment : BaseFragment() {
     private lateinit var searchController: com.mezon.mobile.search.SearchController
     private lateinit var voiceController: VoiceController
     private lateinit var channelAppController: ChannelAppController
+    private lateinit var clansController: ClansController
     private lateinit var mezonApi: MezonApi
     private lateinit var sessionManager: SessionManager
     private lateinit var appScope: CoroutineScope
@@ -273,6 +284,9 @@ class ChatFragment : BaseFragment() {
     private var pendingSeenTimestamp = 0
     private var pendingBadgeCount = 0
     private val markVisibleRunnable = Runnable { flushPendingSeen() }
+    private var inviteJoinPendingClanId = 0L
+    private var inviteJoinClansObserver: NotificationCenter.NotificationCenterDelegate? = null
+    private var inviteJoinTimeout: Runnable? = null
 
     private val postponeNewMessagesCallback = object : NotificationCenter.PostponeNotificationCallback {
         override fun needPostpone(id: Int, currentAccount: Int, args: Array<out Any?>): Boolean {
@@ -916,6 +930,7 @@ class ChatFragment : BaseFragment() {
         pinMessageController = entryPoint.pinMessageController()
         voiceController = entryPoint.voiceController()
         channelAppController = entryPoint.channelAppController()
+        clansController = entryPoint.clansController()
         mezonApi = entryPoint.mezonApi()
         sessionManager = entryPoint.sessionManager()
         appScope = entryPoint.applicationScope()
@@ -1346,7 +1361,7 @@ class ChatFragment : BaseFragment() {
                             .setDestinationInExternalPublicDir(android.os.Environment.DIRECTORY_DOWNLOADS, filename)
                         val dm = context.getSystemService(android.content.Context.DOWNLOAD_SERVICE) as android.app.DownloadManager
                         dm.enqueue(request)
-                        android.widget.Toast.makeText(context, "Downloading $filename", android.widget.Toast.LENGTH_SHORT).show()
+                        MezonToast.show(this@ChatFragment, ToastOverlay.ToastType.INFO, "Downloading $filename")
                     } catch (_: Exception) {}
                 }
             }
@@ -1378,7 +1393,11 @@ class ChatFragment : BaseFragment() {
                 if (msg.isSending) return
                 audioPlayerController.toggle(msg.id, url, msg.attachmentDuration)
             }
+            override fun didClickInviteJoin(cell: ChatMessageCell, msg: MessageEntity, inviteId: Long) {
+                onLinkInviteJoinClicked(inviteId)
+            }
         })
+        adapter.loadLinkInvitePreview = { id -> mezonApi.getLinkInvitePreview(id) }
         adapter.channelType = channelType
         adapter.clanId = clanId
         adapter.isChannelPrivate = resolveChannelPrivate()
@@ -1864,7 +1883,97 @@ class ChatFragment : BaseFragment() {
         voiceRecorder?.cancel()
         voiceRecorder = null
         voiceOverlay = null
+        inviteJoinClansObserver?.let {
+            notificationCenter.removeObserver(it, NotificationCenter.clansDidLoad)
+        }
+        inviteJoinClansObserver = null
+        inviteJoinTimeout?.let { Handler(Looper.getMainLooper()).removeCallbacks(it) }
+        inviteJoinTimeout = null
         super.onFragmentDestroy()
+    }
+
+    private fun onLinkInviteJoinClicked(inviteId: Long) {
+        if (inviteId == 0L) return
+        val act = getParentActivity() ?: return
+        if (clansController.getClanCount() >= CLAN_CREATE_LIMIT) {
+            AlertDialog.Builder(act)
+                .setTitle(getString(R.string.clan_create_limit_reached_title))
+                .setMessage(getString(R.string.clan_create_limit_reached_message))
+                .setPositiveButton(getString(R.string.common_ok), null)
+                .show()
+            return
+        }
+        fragmentScope.launch {
+            val res = runCatching {
+                sessionManager.withAutoRefresh { session ->
+                    withContext(ioDispatcher) {
+                        mezonApi.inviteUserByInviteId(session.apiUrl, session.token, inviteId)
+                    }
+                }
+            }
+            withContext(mainDispatcher) {
+                res.onSuccess { r ->
+                    val cid = r.clanId
+                    if (cid != 0L) {
+                        navigateToJoinedClanFromChatInvite(cid)
+                    } else {
+                        MezonToast.show(this@ChatFragment, ToastOverlay.ToastType.ERROR, getString(R.string.discover_join_failed))
+                    }
+                }.onFailure {
+                    MezonToast.show(this@ChatFragment, ToastOverlay.ToastType.ERROR, getString(R.string.discover_join_failed))
+                }
+            }
+        }
+    }
+
+    private fun navigateToJoinedClanFromChatInvite(clanId: Long) {
+        if (inviteJoinPendingClanId != 0L) return
+        inviteJoinPendingClanId = clanId
+        val handler = Handler(Looper.getMainLooper())
+        val observer = object : NotificationCenter.NotificationCenterDelegate {
+            override fun didReceivedNotification(id: Int, account: Int, vararg args: Any?) {
+                finalizeJoinFromChatInvite(clanId)
+            }
+        }
+        inviteJoinClansObserver = observer
+        notificationCenter.addObserver(observer, NotificationCenter.clansDidLoad)
+        inviteJoinTimeout = Runnable { finalizeJoinFromChatInvite(clanId) }
+        handler.postDelayed(inviteJoinTimeout!!, 2500L)
+        clansController.loadClans(force = true)
+    }
+
+    private fun finalizeJoinFromChatInvite(clanId: Long) {
+        if (inviteJoinPendingClanId != clanId) return
+        inviteJoinPendingClanId = 0L
+        inviteJoinClansObserver?.let {
+            notificationCenter.removeObserver(it, NotificationCenter.clansDidLoad)
+        }
+        inviteJoinClansObserver = null
+        inviteJoinTimeout?.let { Handler(Looper.getMainLooper()).removeCallbacks(it) }
+        inviteJoinTimeout = null
+        clansController.selectClan(clanId, force = true)
+        notificationCenter.postNotificationOnMainThread(NotificationCenter.navigateToClansTab)
+        popToClansFragmentFromChat()
+    }
+
+    private fun popToClansFragmentFromChat() {
+        val layout = parentLayout
+        if (layout == null) {
+            finishFragment()
+            return
+        }
+        val stack = ArrayList(layout.getFragmentStack())
+        for (i in stack.size - 2 downTo 0) {
+            val f = stack[i]
+            if (f is com.mezon.mobile.home.clans.ClansFragment) {
+                for (j in stack.size - 2 downTo i + 1) {
+                    layout.removeFragmentFromStack(stack[j])
+                }
+                finishFragment()
+                return
+            }
+        }
+        finishFragment()
     }
 
     private fun refreshUI() {
@@ -2444,6 +2553,10 @@ class ChatFragment : BaseFragment() {
         if (activity.isFinishing || activity.isDestroyed) return
 
         if (!hasMediaPermission()) {
+            if (mediaPermissionDeniedOnce && !shouldShowMediaPermissionRationale()) {
+                showOpenMediaSettingsDialog()
+                return
+            }
             requestMediaPermission()
             return
         }
@@ -2459,6 +2572,38 @@ class ChatFragment : BaseFragment() {
         } else {
             ContextCompat.checkSelfPermission(ctx, Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED
         }
+    }
+
+    private fun shouldShowMediaPermissionRationale(): Boolean {
+        val activity = getParentActivity() ?: return false
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            activity.shouldShowRequestPermissionRationale(Manifest.permission.READ_MEDIA_IMAGES) ||
+                activity.shouldShowRequestPermissionRationale(Manifest.permission.READ_MEDIA_VIDEO)
+        } else {
+            activity.shouldShowRequestPermissionRationale(Manifest.permission.READ_EXTERNAL_STORAGE)
+        }
+    }
+
+    private fun computeMediaPermissionGrantedFromResult(
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ): Boolean {
+        if (grantResults.isEmpty()) return false
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            var imagesOk = false
+            var videoOk = false
+            for (i in permissions.indices) {
+                if (i >= grantResults.size) break
+                when (permissions[i]) {
+                    Manifest.permission.READ_MEDIA_IMAGES ->
+                        if (grantResults[i] == PackageManager.PERMISSION_GRANTED) imagesOk = true
+                    Manifest.permission.READ_MEDIA_VIDEO ->
+                        if (grantResults[i] == PackageManager.PERMISSION_GRANTED) videoOk = true
+                }
+            }
+            return imagesOk || videoOk
+        }
+        return grantResults[0] == PackageManager.PERMISSION_GRANTED
     }
 
     private fun requestMediaPermission() {
@@ -2536,7 +2681,7 @@ class ChatFragment : BaseFragment() {
         }
         if (item.size > maxSize) {
             val limitText = FileUtils.formatFileSize(maxSize)
-            android.widget.Toast.makeText(ctx, getString(R.string.file_too_large, limitText), android.widget.Toast.LENGTH_SHORT).show()
+            MezonToast.show(this, ToastOverlay.ToastType.ERROR, getString(R.string.file_too_large, limitText))
             return
         }
 
@@ -2625,7 +2770,7 @@ class ChatFragment : BaseFragment() {
             } else if (locationManager.isProviderEnabled(android.location.LocationManager.NETWORK_PROVIDER)) {
                 locationManager.requestSingleUpdate(android.location.LocationManager.NETWORK_PROVIDER, listener, null)
             } else {
-                android.widget.Toast.makeText(ctx, R.string.permission_no_location, android.widget.Toast.LENGTH_SHORT).show()
+                MezonToast.show(this, ToastOverlay.ToastType.ERROR, getString(R.string.permission_no_location))
             }
         } catch (e: Exception) {
             Log.e(TAG, "Failed to get location", e)
@@ -2800,7 +2945,7 @@ class ChatFragment : BaseFragment() {
         val ctx = getContext() ?: return
         val recorder = VoiceRecorder(ctx)
         if (!recorder.start()) {
-            android.widget.Toast.makeText(ctx, R.string.voice_record_failed, android.widget.Toast.LENGTH_SHORT).show()
+            MezonToast.show(this, ToastOverlay.ToastType.ERROR, getString(R.string.voice_record_failed))
             return
         }
         voiceRecorder = recorder
@@ -2837,12 +2982,12 @@ class ChatFragment : BaseFragment() {
         val result = recorder.stop()
         teardownVoiceUi()
         if (result == null) {
-            android.widget.Toast.makeText(ctx, R.string.voice_record_failed, android.widget.Toast.LENGTH_SHORT).show()
+            MezonToast.show(this, ToastOverlay.ToastType.ERROR, getString(R.string.voice_record_failed))
             return
         }
         if (result.durationMs < VoiceRecorder.MIN_RECORD_MS) {
             try { result.file.delete() } catch (_: Exception) {}
-            android.widget.Toast.makeText(ctx, R.string.voice_record_too_short, android.widget.Toast.LENGTH_SHORT).show()
+            MezonToast.show(this, ToastOverlay.ToastType.INFO, getString(R.string.voice_record_too_short))
             return
         }
         sendVoiceRecording(result.file, result.durationMs)
@@ -2854,8 +2999,8 @@ class ChatFragment : BaseFragment() {
         voiceRecorder = null
         voiceCancelled = true
         teardownVoiceUi()
-        if (showToast && ctx != null) {
-            android.widget.Toast.makeText(ctx, R.string.voice_record_cancelled, android.widget.Toast.LENGTH_SHORT).show()
+        if (showToast) {
+            MezonToast.show(this, ToastOverlay.ToastType.INFO, getString(R.string.voice_record_cancelled))
         }
     }
 
@@ -2902,8 +3047,7 @@ class ChatFragment : BaseFragment() {
     }
 
     private fun showHoldToRecordHint() {
-        val ctx = getContext() ?: return
-        android.widget.Toast.makeText(ctx, R.string.voice_record_hint, android.widget.Toast.LENGTH_SHORT).show()
+        MezonToast.show(this, ToastOverlay.ToastType.INFO, getString(R.string.voice_record_hint))
     }
 
     private fun updateAttachmentPreview() {
@@ -3046,8 +3190,14 @@ class ChatFragment : BaseFragment() {
         grantResults: IntArray
     ) {
         if (requestCode == ChatAttachAlert.REQUEST_CODE_MEDIA_PERMISSION) {
-            if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+            if (computeMediaPermissionGrantedFromResult(permissions, grantResults)) {
+                mediaPermissionDeniedOnce = false
                 openAttachAlert()
+            } else {
+                mediaPermissionDeniedOnce = true
+                if (!shouldShowMediaPermissionRationale()) {
+                    showOpenMediaSettingsDialog()
+                }
             }
         }
         if (requestCode == REQUEST_CODE_LOCATION_PERMISSION) {
@@ -3076,6 +3226,25 @@ class ChatFragment : BaseFragment() {
                 }
             }
         }
+    }
+
+    private fun showOpenMediaSettingsDialog() {
+        val activity = getParentActivity() ?: return
+        com.mezon.mobile.core.AlertDialog.Builder(activity)
+            .setTitle(getString(R.string.common_settings))
+            .setMessage(getString(R.string.permission_no_storage))
+            .setPositiveButton(getString(R.string.permission_open_settings)) { _, _ ->
+                try {
+                    val intent = android.content.Intent(
+                        android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                        android.net.Uri.fromParts("package", activity.packageName, null)
+                    )
+                    activity.startActivity(intent)
+                } catch (_: Exception) {}
+            }
+            .setNegativeButton(getString(R.string.permission_not_now), null)
+            .create()
+            .show()
     }
 
     private fun showOpenAudioSettingsDialog() {
@@ -3286,10 +3455,10 @@ class ChatFragment : BaseFragment() {
             isDM = clanId == 0L,
             listener = object : UserProfileBottomSheet.UserProfileListener {
                 override fun onSendMessage(userId: Long) {
-                    android.widget.Toast.makeText(ctx, R.string.feature_coming_soon, android.widget.Toast.LENGTH_SHORT).show()
+                    MezonToast.show(this@ChatFragment, ToastOverlay.ToastType.INFO, getString(R.string.feature_coming_soon))
                 }
                 override fun onVoiceCall(userId: Long) {
-                    android.widget.Toast.makeText(ctx, R.string.feature_coming_soon, android.widget.Toast.LENGTH_SHORT).show()
+                    MezonToast.show(this@ChatFragment, ToastOverlay.ToastType.INFO, getString(R.string.feature_coming_soon))
                 }
                 override fun onAddFriend(userId: Long) {
                     showAddFriendBottomSheet()
@@ -3313,11 +3482,11 @@ class ChatFragment : BaseFragment() {
                 val plainText = parseContentText(msg.content).ifBlank { msg.content }
                 val clipboard = ctx.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
                 clipboard.setPrimaryClip(android.content.ClipData.newPlainText("message", plainText))
-                android.widget.Toast.makeText(ctx, R.string.message_toast_copy_text, android.widget.Toast.LENGTH_SHORT).show()
+                MezonToast.show(this, ToastOverlay.ToastType.INFO, getString(R.string.message_toast_copy_text))
             }
             MessageActionBottomSheet.ActionType.ForwardMessage -> {
-                val c = getContext() ?: return
-                android.widget.Toast.makeText(c, R.string.feature_coming_soon, android.widget.Toast.LENGTH_SHORT).show()
+                getContext() ?: return
+                MezonToast.show(this, ToastOverlay.ToastType.INFO, getString(R.string.feature_coming_soon))
             }
             MessageActionBottomSheet.ActionType.PinMessage -> {
                 showPinConfirmation(msg, isUnpin = false)
@@ -3329,16 +3498,16 @@ class ChatFragment : BaseFragment() {
                 showDeleteConfirmation(msg)
             }
             MessageActionBottomSheet.ActionType.CreateThread -> {
-                val c = getContext() ?: return
-                android.widget.Toast.makeText(c, R.string.feature_coming_soon, android.widget.Toast.LENGTH_SHORT).show()
+                getContext() ?: return
+                MezonToast.show(this, ToastOverlay.ToastType.INFO, getString(R.string.feature_coming_soon))
             }
             MessageActionBottomSheet.ActionType.MarkUnRead -> {
-                val c = getContext() ?: return
-                android.widget.Toast.makeText(c, R.string.feature_coming_soon, android.widget.Toast.LENGTH_SHORT).show()
+                getContext() ?: return
+                MezonToast.show(this, ToastOverlay.ToastType.INFO, getString(R.string.feature_coming_soon))
             }
             MessageActionBottomSheet.ActionType.SaveMedia -> {
-                val c = getContext() ?: return
-                android.widget.Toast.makeText(c, R.string.feature_coming_soon, android.widget.Toast.LENGTH_SHORT).show()
+                getContext() ?: return
+                MezonToast.show(this, ToastOverlay.ToastType.INFO, getString(R.string.feature_coming_soon))
             }
             MessageActionBottomSheet.ActionType.CopyMediaLink -> {
                 val url = msg.attachmentUrl
@@ -3346,13 +3515,13 @@ class ChatFragment : BaseFragment() {
                     val ctx = getContext() ?: return
                     val clipboard = ctx.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
                     clipboard.setPrimaryClip(android.content.ClipData.newPlainText("media_url", url))
-                    android.widget.Toast.makeText(ctx, R.string.action_copy_link, android.widget.Toast.LENGTH_SHORT).show()
+                    MezonToast.show(this, ToastOverlay.ToastType.INFO, getString(R.string.action_copy_link))
                 }
             }
             MessageActionBottomSheet.ActionType.CopyImage,
             MessageActionBottomSheet.ActionType.ShareImage -> {
-                val c = getContext() ?: return
-                android.widget.Toast.makeText(c, R.string.feature_coming_soon, android.widget.Toast.LENGTH_SHORT).show()
+                getContext() ?: return
+                MezonToast.show(this, ToastOverlay.ToastType.INFO, getString(R.string.feature_coming_soon))
             }
             MessageActionBottomSheet.ActionType.Report -> {
                 showReportMessageSheet(msg)

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
@@ -15,6 +15,7 @@ import android.text.TextUtils
 import android.text.style.ClickableSpan
 import android.view.MotionEvent
 import com.mezon.mobile.BuildConfig
+import com.mezon.mobile.R
 import com.mezon.mobile.core.AndroidUtilities
 import com.mezon.mobile.core.AvatarDrawable
 import com.mezon.mobile.core.BaseCell
@@ -37,18 +38,22 @@ import com.mezon.mobile.util.parseContentPreview
 import com.mezon.mobile.util.parseContentText
 import com.mezon.mobile.util.parseContentToSpannable
 import com.mezon.mobile.util.parseOgpData
+import android.graphics.Bitmap
+import android.graphics.Typeface
+import android.text.TextPaint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
 import android.util.Log
 import androidx.core.content.ContextCompat
 import kotlin.math.min
+import kotlin.math.max
 
 class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCell(context) {
     var hasMentionHighlight: Boolean = false
@@ -56,6 +61,12 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
 
     var messageEntity: MessageEntity? = null
         private set
+    private val linkInviteBlock = LinkInviteBlock(this, theme) { messageEntity?.id }
+    var loadLinkInvitePreview: (suspend (Long) -> com.mezon.mobile.network.LinkInvitePreview?)?
+        get() = linkInviteBlock.loadLinkInvitePreview
+        set(v) {
+            linkInviteBlock.loadLinkInvitePreview = v
+        }
     var isCombined: Boolean = false
     var isInPinMode: Boolean = false
 
@@ -130,6 +141,8 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
     private var ogpBlockRight = 0
     private var ogpBlockBottom = 0
 
+    private var pressedOnInviteJoin = false
+
     private var embedData: EmbedData? = null
     private var embedTitleLayout: StaticLayout? = null
     private var embedDescLayout: StaticLayout? = null
@@ -190,6 +203,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         photoImage.onAttachedToWindow()
         extraPhotoImages.forEach { it.onAttachedToWindow() }
         ogpImage.onAttachedToWindow()
+        linkInviteBlock.onAttachedToWindow()
         embedImage.onAttachedToWindow()
         embedThumbImage.onAttachedToWindow()
         pendingMessage?.let { msg ->
@@ -204,6 +218,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         photoImage.onDetachedFromWindow()
         extraPhotoImages.forEach { it.onDetachedFromWindow() }
         ogpImage.onDetachedFromWindow()
+        linkInviteBlock.onDetachedFromWindow()
         embedImage.onDetachedFromWindow()
         embedThumbImage.onDetachedFromWindow()
         avatarCancellable?.cancel()
@@ -236,6 +251,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         ogpTitleLayout = null
         ogpDescLayout = null
         ogpData = null
+        linkInviteBlock.clear()
         hasReply = false
         replyRefMessageId = 0L
         replySenderId = 0L
@@ -338,7 +354,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
                 if (isAnon) loadAnonymousAvatar() else loadAvatar(msg.senderAvatar)
             }
             if (drawPhotoImage) loadPhotoImage(msg)
-            if (drawPhotoImage) {
+            if (BuildConfig.DEBUG && drawPhotoImage) {
                 Log.d(
                     TAG,
                     "update mask=0 id=${msg.id} sendState=${msg.sendState} drawSending=$drawSending " +
@@ -362,10 +378,12 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             val prevError = drawError
             drawSending = msg.isSending
             drawError = msg.isError
-            Log.d(
-                TAG,
-                "update SEND_STATE id=${msg.id} sendState=${msg.sendState} drawSending=$drawSending drawPhotoImage=$drawPhotoImage"
-            )
+            if (BuildConfig.DEBUG) {
+                Log.d(
+                    TAG,
+                    "update SEND_STATE id=${msg.id} sendState=${msg.sendState} drawSending=$drawSending drawPhotoImage=$drawPhotoImage"
+                )
+            }
             if (drawError && !prevError) {
                 rebuildLayout = true
             } else {
@@ -419,12 +437,12 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         return false
     }
 
-    private fun computePhotoSize(msg: MessageEntity) {
+    private fun computePhotoSize(msg: MessageEntity, width: Int = currentWidth()) {
         val screenW = min(resources.displayMetrics.widthPixels, resources.displayMetrics.heightPixels)
         val isStickerMsg = msg.messageType == MessageEntity.TYPE_GIF &&
             (msg.attachmentFiletype.equals("sticker", true) || msg.attachmentUrl.contains("/stickers/"))
         val rawMaxW = if (isStickerMsg) LayoutHelper.dp(160) else (screenW * 0.65f).toInt()
-        val maxW = if (isInPinMode) rawMaxW.coerceAtMost(maxBubbleWidth()) else rawMaxW
+        val maxW = if (isInPinMode) rawMaxW.coerceAtMost(maxBubbleWidth(width)) else rawMaxW
         val maxH = maxW + LayoutHelper.dp(100)
 
         var imgW = msg.attachmentWidth
@@ -588,14 +606,25 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         currentTimePaint = theme.chatTimePaint
     }
 
-    private fun maxBubbleWidth(): Int {
-        val w = if (measuredWidth > 0) measuredWidth else resources.displayMetrics.widthPixels
-        if (isInPinMode) return w - PIN_PAD_H * 2
-        return w - PAD_H - AVATAR_SIZE - GAP_AVATAR - LayoutHelper.dp(28)
+    private fun currentWidth(): Int {
+        if (measuredWidth > 0) return measuredWidth
+        if (AndroidUtilities.displaySize.x > 0) return AndroidUtilities.displaySize.x
+        return resources.displayMetrics.widthPixels
+    }
+
+    private fun maxBubbleWidth(): Int = maxBubbleWidth(currentWidth())
+
+    private fun maxBubbleWidth(width: Int): Int {
+        if (isInPinMode) return width - PIN_PAD_H * 2
+        return width - PAD_H - AVATAR_SIZE - GAP_AVATAR - LayoutHelper.dp(28)
     }
 
     private fun buildLayouts(msg: MessageEntity) {
-        val bubbleMaxW = maxBubbleWidth()
+        buildLayouts(msg, currentWidth())
+    }
+
+    private fun buildLayouts(msg: MessageEntity, width: Int) {
+        val bubbleMaxW = maxBubbleWidth(width)
         // No bubble padding — content starts right after avatar (flat style like RN)
         val bubbleWidth = if (drawPhotoImage) photoWidth else bubbleMaxW
         if (bubbleWidth <= 0) return
@@ -702,6 +731,12 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             parseEmbedData(msg.content)
         } else null
         buildEmbedLayouts(textWidth)
+        linkInviteBlock.build(msg, bubbleMaxW) {
+            val m = messageEntity ?: return@build
+            buildLayouts(m)
+            requestLayout()
+            invalidate()
+        }
 
         durationLayout = if (msg.messageType == MessageEntity.TYPE_VIDEO && msg.attachmentDuration > 0) {
             val dur = formatDuration(msg.attachmentDuration)
@@ -733,12 +768,13 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         val fileW = if (drawFileAttachment) fileRowWidth.toFloat() else 0f
         val audioW = if (drawAudioAttachment) audioPillWidth.toFloat() else 0f
         val embedW = if (embedData != null) (bubbleMaxW).toFloat() else 0f
+        val inviteW = if (linkInviteBlock.isVisible) linkInviteBlock.cachedWidth else 0f
         cachedInnerWidth = if (drawPhotoImage) {
             photoWidth
         } else if (hasCodeFence) {
             bubbleMaxW
         } else {
-            val allW = maxOf(cachedSenderW, cachedContentW, cachedTimeW, replyW, ogpW, cachedForwardW, fileW, audioW, cachedEphW, embedW)
+            val allW = maxOf(cachedSenderW, cachedContentW, cachedTimeW, replyW, ogpW, cachedForwardW, fileW, audioW, cachedEphW, embedW, inviteW)
             allW.toInt().coerceAtMost(bubbleMaxW)
         }
 
@@ -757,7 +793,21 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         forwardLayout?.let { h += it.height + GAP_V_INNER }
         senderLayout?.let { h += it.height + GAP_V_INNER }
 
-        contentLayout?.let { h += it.height + GAP_V_INNER }
+        contentLayout?.let {
+            h += it.height
+            h += if (ogpData != null || linkInviteBlock.isVisible) LINK_INVITE_V_MARGIN else GAP_V_INNER
+        }
+
+        if (ogpData != null) {
+            h += GAP_V_INNER
+            ogpTitleLayout?.let { h += it.height + GAP_V_INNER }
+            ogpDescLayout?.let { h += it.height + GAP_V_INNER }
+            h += ogpImageH + GAP_V_INNER
+        }
+
+        if (linkInviteBlock.isVisible) {
+            h += linkInviteBlock.blockHeight + LINK_INVITE_V_MARGIN
+        }
 
         if (drawPhotoImage) {
             val imgH = if (mediaGridCount > 1) mediaGridTotalH else photoHeight
@@ -772,13 +822,6 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
 
         if (drawAudioAttachment) {
             h += AUDIO_PILL_HEIGHT + GAP_V_INNER
-        }
-
-        if (ogpData != null) {
-            h += GAP_V_INNER
-            ogpTitleLayout?.let { h += it.height + GAP_V_INNER }
-            ogpDescLayout?.let { h += it.height + GAP_V_INNER }
-            h += ogpImageH + GAP_V_INNER
         }
 
         if (embedData != null) {
@@ -1267,7 +1310,8 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         val msg = messageEntity
         if (msg != null && w > 0 && w != cachedMeasuredWidth) {
             cachedMeasuredWidth = w
-            buildLayouts(msg)
+            if (drawPhotoImage) computePhotoSize(msg, w)
+            buildLayouts(msg, w)
         }
         setMeasuredDimension(w, measuredCellHeight)
     }
@@ -1286,6 +1330,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         fun didTapReaction(cell: ChatMessageCell, msg: MessageEntity, group: ReactionGroup) {}
         fun didLongPressReaction(cell: ChatMessageCell, msg: MessageEntity, group: ReactionGroup) {}
         fun didTapAddReaction(cell: ChatMessageCell, msg: MessageEntity) {}
+        fun didClickInviteJoin(cell: ChatMessageCell, msg: MessageEntity, inviteId: Long) {}
     }
 
     private var pressedLink: ClickableSpan? = null
@@ -1332,6 +1377,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         pressedOnAudio = false
         pressedOnAvatar = false
         pressedOnReply = false
+        pressedOnInviteJoin = false
     }
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
@@ -1348,6 +1394,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
                 pressedOnAudio = false
                 pressedOnAvatar = false
                 pressedOnReply = false
+                pressedOnInviteJoin = false
                 pressedReactionIndex = -1
                 longPressHandled = false
                 startX = x
@@ -1385,6 +1432,10 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
                 if (drawAudioAttachment && x >= audioBlockLeft && x <= audioBlockRight && y >= audioBlockTop && y <= audioBlockBottom) {
                     pressedOnAudio = true
                     scheduleLongPress()
+                    return true
+                }
+                if (linkInviteBlock.hitTestJoin(x, y)) {
+                    pressedOnInviteJoin = true
                     return true
                 }
                 if (drawPhotoImage) {
@@ -1429,19 +1480,24 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
                     if (hasReply) reacBaseY += REPLY_ROW_HEIGHT + REPLY_V_GAP
                     forwardLayout?.let { reacBaseY += it.height + GAP_V_INNER }
                     senderLayout?.let { reacBaseY += it.height + GAP_V_INNER }
-                    contentLayout?.let { reacBaseY += it.height + GAP_V_INNER }
-                    if (drawPhotoImage) {
-                        val imgH = if (mediaGridCount > 1) mediaGridTotalH else photoHeight
-                        reacBaseY += imgH + GAP_V_INNER
+                    contentLayout?.let {
+                        reacBaseY += it.height + (if (ogpData != null || linkInviteBlock.isVisible) LINK_INVITE_V_MARGIN else GAP_V_INNER)
                     }
-                    if (drawFileAttachment) reacBaseY += FILE_ICON_SIZE + GAP_V_INNER
-                    if (drawAudioAttachment) reacBaseY += AUDIO_PILL_HEIGHT + GAP_V_INNER
                     if (ogpData != null) {
                         reacBaseY += GAP_V_INNER
                         ogpTitleLayout?.let { reacBaseY += it.height + GAP_V_INNER }
                         ogpDescLayout?.let { reacBaseY += it.height + GAP_V_INNER }
                         reacBaseY += ogpImageH + GAP_V_INNER
                     }
+                    if (linkInviteBlock.isVisible) {
+                        reacBaseY += linkInviteBlock.blockHeight + LINK_INVITE_V_MARGIN
+                    }
+                    if (drawPhotoImage) {
+                        val imgH = if (mediaGridCount > 1) mediaGridTotalH else photoHeight
+                        reacBaseY += imgH + GAP_V_INNER
+                    }
+                    if (drawFileAttachment) reacBaseY += FILE_ICON_SIZE + GAP_V_INNER
+                    if (drawAudioAttachment) reacBaseY += AUDIO_PILL_HEIGHT + GAP_V_INNER
                     if (embedData != null) reacBaseY += computeEmbedHeight()
                     if (drawEphemeral) ephemeralLayout?.let { reacBaseY += it.height + GAP_V_INNER }
                     reacBaseY += REACTION_TOP_PAD
@@ -1510,6 +1566,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
                     pressedOnAudio = false
                     pressedOnAvatar = false
                     pressedOnReply = false
+                    pressedOnInviteJoin = false
                     pressedReactionIndex = -1
                     return true
                 }
@@ -1567,6 +1624,14 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
                     embedData?.let { if (it.url.isNotEmpty()) onLinkClicked(it.url) }
                     return true
                 }
+                if (pressedOnInviteJoin) {
+                    pressedOnInviteJoin = false
+                    val msg = messageEntity
+                    if (msg != null && linkInviteBlock.activeIdForJoin != 0L) {
+                        delegate?.didClickInviteJoin(this, msg, linkInviteBlock.activeIdForJoin)
+                    }
+                    return true
+                }
                 pressedLink?.let { span ->
                     pressedLink = null
                     span.onClick(this)
@@ -1584,6 +1649,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
                 pressedOnAudio = false
                 pressedOnAvatar = false
                 pressedOnReply = false
+                pressedOnInviteJoin = false
             }
         }
         return super.onTouchEvent(event)
@@ -1817,7 +1883,16 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             canvas.translate(contentLeft.toFloat(), yOff)
             it.draw(canvas)
             canvas.restore()
-            yOff += it.height + GAP_V_INNER
+            yOff += it.height + (if (ogpData != null || linkInviteBlock.isVisible) LINK_INVITE_V_MARGIN else GAP_V_INNER)
+        }
+
+        if (ogpData != null) {
+            yOff += GAP_V_INNER
+            yOff = drawOgpBlock(canvas, contentLeft.toFloat(), yOff) + GAP_V_INNER
+        }
+
+        if (linkInviteBlock.isVisible) {
+            yOff = linkInviteBlock.draw(canvas, contentLeft.toFloat(), yOff) + LINK_INVITE_V_MARGIN
         }
 
         if (drawPhotoImage) {
@@ -1840,8 +1915,6 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         if (drawAudioAttachment) {
             yOff = drawAudioBlock(canvas, contentLeft.toFloat(), yOff, msg)
         }
-
-        ogpData?.let { yOff = drawOgpBlock(canvas, contentLeft.toFloat(), yOff) + GAP_V_INNER }
 
         if (embedData != null) {
             yOff = drawEmbedCard(canvas, contentLeft.toFloat(), yOff)
@@ -2570,7 +2643,8 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         private val MENTION_BG_PAINT = android.graphics.Paint().apply {
             style = android.graphics.Paint.Style.FILL
         }
-        private val GAP_V_INNER = LayoutHelper.dp(6) 
+        private val GAP_V_INNER = LayoutHelper.dp(6)
+        private val LINK_INVITE_V_MARGIN = LayoutHelper.dp(12) 
         private val MEDIA_RADIUS = LayoutHelper.dp(12).toFloat()
         private val OGP_RADIUS = LayoutHelper.dp(8).toFloat()
         private const val OGP_MAX_CHARS = 200

--- a/app/src/main/java/com/mezon/mobile/home/chat/LinkInviteBlock.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/LinkInviteBlock.kt
@@ -1,0 +1,474 @@
+package com.mezon.mobile.home.chat
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.RectF
+import android.graphics.Typeface
+import android.text.StaticLayout
+import android.text.TextPaint
+import android.text.TextUtils
+import android.view.View
+import com.mezon.mobile.R
+import com.mezon.mobile.core.LayoutHelper
+import com.mezon.mobile.core.ThemeColors
+import com.mezon.mobile.network.LinkInvitePreview
+import com.mezon.mobile.ui.theme.ThemeMode
+import com.mezon.mobile.util.createImgproxyUrl
+import com.mezon.mobile.util.parseInviteLinkMessageId
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.math.max
+import kotlin.math.min
+
+private sealed class LinkInviteUiState {
+    data object Hidden : LinkInviteUiState()
+    data object Loading : LinkInviteUiState()
+    data object Invalid : LinkInviteUiState()
+    data class Ready(val preview: LinkInvitePreview) : LinkInviteUiState()
+}
+
+class LinkInviteBlock(
+    private val host: View,
+    private val theme: ThemeColors,
+    private val currentMessageId: () -> Long?
+) {
+    var loadLinkInvitePreview: (suspend (Long) -> LinkInvitePreview?)? = null
+
+    private val logo = ImageReceiver(host)
+    private var state: LinkInviteUiState = LinkInviteUiState.Hidden
+    private var activeInviteId = 0L
+    private var previewJob: Job? = null
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var titleLayout: StaticLayout? = null
+    private var clanLayout: StaticLayout? = null
+    private var channelLayout: StaticLayout? = null
+    private var invalidTitleLayout: StaticLayout? = null
+    private var invalidMsgLayout: StaticLayout? = null
+    private var joinLayout: StaticLayout? = null
+    private var cardW = 0
+    var blockHeight: Int = 0
+        private set
+    var cachedWidth: Float = 0f
+        private set
+    val joinRect = RectF()
+    private val cardBgPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
+    private val joinBgPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
+    private val titleTextPaint = TextPaint(Paint.ANTI_ALIAS_FLAG)
+    private val clanTextPaint = TextPaint(Paint.ANTI_ALIAS_FLAG)
+    private val channelTextPaint = TextPaint(Paint.ANTI_ALIAS_FLAG)
+    private val invalidTitlePaint = TextPaint(Paint.ANTI_ALIAS_FLAG)
+    private val joinTextPaint = TextPaint(Paint.ANTI_ALIAS_FLAG)
+    private val cardRect = RectF()
+    private val defaultClanFillPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
+    private val defaultClanTextPaint = TextPaint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.WHITE
+        typeface = Typeface.create(Typeface.DEFAULT, 600, false)
+        textAlign = Paint.Align.CENTER
+    }
+    private val invalidPhPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
+    private val loadingStrokePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeCap = Paint.Cap.ROUND
+    }
+    private val tmpAvatarRect = RectF()
+    private val tmpLoadingArc = RectF()
+    private var loadingAngleDeg = 0f
+    private var loadingBodyRowHeight = 0
+
+    val isVisible: Boolean
+        get() = state !is LinkInviteUiState.Hidden
+    val activeIdForJoin: Long
+        get() = if (state is LinkInviteUiState.Ready) activeInviteId else 0L
+
+    private val context: Context
+        get() = host.context
+
+    private val cardRadius: Float
+        get() = LayoutHelper.dpf(12f)
+    private val joinRadius: Float
+        get() = LayoutHelper.dpf(4f)
+    private val defaultAvatarCorner: Float
+        get() = LayoutHelper.dpf(8f)
+    private val loadingSize: Int
+        get() = LayoutHelper.dp(20)
+
+    fun onAttachedToWindow() {
+        logo.onAttachedToWindow()
+    }
+
+    fun onDetachedFromWindow() {
+        logo.onDetachedFromWindow()
+    }
+
+    fun clear() {
+        previewJob?.cancel()
+        previewJob = null
+        state = LinkInviteUiState.Hidden
+        activeInviteId = 0L
+        titleLayout = null
+        clanLayout = null
+        channelLayout = null
+        invalidTitleLayout = null
+        invalidMsgLayout = null
+        joinLayout = null
+        cardW = 0
+        blockHeight = 0
+        cachedWidth = 0f
+        joinRect.setEmpty()
+        logo.setImage(null, null, context)
+        loadingAngleDeg = 0f
+        loadingBodyRowHeight = 0
+    }
+
+    fun build(msg: MessageEntity, bubbleMaxW: Int, onPreviewLayoutChanged: () -> Unit) {
+        val inviteId = parseInviteLinkMessageId(msg.content)
+        if (inviteId == null) {
+            state = LinkInviteUiState.Hidden
+            blockHeight = 0
+            cachedWidth = 0f
+            titleLayout = null
+            clanLayout = null
+            channelLayout = null
+            invalidTitleLayout = null
+            invalidMsgLayout = null
+            joinLayout = null
+            logo.setImage(null, null, context)
+            return
+        }
+        if (activeInviteId != inviteId) {
+            previewJob?.cancel()
+            previewJob = null
+            state = LinkInviteUiState.Loading
+            activeInviteId = inviteId
+        } else if (state is LinkInviteUiState.Hidden) {
+            state = LinkInviteUiState.Loading
+        }
+        cardBgPaint.color = theme.channelPanelBg
+        joinBgPaint.color = theme.blurple
+        titleTextPaint.set(theme.chatTimePaint)
+        titleTextPaint.textSize = LayoutHelper.dpf(CARD_TITLE_SP)
+        titleTextPaint.typeface = Typeface.create(Typeface.DEFAULT, 600, false)
+        titleTextPaint.color = theme.textDisabled
+        titleTextPaint.letterSpacing = letterSpacingEmFromRnHalf(titleTextPaint)
+        clanTextPaint.set(theme.chatContentPaint)
+        clanTextPaint.typeface = Typeface.create(Typeface.DEFAULT, 700, false)
+        clanTextPaint.color = theme.colorText
+        channelTextPaint.set(theme.chatTimePaint)
+        channelTextPaint.textSize = LayoutHelper.dpf(CHANNEL_TEXT_SP)
+        channelTextPaint.typeface = Typeface.create(Typeface.DEFAULT, 500, false)
+        channelTextPaint.color = theme.textDisabled
+        channelTextPaint.letterSpacing = letterSpacingEmFromRnHalf(channelTextPaint)
+        invalidTitlePaint.set(clanTextPaint)
+        invalidTitlePaint.color = theme.error
+        invalidTitlePaint.letterSpacing = 0f
+        joinTextPaint.set(clanTextPaint)
+        joinTextPaint.color = 0xFFFFFFFF.toInt()
+        joinTextPaint.textSize = LayoutHelper.dpf(14f)
+        joinTextPaint.typeface = Typeface.create(Typeface.DEFAULT, 600, false)
+        joinTextPaint.letterSpacing = letterSpacingEmFromRnHalf(joinTextPaint)
+        loadingStrokePaint.color = theme.colorText
+        loadingStrokePaint.strokeWidth = LayoutHelper.dpf(2f)
+        invalidPhPaint.color = invalidPlaceholderBackground()
+
+        if (loadLinkInvitePreview == null && state is LinkInviteUiState.Loading) {
+            state = LinkInviteUiState.Ready(LinkInvitePreview("", "", ""))
+        }
+        cardW = min(bubbleMaxW, CARD_MAX_W).coerceAtLeast(1)
+        val innerW = (cardW - INNER_PAD * 2).coerceAtLeast(1)
+        val titleText = context.getString(R.string.clan_link_invite_title)
+        titleLayout = StaticLayout.Builder.obtain(titleText, 0, titleText.length, titleTextPaint, innerW)
+            .setMaxLines(2)
+            .setEllipsize(TextUtils.TruncateAt.END)
+            .build()
+
+        if (state is LinkInviteUiState.Loading && loadLinkInvitePreview != null && previewJob?.isActive != true) {
+            requestLoad(msg, inviteId, onPreviewLayoutChanged)
+        }
+        val textColW = (innerW - AVATAR - ROW_GAP)
+        val nameW = max(1, (textColW * 0.91f).toInt().coerceAtMost(textColW))
+        when (val st = state) {
+            is LinkInviteUiState.Hidden -> {}
+            is LinkInviteUiState.Loading -> {
+                clanLayout = null
+                channelLayout = null
+                invalidTitleLayout = null
+                invalidMsgLayout = null
+                joinLayout = null
+                logo.setImage(null, null, context)
+            }
+            is LinkInviteUiState.Invalid -> {
+                val invT = context.getString(R.string.clan_link_invite_invalid_title)
+                invalidTitleLayout = StaticLayout.Builder.obtain(invT, 0, invT.length, invalidTitlePaint, nameW)
+                    .setMaxLines(1)
+                    .setEllipsize(TextUtils.TruncateAt.END)
+                    .build()
+                val invM = context.getString(R.string.clan_link_invite_invalid_message)
+                val invPaint = TextPaint(Paint.ANTI_ALIAS_FLAG)
+                invPaint.set(channelTextPaint)
+                invalidMsgLayout = StaticLayout.Builder.obtain(invM, 0, invM.length, invPaint, nameW)
+                    .setMaxLines(2)
+                    .setEllipsize(TextUtils.TruncateAt.END)
+                    .build()
+                clanLayout = null
+                channelLayout = null
+                joinLayout = null
+                logo.setImage(null, null, context)
+            }
+            is LinkInviteUiState.Ready -> {
+                val p = st.preview
+                invalidTitleLayout = null
+                invalidMsgLayout = null
+                val clan = p.clanName.trim().ifEmpty { context.getString(R.string.clan_link_invite_unknown_clan) }
+                clanLayout = StaticLayout.Builder.obtain(clan, 0, clan.length, clanTextPaint, nameW)
+                    .setMaxLines(1)
+                    .setEllipsize(TextUtils.TruncateAt.END)
+                    .build()
+                if (p.channelLabel.isNotEmpty()) {
+                    val chT = context.getString(R.string.clan_link_invite_channel_prefix, p.channelLabel)
+                    channelLayout = StaticLayout.Builder.obtain(chT, 0, chT.length, channelTextPaint, nameW)
+                        .setMaxLines(1)
+                        .setEllipsize(TextUtils.TruncateAt.END)
+                        .build()
+                } else {
+                    channelLayout = null
+                }
+                val joinT = context.getString(R.string.clan_link_invite_join)
+                joinLayout = StaticLayout.Builder.obtain(joinT, 0, joinT.length, joinTextPaint, innerW)
+                    .setMaxLines(1)
+                    .build()
+                if (p.logoUrl.isNotEmpty()) {
+                    val av = LayoutHelper.dp(48)
+                    val prox = createImgproxyUrl(p.logoUrl, av, av, "fit")
+                    logo.setRoundRadius(LayoutHelper.dp(14))
+                    logo.setImage(prox, null, context)
+                } else {
+                    logo.setImage(null, null, context)
+                }
+            }
+        }
+        var h = INNER_PAD
+        titleLayout?.let { h += it.height + TITLE_TO_BODY_GAP }
+        loadingBodyRowHeight = 0
+        when (state) {
+            is LinkInviteUiState.Loading -> {
+                val (rowH, joinBlockH) = measureReservedReadyBlockHeight(innerW, nameW)
+                loadingBodyRowHeight = rowH
+                h += rowH + BLOCK_GAP + joinBlockH
+            }
+            is LinkInviteUiState.Invalid -> {
+                val colH = (invalidTitleLayout?.height ?: 0) + (invalidMsgLayout?.let { it.height + LayoutHelper.dp(2) } ?: 0)
+                h += max(AVATAR, colH)
+            }
+            is LinkInviteUiState.Ready -> {
+                val colH = (clanLayout?.height ?: 0) + (channelLayout?.let { it.height + LayoutHelper.dp(2) } ?: 0)
+                val rowH = max(AVATAR, colH)
+                h += rowH
+                h += BLOCK_GAP
+                h += JOIN_V * 2 + (joinLayout?.height ?: LayoutHelper.dp(14))
+            }
+            else -> {}
+        }
+        h += INNER_PAD
+        blockHeight = h
+        cachedWidth = cardW.toFloat()
+    }
+
+    private fun measureReservedReadyBlockHeight(innerW: Int, nameW: Int): Pair<Int, Int> {
+        val joinT = context.getString(R.string.clan_link_invite_join)
+        val joinLay = StaticLayout.Builder.obtain(joinT, 0, joinT.length, joinTextPaint, innerW)
+            .setMaxLines(1)
+            .setEllipsize(TextUtils.TruncateAt.END)
+            .build()
+        val joinBlockH = JOIN_V * 2 + joinLay.height
+        val clanPl = context.getString(R.string.clan_link_invite_unknown_clan)
+        val clanLay = StaticLayout.Builder.obtain(clanPl, 0, clanPl.length, clanTextPaint, nameW)
+            .setMaxLines(1)
+            .setEllipsize(TextUtils.TruncateAt.END)
+            .build()
+        val chPl = context.getString(R.string.clan_link_invite_channel_prefix, "\u2014")
+        val chLay = StaticLayout.Builder.obtain(chPl, 0, chPl.length, channelTextPaint, nameW)
+            .setMaxLines(1)
+            .setEllipsize(TextUtils.TruncateAt.END)
+            .build()
+        val colH = clanLay.height + LayoutHelper.dp(2) + chLay.height
+        val rowH = max(AVATAR, colH)
+        return Pair(rowH, joinBlockH)
+    }
+
+    private fun invalidPlaceholderBackground(): Int {
+        return when (theme.resolvedMode) {
+            ThemeMode.LIGHT -> 0xFFF0F0F0.toInt()
+            else -> theme.secondaryLight
+        }
+    }
+
+    private fun letterSpacingEmFromRnHalf(paint: TextPaint): Float {
+        return LayoutHelper.dpf(0.5f) / paint.textSize.coerceAtLeast(1e-3f)
+    }
+
+    private fun requestLoad(msg: MessageEntity, inviteId: Long, onPreviewLayoutChanged: () -> Unit) {
+        val loader = loadLinkInvitePreview ?: return
+        previewJob?.cancel()
+        previewJob = scope.launch {
+            val result = try {
+                withContext(Dispatchers.IO) { loader(inviteId) }
+            } catch (_: Exception) {
+                null
+            }
+            if (currentMessageId() != msg.id) return@launch
+            val preview = result ?: LinkInvitePreview("", "", "")
+            state = LinkInviteUiState.Ready(preview)
+            if (currentMessageId() == msg.id) {
+                onPreviewLayoutChanged()
+            }
+        }
+    }
+
+    fun draw(canvas: Canvas, contentLeft: Float, yTop: Float): Float {
+        if (state is LinkInviteUiState.Hidden) return yTop
+        var y = yTop
+        val cLeft = contentLeft
+        val cW = cardW.toFloat()
+        cardRect.set(cLeft, y, cLeft + cW, y + blockHeight)
+        canvas.drawRoundRect(cardRect, cardRadius, cardRadius, cardBgPaint)
+        y += INNER_PAD
+        val innerL = contentLeft + INNER_PAD
+        val innerW = (cardW - INNER_PAD * 2).coerceAtLeast(1)
+        titleLayout?.let {
+            canvas.save()
+            canvas.translate(innerL, y)
+            it.draw(canvas)
+            canvas.restore()
+            y += it.height + TITLE_TO_BODY_GAP
+        }
+        when (val st = state) {
+            is LinkInviteUiState.Loading -> {
+                val rowH = loadingBodyRowHeight.coerceAtLeast(AVATAR)
+                val cx = innerL + innerW / 2f
+                val cy = y + rowH / 2f
+                val r = loadingSize / 2f
+                tmpLoadingArc.set(cx - r, cy - r, cx + r, cy + r)
+                canvas.drawArc(tmpLoadingArc, loadingAngleDeg, 270f, false, loadingStrokePaint)
+                loadingAngleDeg = (loadingAngleDeg + 6f) % 360f
+                if (host.isAttachedToWindow) {
+                    host.postInvalidateOnAnimation()
+                }
+            }
+            is LinkInviteUiState.Invalid -> {
+                val avSize = AVATAR.toFloat()
+                val avLeft = innerL
+                val avTop = y
+                tmpAvatarRect.set(avLeft, avTop, avLeft + avSize, avTop + avSize)
+                canvas.drawRoundRect(tmpAvatarRect, defaultAvatarCorner, defaultAvatarCorner, invalidPhPaint)
+                val textLeft = avLeft + avSize + ROW_GAP
+                var iy = avTop
+                invalidTitleLayout?.let {
+                    canvas.save()
+                    canvas.translate(textLeft, iy)
+                    it.draw(canvas)
+                    canvas.restore()
+                    iy += it.height + LayoutHelper.dp(2)
+                }
+                invalidMsgLayout?.let {
+                    canvas.save()
+                    canvas.translate(textLeft, iy)
+                    it.draw(canvas)
+                    canvas.restore()
+                }
+            }
+            is LinkInviteUiState.Ready -> {
+                val p = st.preview
+                val displayClan = p.clanName.trim().ifEmpty { context.getString(R.string.clan_link_invite_unknown_clan) }
+                val avSize = AVATAR.toFloat()
+                val avLeft = innerL
+                val avTop = y
+                if (p.logoUrl.isNotEmpty()) {
+                    tmpAvatarRect.set(avLeft, avTop, avLeft + avSize, avTop + avSize)
+                    canvas.drawRoundRect(tmpAvatarRect, CLAN_LOGO_AVATAR_R, CLAN_LOGO_AVATAR_R, cardBgPaint)
+                    logo.setImageCoords(avLeft, avTop, avSize, avSize)
+                    logo.setRoundRadius(LayoutHelper.dp(14))
+                    logo.draw(canvas)
+                } else {
+                    drawDefaultClanInitial(canvas, avLeft, avTop, avSize, displayClan)
+                }
+                val textTop = avTop
+                clanLayout?.let {
+                    val tx = avLeft + avSize + ROW_GAP
+                    canvas.save()
+                    canvas.translate(tx, textTop)
+                    it.draw(canvas)
+                    canvas.restore()
+                }
+                val chY = textTop + (clanLayout?.height ?: 0) + LayoutHelper.dp(2)
+                channelLayout?.let {
+                    val tx = avLeft + avSize + ROW_GAP
+                    canvas.save()
+                    canvas.translate(tx, chY)
+                    it.draw(canvas)
+                    canvas.restore()
+                }
+                val textColH = (clanLayout?.height ?: 0) +
+                    (channelLayout?.let { it.height + LayoutHelper.dp(2) } ?: 0)
+                y += max(avSize, textColH.toFloat())
+                y += BLOCK_GAP
+                val jh = (joinLayout?.height ?: LayoutHelper.dp(14)) + JOIN_V * 2
+                val joinW = innerW.toFloat()
+                joinRect.set(innerL, y, innerL + joinW, y + jh)
+                canvas.drawRoundRect(joinRect, joinRadius, joinRadius, joinBgPaint)
+                joinLayout?.let { jl ->
+                    val jx = joinRect.left + (joinRect.width() - staticLayoutMaxWidth(jl)) / 2f
+                    val jy = joinRect.top + (joinRect.height() - jl.height) / 2f
+                    canvas.save()
+                    canvas.translate(jx, jy)
+                    jl.draw(canvas)
+                    canvas.restore()
+                }
+            }
+            else -> {}
+        }
+        return yTop + blockHeight
+    }
+
+    private fun drawDefaultClanInitial(canvas: Canvas, left: Float, top: Float, size: Float, clanName: String) {
+        defaultClanFillPaint.color = theme.blurple
+        tmpAvatarRect.set(left, top, left + size, top + size)
+        canvas.drawRoundRect(tmpAvatarRect, defaultAvatarCorner, defaultAvatarCorner, defaultClanFillPaint)
+        val initial = (clanName.firstOrNull { !it.isWhitespace() }?.uppercaseChar()?.toString()) ?: "?"
+        defaultClanTextPaint.textSize = LayoutHelper.dpf(26f)
+        val cx = left + size / 2f
+        val cy = top + size / 2f - (defaultClanTextPaint.ascent() + defaultClanTextPaint.descent()) / 2f
+        canvas.drawText(initial, 0, 1, cx, cy, defaultClanTextPaint)
+    }
+
+    fun hitTestJoin(x: Float, y: Float): Boolean {
+        if (state !is LinkInviteUiState.Ready) return false
+        return x >= joinRect.left && x <= joinRect.right && y >= joinRect.top && y <= joinRect.bottom
+    }
+
+    companion object {
+        private val CARD_MAX_W = LayoutHelper.dp(260)
+        private val INNER_PAD = LayoutHelper.dp(12)
+        private val TITLE_TO_BODY_GAP = LayoutHelper.dp(10)
+        private val CLAN_LOGO_AVATAR_R = LayoutHelper.dpf(14f)
+        private val BLOCK_GAP = LayoutHelper.dp(16)
+        private val AVATAR = LayoutHelper.dp(48)
+        private val ROW_GAP = LayoutHelper.dp(10)
+        private val JOIN_V = LayoutHelper.dp(6)
+        private const val CARD_TITLE_SP = 11f
+        private const val CHANNEL_TEXT_SP = 12f
+    }
+}
+
+private fun staticLayoutMaxWidth(layout: StaticLayout): Float {
+    var maxW = 0f
+    for (i in 0 until layout.lineCount) {
+        maxW = maxOf(maxW, layout.getLineWidth(i))
+    }
+    return maxW
+}

--- a/app/src/main/java/com/mezon/mobile/home/chat/PhotoViewer.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/PhotoViewer.kt
@@ -1,7 +1,6 @@
 package com.mezon.mobile.home.chat
 
 import android.animation.ObjectAnimator
-import android.annotation.SuppressLint
 import android.app.Dialog
 import android.app.DownloadManager
 import android.content.ClipData
@@ -9,41 +8,47 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Color
+import android.graphics.Outline
 import android.graphics.drawable.AnimatedImageDrawable
+import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
-import android.view.GestureDetector
+import android.util.TypedValue
 import android.view.Gravity
-import android.view.MotionEvent
+import android.view.View
 import android.view.ViewGroup
+import android.view.ViewOutlineProvider
 import android.view.Window
 import android.view.WindowManager
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.Toast
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewpager2.widget.ViewPager2
+import com.github.chrisbanes.photoview.PhotoView
+import com.mezon.mobile.R
 import com.mezon.mobile.core.LayoutHelper
 import com.mezon.mobile.util.createImgproxyUrl
-import com.otaliastudios.zoom.Alignment
-import com.otaliastudios.zoom.ZoomApi
-import com.otaliastudios.zoom.ZoomLayout
 
 class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Black_NoTitleBar_Fullscreen) {
 
-    companion object {
-        private const val MIN_ZOOM = 1f
-        private const val MAX_ZOOM = 4f
-        private const val GALLERY_FLING_ZOOM_THRESHOLD = 1.02f
-    }
-
-    private val imageView: ImageView
-    private val zoomLayout: ZoomLayout
-    private lateinit var gestureDetector: GestureDetector
     private val backgroundDrawable = ColorDrawable(Color.BLACK)
-    private val closeButton: ImageView
+    private val viewPager: ViewPager2
+    private val topBar: FrameLayout
+    private val bottomBar: LinearLayout
+    private val counterView: android.widget.TextView
+    private var toolbarVisible = true
+
+    private var urls = emptyList<String>()
+    private var isAnimated = false
+    private var currentIndex = 0
+    private val currentUrl get() = urls.getOrElse(currentIndex) { "" }
 
     init {
         requestWindowFeature(Window.FEATURE_NO_TITLE)
@@ -53,98 +58,287 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
 
         val root = FrameLayout(context)
 
-        imageView = ImageView(context).apply {
-            scaleType = ImageView.ScaleType.FIT_CENTER
+        viewPager = ViewPager2(context).apply {
+            offscreenPageLimit = 1
+            setBackgroundColor(Color.BLACK)
         }
-        zoomLayout = object : ZoomLayout(context) {
-            @SuppressLint("ClickableViewAccessibility")
-            override fun onTouchEvent(ev: MotionEvent): Boolean {
-                gestureDetector.onTouchEvent(ev)
-                return super.onTouchEvent(ev)
-            }
-        }.apply {
-            setTransformation(ZoomApi.TRANSFORMATION_CENTER_INSIDE, ZoomApi.TRANSFORMATION_GRAVITY_AUTO)
-            setAlignment(Alignment.CENTER)
-            setMinZoom(MIN_ZOOM, ZoomApi.TYPE_ZOOM)
-            setMaxZoom(MAX_ZOOM, ZoomApi.TYPE_ZOOM)
-            setOverPinchable(false)
-            setHorizontalPanEnabled(true)
-            setVerticalPanEnabled(true)
-            setFlingEnabled(true)
-        }
-        zoomLayout.addView(imageView, FrameLayout.LayoutParams(
-            FrameLayout.LayoutParams.MATCH_PARENT,
-            FrameLayout.LayoutParams.MATCH_PARENT
-        ))
-        root.addView(zoomLayout, FrameLayout.LayoutParams(
+        root.addView(viewPager, FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.MATCH_PARENT,
             FrameLayout.LayoutParams.MATCH_PARENT
         ))
 
-        gestureDetector = GestureDetector(context, object : GestureDetector.SimpleOnGestureListener() {
-            override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
-                dismissWithAnimation()
-                return true
+        topBar = FrameLayout(context)
+        counterView = android.widget.TextView(context).apply {
+            setTextColor(Color.WHITE)
+            textSize = 16f
+        }
+        val closeDiameter = LayoutHelper.dp(44)
+        val closeWrap = FrameLayout(context).apply {
+            background = GradientDrawable().apply {
+                shape = GradientDrawable.OVAL
+                setColor(0x80000000.toInt())
             }
-
-            override fun onFling(e1: MotionEvent?, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
-                if (zoomLayout.zoom > GALLERY_FLING_ZOOM_THRESHOLD) return false
-                if (urls.size <= 1) return false
-                if (kotlin.math.abs(velocityX) > kotlin.math.abs(velocityY) && kotlin.math.abs(velocityX) > 800) {
-                    if (velocityX < 0 && currentIndex < urls.size - 1) {
-                        navigateTo(currentIndex + 1)
-                        return true
-                    } else if (velocityX > 0 && currentIndex > 0) {
-                        navigateTo(currentIndex - 1)
-                        return true
-                    }
+            outlineProvider = object : ViewOutlineProvider() {
+                override fun getOutline(view: View, outline: Outline) {
+                    outline.setOval(0, 0, view.width, view.height)
                 }
-                return false
             }
-        })
-
-        closeButton = ImageView(context).apply {
-            setImageResource(android.R.drawable.ic_menu_close_clear_cancel)
-            setColorFilter(Color.WHITE)
-            setPadding(LayoutHelper.dp(12), LayoutHelper.dp(12), LayoutHelper.dp(12), LayoutHelper.dp(12))
+            clipToOutline = true
+            isClickable = true
+            isFocusable = true
+            contentDescription = context.getString(R.string.common_close)
+            val tvRipple = TypedValue()
+            if (context.theme.resolveAttribute(android.R.attr.selectableItemBackgroundBorderless, tvRipple, true)) {
+                foreground = ContextCompat.getDrawable(context, tvRipple.resourceId)
+            }
             setOnClickListener { dismissWithAnimation() }
+            val closeBtn = ImageView(context).apply {
+                setImageResource(android.R.drawable.ic_menu_close_clear_cancel)
+                setColorFilter(Color.WHITE)
+                val p = LayoutHelper.dp(10)
+                setPadding(p, p, p, p)
+                isClickable = false
+                isFocusable = false
+                importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+            }
+            addView(closeBtn, FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                Gravity.CENTER
+            ))
         }
-        val closeParams = FrameLayout.LayoutParams(LayoutHelper.dp(48), LayoutHelper.dp(48))
-        closeParams.gravity = Gravity.TOP or Gravity.START
-        closeParams.topMargin = LayoutHelper.dp(40)
-        closeParams.leftMargin = LayoutHelper.dp(8)
-        root.addView(closeButton, closeParams)
+        val counterParams = FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.WRAP_CONTENT,
+            FrameLayout.LayoutParams.WRAP_CONTENT,
+            Gravity.CENTER
+        )
+        topBar.addView(counterView, counterParams)
+        val closeBtnParams = FrameLayout.LayoutParams(closeDiameter, closeDiameter, Gravity.END or Gravity.CENTER_VERTICAL)
+        closeBtnParams.marginEnd = LayoutHelper.dp(8)
+        topBar.addView(closeWrap, closeBtnParams)
 
-        val toolbar = LinearLayout(context).apply {
+        val topBarParams = FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            LayoutHelper.dp(56)
+        )
+        topBarParams.gravity = Gravity.TOP
+        topBarParams.topMargin = LayoutHelper.dp(32)
+        root.addView(topBar, topBarParams)
+
+        bottomBar = LinearLayout(context).apply {
             orientation = LinearLayout.HORIZONTAL
             gravity = Gravity.CENTER
             setBackgroundColor(0x99000000.toInt())
             val pad = LayoutHelper.dp(12)
             setPadding(pad, pad, pad, pad)
         }
-        val toolbarParams = FrameLayout.LayoutParams(
+        bottomBar.addView(createToolbarButton(context, android.R.drawable.ic_menu_share, "Share") {
+            shareUrl(currentUrl)
+        })
+        bottomBar.addView(createToolbarButton(context, android.R.drawable.ic_menu_save, "Save") {
+            downloadUrl(currentUrl)
+        })
+        bottomBar.addView(createToolbarButton(context, android.R.drawable.ic_menu_agenda, "Copy") {
+            copyLink(currentUrl)
+        })
+        val bottomBarParams = FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.MATCH_PARENT,
             LayoutHelper.dp(56)
         )
-        toolbarParams.gravity = Gravity.BOTTOM
-        root.addView(toolbar, toolbarParams)
-
-        toolbar.addView(createToolbarButton(context, android.R.drawable.ic_menu_share, "Share") {
-            shareUrl(currentUrl)
-        })
-        toolbar.addView(createToolbarButton(context, android.R.drawable.ic_menu_save, "Save") {
-            downloadUrl(currentUrl)
-        })
-        toolbar.addView(createToolbarButton(context, android.R.drawable.ic_menu_agenda, "Copy") {
-            copyLink(currentUrl)
-        })
+        bottomBarParams.gravity = Gravity.BOTTOM
+        root.addView(bottomBar, bottomBarParams)
 
         setContentView(root)
     }
 
-    private var currentUrl = ""
-    private var isAnimated = false
-    private var urls = emptyList<String>()
+    fun show(
+        url: String,
+        animated: Boolean = false,
+        gallery: List<String> = emptyList(),
+        index: Int = 0,
+        thumbBitmap: Bitmap? = null
+    ) {
+        urls = if (gallery.isEmpty()) listOf(url) else gallery
+        currentIndex = if (index in urls.indices) index else 0
+        isAnimated = animated
+
+        viewPager.adapter = PhotoPagerAdapter(thumbBitmap.takeIf { !animated && urls.size == 1 })
+        viewPager.setCurrentItem(currentIndex, false)
+        viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                currentIndex = position
+                updateCounter()
+            }
+        })
+
+        updateCounter()
+        backgroundDrawable.alpha = 0
+        super.show()
+        ObjectAnimator.ofInt(backgroundDrawable, "alpha", 0, 255).setDuration(200).start()
+    }
+
+    private fun updateCounter() {
+        if (urls.size > 1) {
+            counterView.text = "${currentIndex + 1} / ${urls.size}"
+            counterView.visibility = View.VISIBLE
+        } else {
+            counterView.visibility = View.GONE
+        }
+    }
+
+    private fun toggleToolbar() {
+        toolbarVisible = !toolbarVisible
+        val targetAlpha = if (toolbarVisible) 1f else 0f
+        topBar.animate().alpha(targetAlpha).setDuration(200).start()
+        bottomBar.animate().alpha(targetAlpha).setDuration(200).start()
+    }
+
+    private fun dismissWithAnimation() {
+        val anim = ObjectAnimator.ofInt(backgroundDrawable, "alpha", 255, 0)
+        anim.duration = 150
+        anim.addListener(object : android.animation.AnimatorListenerAdapter() {
+            override fun onAnimationEnd(animation: android.animation.Animator) { dismiss() }
+        })
+        anim.start()
+        viewPager.animate().alpha(0f).setDuration(150).start()
+    }
+
+    override fun onBackPressed() {
+        dismissWithAnimation()
+    }
+
+    private inner class PhotoPagerAdapter(
+        private val initialThumb: Bitmap?
+    ) : RecyclerView.Adapter<PhotoPagerAdapter.ViewHolder>() {
+
+        inner class ViewHolder(val photoView: PhotoView) : RecyclerView.ViewHolder(photoView) {
+            var pendingLoad: MezonImageLoader.Cancellable? = null
+            var bindGeneration: Long = 0L
+        }
+
+        private fun stopAndClearPhotoView(photoView: PhotoView) {
+            (photoView.drawable as? AnimatedImageDrawable)?.stop()
+            photoView.setImageDrawable(null)
+            photoView.getAttacher().update()
+            photoView.setScale(1f, false)
+        }
+
+        private fun applyLoadedDrawable(
+            holder: ViewHolder,
+            expectedPosition: Int,
+            expectedUrl: String,
+            drawable: Drawable
+        ) {
+            if (holder.bindingAdapterPosition != expectedPosition) return
+            if (urls.getOrNull(expectedPosition) != expectedUrl) return
+            val pv = holder.photoView
+            (pv.drawable as? AnimatedImageDrawable)?.stop()
+            pv.setImageDrawable(drawable)
+            pv.getAttacher().update()
+            pv.setScale(1f, false)
+            if (drawable is AnimatedImageDrawable) {
+                drawable.repeatCount = AnimatedImageDrawable.REPEAT_INFINITE
+                drawable.start()
+            }
+        }
+
+        private fun applyLoadedBitmap(
+            holder: ViewHolder,
+            expectedPosition: Int,
+            expectedUrl: String,
+            bmp: Bitmap
+        ) {
+            if (holder.bindingAdapterPosition != expectedPosition) return
+            if (urls.getOrNull(expectedPosition) != expectedUrl) return
+            val pv = holder.photoView
+            (pv.drawable as? AnimatedImageDrawable)?.stop()
+            pv.setImageDrawable(BitmapDrawable(pv.context.resources, bmp))
+            pv.getAttacher().update()
+            pv.setScale(1f, false)
+        }
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+            val photoView = PhotoView(parent.context).apply {
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+                )
+                setBackgroundColor(Color.BLACK)
+                maximumScale = 4f
+                mediumScale = 2f
+                minimumScale = 0.5f
+                setOnSingleFlingListener { _, _, velocityX, velocityY ->
+                    val absX = kotlin.math.abs(velocityX)
+                    val absY = kotlin.math.abs(velocityY)
+                    val nearDefault = kotlin.math.abs(scale - 1f) < 0.06f
+                    if (absY > absX && absY > 800f && velocityY > 0 && nearDefault) {
+                        dismissWithAnimation()
+                        true
+                    } else false
+                }
+                setOnPhotoTapListener { _, _, _ -> toggleToolbar() }
+                setOnOutsidePhotoTapListener { toggleToolbar() }
+            }
+            return ViewHolder(photoView)
+        }
+
+        override fun onViewRecycled(holder: ViewHolder) {
+            super.onViewRecycled(holder)
+            holder.pendingLoad?.cancel()
+            holder.pendingLoad = null
+            holder.bindGeneration++
+            stopAndClearPhotoView(holder.photoView)
+        }
+
+        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+            val url = urls[position]
+            val photoView = holder.photoView
+
+            holder.pendingLoad?.cancel()
+            holder.pendingLoad = null
+            holder.bindGeneration++
+            val bindGen = holder.bindGeneration
+            stopAndClearPhotoView(photoView)
+
+            if (position == currentIndex && initialThumb != null) {
+                photoView.setImageBitmap(initialThumb)
+                photoView.getAttacher().update()
+                photoView.setScale(1f, false)
+            }
+
+            val screenW = context.resources.displayMetrics.widthPixels
+            val screenH = context.resources.displayMetrics.heightPixels
+            val loader = MezonImageLoader.getInstance(context)
+
+            if (isAnimated) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    holder.pendingLoad = loader.loadDrawable(url, screenW, screenH,
+                        onSuccess = { drawable ->
+                            if (holder.bindGeneration != bindGen) return@loadDrawable
+                            applyLoadedDrawable(holder, position, url, drawable)
+                        }
+                    )
+                } else {
+                    holder.pendingLoad = loader.load(url, screenW, screenH,
+                        onSuccess = { bmp ->
+                            if (holder.bindGeneration != bindGen) return@load
+                            applyLoadedBitmap(holder, position, url, bmp)
+                        }
+                    )
+                }
+            } else {
+                val loadUrl = createImgproxyUrl(url, screenW, screenH, "fit")
+                holder.pendingLoad = loader.load(loadUrl, screenW, screenH,
+                    onSuccess = { bmp ->
+                        if (holder.bindGeneration != bindGen) return@load
+                        applyLoadedBitmap(holder, position, url, bmp)
+                    }
+                )
+            }
+        }
+
+        override fun getItemCount() = urls.size
+    }
 
     private fun createToolbarButton(ctx: Context, iconRes: Int, desc: String, onClick: () -> Unit): ImageView {
         return ImageView(ctx).apply {
@@ -190,106 +384,5 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
             }
             context.startActivity(android.content.Intent.createChooser(intent, "Share"))
         } catch (_: Exception) {}
-    }
-
-    private var currentIndex = 0
-
-    fun show(url: String, animated: Boolean = false, gallery: List<String> = emptyList(), index: Int = 0, thumbBitmap: Bitmap? = null) {
-        urls = if (gallery.isEmpty()) listOf(url) else gallery
-        currentIndex = if (index in urls.indices) index else 0
-        currentUrl = urls[currentIndex]
-        isAnimated = animated
-        zoomLayout.moveToCenter(MIN_ZOOM, false)
-
-        if (thumbBitmap != null && !animated) {
-            imageView.setImageDrawable(BitmapDrawable(context.resources, thumbBitmap))
-        }
-
-        backgroundDrawable.alpha = 0
-        super.show()
-        ObjectAnimator.ofInt(backgroundDrawable, "alpha", 0, 255).setDuration(200).start()
-
-        val screenW = context.resources.displayMetrics.widthPixels
-        val screenH = context.resources.displayMetrics.heightPixels
-        val loader = MezonImageLoader.getInstance(context)
-
-        if (animated) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                loader.loadDrawable(url, screenW, screenH,
-                    onSuccess = { drawable ->
-                        imageView.setImageDrawable(drawable)
-                        if (drawable is AnimatedImageDrawable) {
-                            drawable.repeatCount = AnimatedImageDrawable.REPEAT_INFINITE
-                            drawable.start()
-                        }
-                    }
-                )
-            } else {
-                loader.load(url, screenW, screenH,
-                    onSuccess = { bmp ->
-                        imageView.setImageDrawable(BitmapDrawable(context.resources, bmp))
-                    }
-                )
-            }
-        } else {
-            val loadUrl = createImgproxyUrl(url, screenW, screenH, "fit")
-            loader.load(loadUrl, screenW, screenH,
-                onSuccess = { bmp ->
-                    imageView.setImageDrawable(BitmapDrawable(context.resources, bmp))
-                }
-            )
-        }
-    }
-
-    private fun navigateTo(index: Int) {
-        if (index !in urls.indices) return
-        currentIndex = index
-        currentUrl = urls[currentIndex]
-        zoomLayout.moveToCenter(MIN_ZOOM, false)
-        imageView.animate().alpha(0f).setDuration(100).withEndAction {
-            loadCurrentImage()
-            imageView.animate().alpha(1f).setDuration(150).start()
-        }.start()
-    }
-
-    private fun loadCurrentImage() {
-        val screenW = context.resources.displayMetrics.widthPixels
-        val screenH = context.resources.displayMetrics.heightPixels
-        val loader = MezonImageLoader.getInstance(context)
-
-        if (isAnimated && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            loader.loadDrawable(currentUrl, screenW, screenH,
-                onSuccess = { drawable ->
-                    imageView.setImageDrawable(drawable)
-                    if (drawable is AnimatedImageDrawable) {
-                        drawable.repeatCount = AnimatedImageDrawable.REPEAT_INFINITE
-                        drawable.start()
-                    }
-                }
-            )
-        } else {
-            val loadUrl = if (isAnimated) currentUrl else createImgproxyUrl(currentUrl, screenW, screenH, "fit")
-            loader.load(loadUrl, screenW, screenH,
-                onSuccess = { bmp ->
-                    imageView.setImageDrawable(BitmapDrawable(context.resources, bmp))
-                }
-            )
-        }
-    }
-
-    private fun dismissWithAnimation() {
-        val anim = ObjectAnimator.ofInt(backgroundDrawable, "alpha", 255, 0)
-        anim.duration = 150
-        anim.addListener(object : android.animation.AnimatorListenerAdapter() {
-            override fun onAnimationEnd(animation: android.animation.Animator) {
-                dismiss()
-            }
-        })
-        anim.start()
-        imageView.animate().alpha(0f).setDuration(150).start()
-    }
-
-    override fun onBackPressed() {
-        dismissWithAnimation()
     }
 }

--- a/app/src/main/java/com/mezon/mobile/network/LinkInvitePreview.kt
+++ b/app/src/main/java/com/mezon/mobile/network/LinkInvitePreview.kt
@@ -1,0 +1,7 @@
+package com.mezon.mobile.network
+
+data class LinkInvitePreview(
+    val clanName: String,
+    val channelLabel: String,
+    val logoUrl: String
+)

--- a/app/src/main/java/com/mezon/mobile/network/MezonApi.kt
+++ b/app/src/main/java/com/mezon/mobile/network/MezonApi.kt
@@ -75,6 +75,7 @@ import com.mezon.mezon.rtapi.ActiveArchivedThread
 import com.mezon.mezon.rtapi.ChannelMessageSend
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.put
@@ -88,6 +89,8 @@ import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import org.json.JSONObject
+import java.util.Collections
 import javax.inject.Inject
 import javax.inject.Singleton
 class UnauthorizedException(message: String) : RuntimeException(message)
@@ -193,6 +196,53 @@ class MezonApi @Inject constructor(
     companion object {
         private val SERVER_KEY = BuildConfig.MEZON_API_KEY
         private const val DISCOVER_ITEMS_PER_PAGE = 6
+    }
+
+    private val linkInvitePreviewCache =
+        Collections.synchronizedMap(mutableMapOf<Long, LinkInvitePreview>())
+
+    suspend fun getLinkInvitePreview(inviteId: Long): LinkInvitePreview? {
+        if (inviteId == 0L) return null
+        synchronized(linkInvitePreviewCache) {
+            linkInvitePreviewCache[inviteId]?.let { return it }
+        }
+        return try {
+            val gatewayUrl = BuildConfig.MEZON_GATEWAY_URL.trimEnd('/')
+            val url = "$gatewayUrl/v2/invite/$inviteId?"
+            val basicCreds = Base64.encodeToString(
+                "$SERVER_KEY:".toByteArray(),
+                Base64.NO_WRAP
+            )
+            val response = httpClient.get(url) {
+                header(HttpHeaders.Authorization, "Basic $basicCreds")
+                header(HttpHeaders.Accept, ContentType.Application.Json.toString())
+            }
+            if (!response.status.isSuccess()) {
+                return null
+            }
+            val text = response.bodyAsText()
+            val obj = JSONObject(text)
+            val clanName = obj.optString("clan_name", "")
+                .ifEmpty { obj.optString("clanName", "") }
+                .trim()
+            val channelLabel = obj.optString("channel_label", "")
+                .ifEmpty { obj.optString("channelLabel", "") }
+                .trim()
+            val logo = obj.optString("clan_logo", "")
+                .ifEmpty { obj.optString("clanLogo", "") }
+                .trim()
+            val preview = LinkInvitePreview(
+                clanName = clanName,
+                channelLabel = channelLabel,
+                logoUrl = logo
+            )
+            synchronized(linkInvitePreviewCache) {
+                linkInvitePreviewCache[inviteId] = preview
+            }
+            preview
+        } catch (_: Exception) {
+            null
+        }
     }
 
     suspend fun authenticateEmail(

--- a/app/src/main/java/com/mezon/mobile/network/MezonSocket.kt
+++ b/app/src/main/java/com/mezon/mobile/network/MezonSocket.kt
@@ -115,7 +115,7 @@ class MezonSocket @Inject constructor(
 
     private fun correlationKeyForPending(envelope: Envelope, raw: ByteArray): String? {
         val fromParsed = envelope.cid
-        if (fromParsed != 0) return fromParsed.toString()
+        if (fromParsed.isNotEmpty()) return fromParsed
         return readCorrelationIdField1(raw)
     }
 
@@ -197,7 +197,7 @@ class MezonSocket @Inject constructor(
     suspend fun send(block: EnvelopeKt.Dsl.() -> Unit): Envelope {
         val cid = cidCounter.incrementAndGet()
         val env = envelope {
-            this.cid = cid
+            this.cid = cid.toString()
             block()
         }
 

--- a/app/src/main/java/com/mezon/mobile/notification/MezonFirebaseService.kt
+++ b/app/src/main/java/com/mezon/mobile/notification/MezonFirebaseService.kt
@@ -70,7 +70,12 @@ class MezonFirebaseService : FirebaseMessagingService() {
                 }
 
                 if (isAppInForeground()) {
-                    notificationHelper.showInAppToast(title, body, channelId = channelId, clanId = clanId)
+                    notificationHelper.showInAppToast(
+                        title,
+                        body,
+                        channelId = channelId,
+                        clanId = clanId
+                    )
                 } else {
                     notificationHelper.showMessageNotification(title, body, channelId = channelId, clanId = clanId)
                 }
@@ -83,7 +88,11 @@ class MezonFirebaseService : FirebaseMessagingService() {
                     }
 
                     if (isAppInForeground()) {
-                        notificationHelper.showInAppToast(title, body, dmId = dmId)
+                        notificationHelper.showInAppToast(
+                            title,
+                            body,
+                            dmId = dmId
+                        )
                     } else {
                         notificationHelper.showDmNotification(title, body, dmChannelId = dmId)
                     }
@@ -95,4 +104,5 @@ class MezonFirebaseService : FirebaseMessagingService() {
     private fun isAppInForeground(): Boolean {
         return MainActivity.isResumed
     }
+
 }

--- a/app/src/main/java/com/mezon/mobile/notification/NotificationHelper.kt
+++ b/app/src/main/java/com/mezon/mobile/notification/NotificationHelper.kt
@@ -242,11 +242,11 @@ class NotificationHelper @Inject constructor(
                     }
                     else -> null
                 }
-                ToastOverlay(activity, activity.themeColors).show(
+                ToastOverlay.showInAppNotification(
+                    activity = activity,
                     parent = activity.drawerLayoutContainer,
-                    type = ToastOverlay.ToastType.INFO,
                     title = title,
-                    description = body,
+                    body = body,
                     onTap = onTap
                 )
             }

--- a/app/src/main/java/com/mezon/mobile/search/GlobalSearchFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/search/GlobalSearchFragment.kt
@@ -117,6 +117,7 @@ class GlobalSearchFragment : BaseFragment() {
     private var channelScopedMembers: List<SearchMember>? = null
     private var membersRequested = false
     private var channelsRequested = false
+    private var channelsFirstLoadPending = false
     private var isChannelPickerMode = false
     private var pickerQuery = ""
     private var pickerDisplayLimit = LOCAL_PAGE_SIZE
@@ -183,6 +184,7 @@ class GlobalSearchFragment : BaseFragment() {
         }
         observe(NotificationCenter.searchChannelsDidLoad) { _, _, _ ->
             if (fragmentView == null || isPaused) return@observe
+            channelsFirstLoadPending = false
             if (currentTab == TAB_CHANNELS) {
                 loadingView.visibility = View.GONE
                 recyclerView.visibility = View.VISIBLE
@@ -482,11 +484,16 @@ class GlobalSearchFragment : BaseFragment() {
             TAB_CHANNELS -> {
                 if (!channelsRequested) {
                     channelsRequested = true
+                    channelsFirstLoadPending = true
+                    emptyView.visibility = View.GONE
                     loadingView.visibility = View.VISIBLE
-                    recyclerView.visibility = View.GONE
+                    recyclerView.visibility = View.VISIBLE
+                    updateChannelsList()
                     searchController.loadChannels()
                 } else {
-                    loadingView.visibility = View.GONE
+                    loadingView.visibility =
+                        if (channelsFirstLoadPending) View.VISIBLE else View.GONE
+                    recyclerView.visibility = View.VISIBLE
                     updateChannelsList()
                 }
             }
@@ -548,7 +555,13 @@ class GlobalSearchFragment : BaseFragment() {
         )
         val totalCount = searchController.totalChannelsForQuery(searchText)
         adapter.hasMore = filtered.size < totalCount
-        updateEmptyState(filtered.isEmpty())
+        val isEmpty = filtered.isEmpty()
+        if (channelsFirstLoadPending && isEmpty) {
+            emptyView.visibility = View.GONE
+            recyclerView.visibility = View.VISIBLE
+        } else {
+            updateEmptyState(isEmpty)
+        }
     }
 
     private fun updateMessagesList() {

--- a/app/src/main/java/com/mezon/mobile/ui/MezonToast.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/MezonToast.kt
@@ -1,0 +1,25 @@
+package com.mezon.mobile.ui
+
+import com.mezon.mobile.MainActivity
+import com.mezon.mobile.core.BaseFragment
+import com.mezon.mobile.ui.cells.ToastOverlay
+
+object MezonToast {
+
+    fun show(
+        fragment: BaseFragment,
+        type: ToastOverlay.ToastType,
+        message: String,
+        description: String? = null
+    ) {
+        val act = fragment.getParentActivity() as? MainActivity ?: return
+        val parent = fragment.getLayoutContainer()
+            ?: act.drawerLayoutContainer
+        ToastOverlay(act, act.themeColors).show(
+            parent,
+            type,
+            message,
+            description
+        )
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/ui/cells/InAppNotificationToastView.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/cells/InAppNotificationToastView.kt
@@ -1,0 +1,75 @@
+package com.mezon.mobile.ui.cells
+
+import android.content.Context
+import android.graphics.drawable.GradientDrawable
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.TextView
+import com.mezon.mobile.core.LayoutHelper
+import com.mezon.mobile.core.ThemeColors
+import com.mezon.mobile.ui.theme.ThemeMode
+
+class InAppNotificationToastView(
+    context: Context,
+    private val theme: ThemeColors
+) : LinearLayout(context) {
+
+    private val titleView: TextView
+    private val bodyView: TextView
+
+    init {
+        orientation = VERTICAL
+        elevation = LayoutHelper.dpf(8f)
+        val bg = GradientDrawable().apply {
+            setColor(theme.channelPanelBg)
+            cornerRadius = LayoutHelper.dpf(16f)
+            setStroke(LayoutHelper.dp(2), theme.primary)
+        }
+        background = bg
+        setPadding(0, 0, 0, 0)
+        isClickable = true
+        val contentPad = LayoutHelper.dp(10)
+        val textBlock = LinearLayout(context).apply {
+            orientation = VERTICAL
+            setPadding(contentPad, contentPad, contentPad, contentPad)
+        }
+        titleView = TextView(context).apply {
+            setTextColor(
+                if (theme.resolvedMode == ThemeMode.LIGHT) theme.onSurface else 0xFFFFFFFF.toInt()
+            )
+            textSize = 15f
+            setTypeface(typeface, android.graphics.Typeface.BOLD)
+        }
+        bodyView = TextView(context).apply {
+            setTextColor(theme.textStrong)
+            textSize = 14f
+            maxLines = 3
+        }
+        textBlock.addView(
+            titleView,
+            LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+        )
+        textBlock.addView(
+            bodyView,
+            LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+        )
+        addView(
+            textBlock,
+            LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+        )
+    }
+
+    fun updateContent(title: String, body: String) {
+        titleView.text = title
+        bodyView.text = body
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/ui/cells/SearchTabHeader.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/cells/SearchTabHeader.kt
@@ -107,7 +107,9 @@ class SearchTabHeader(context: Context, private val theme: ThemeColors) : Linear
                 count > 0 -> " ($count)"
                 else -> ""
             }
-            labelView.text = "$tabLabel$countText"
+            val newText = "$tabLabel$countText"
+            if (newText == labelView.text.toString()) return
+            labelView.text = newText
         }
 
         fun setActive(active: Boolean) {

--- a/app/src/main/java/com/mezon/mobile/ui/cells/ToastOverlay.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/cells/ToastOverlay.kt
@@ -6,12 +6,14 @@ import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.RectF
+import android.graphics.drawable.Drawable
 import android.os.Handler
 import android.os.Looper
 import android.text.Layout
 import android.text.StaticLayout
 import android.text.TextPaint
 import android.text.TextUtils
+import com.mezon.mobile.MainActivity
 import android.view.Gravity
 import android.view.MotionEvent
 import android.view.View
@@ -25,11 +27,54 @@ class ToastOverlay(context: Context, private val theme: ThemeColors) : FrameLayo
 
     enum class ToastType { SUCCESS, ERROR, INFO, TOOLTIP }
 
+    companion object {
+        @Volatile
+        private var visibleInstance: ToastOverlay? = null
+
+        @JvmStatic
+        fun hideVisible() {
+            visibleInstance?.let { o ->
+                o.handler.removeCallbacksAndMessages(null)
+                if (o.childCount > 0) {
+                    o.getChildAt(0).animate().cancel()
+                }
+                o.removeAllViews()
+                (o.parent as? ViewGroup)?.removeView(o)
+            }
+            visibleInstance = null
+        }
+
+        @JvmStatic
+        fun showInAppNotification(
+            activity: MainActivity,
+            parent: ViewGroup = activity.drawerLayoutContainer,
+            title: String,
+            body: String,
+            durationMs: Long = 3000L,
+            onTap: (() -> Unit)? = null
+        ) {
+            val current = visibleInstance
+            if (current != null && current.parent != null && current.childCount == 1) {
+                val inApp = current.getChildAt(0) as? InAppNotificationToastView
+                if (inApp != null) {
+                    inApp.updateContent(title, body)
+                    current.rebindInAppFromNextNotification(parent, durationMs, onTap)
+                    return
+                }
+            }
+            hideVisible()
+            ToastOverlay(activity, activity.themeColors)
+                .attachInAppFirstShow(parent, title, body, durationMs, onTap)
+        }
+    }
+
     private val handler = Handler(Looper.getMainLooper())
 
     init {
         isClickable = false
         isFocusable = false
+        clipChildren = false
+        setWillNotDraw(true)
     }
 
     fun show(
@@ -41,6 +86,70 @@ class ToastOverlay(context: Context, private val theme: ThemeColors) : FrameLayo
         onTap: (() -> Unit)? = null
     ) {
         val toastView = ToastView(context, theme, type, title, description)
+        presentContent(parent, toastView, durationMs, onTap)
+    }
+
+    private fun attachInAppFirstShow(
+        parent: ViewGroup,
+        title: String,
+        body: String,
+        durationMs: Long,
+        onTap: (() -> Unit)?
+    ) {
+        val v = InAppNotificationToastView(context, theme)
+        v.updateContent(title, body)
+        presentContent(
+            parent = parent,
+            toastView = v,
+            durationMs = durationMs,
+            onTap = onTap,
+            evictVisibleFirst = false
+        )
+    }
+
+    private fun rebindInAppFromNextNotification(
+        parent: ViewGroup,
+        durationMs: Long,
+        onTap: (() -> Unit)?
+    ) {
+        if (this.parent == null) {
+            addSelfToParentWithOverlayLp(parent)
+        } else if (this.parent !== parent) {
+            (this.parent as? ViewGroup)?.removeView(this)
+            addSelfToParentWithOverlayLp(parent)
+        }
+        parent.bringChildToFront(this)
+        visibleInstance = this
+        if (childCount == 0) return
+        val toastView = getChildAt(0)
+        bindInAppNotificationInteraction(toastView, onTap)
+        scheduleInAppDismiss(durationMs)
+    }
+
+    private fun addSelfToParentWithOverlayLp(parent: ViewGroup) {
+        val overlayLp = LayoutParams(
+            LayoutParams.MATCH_PARENT,
+            LayoutParams.WRAP_CONTENT,
+            Gravity.TOP
+        )
+        parent.addView(this, overlayLp)
+    }
+
+    private fun scheduleInAppDismiss(durationMs: Long) {
+        handler.removeCallbacksAndMessages(null)
+        handler.postDelayed({ dismiss() }, durationMs)
+    }
+
+    private fun presentContent(
+        parent: ViewGroup,
+        toastView: View,
+        durationMs: Long,
+        onTap: (() -> Unit)?,
+        evictVisibleFirst: Boolean = true
+    ) {
+        if (evictVisibleFirst) {
+            ToastOverlay.hideVisible()
+        }
         val statusBarHeight = AndroidUtilities.statusBarHeight
         val lp = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT).apply {
             gravity = Gravity.TOP or Gravity.CENTER_HORIZONTAL
@@ -53,10 +162,23 @@ class ToastOverlay(context: Context, private val theme: ThemeColors) : FrameLayo
         addView(toastView, lp)
 
         if (this.parent == null) {
-            val overlayLp = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
-            parent.addView(this, overlayLp)
+            addSelfToParentWithOverlayLp(parent)
         }
+        visibleInstance = this
+        bindInAppNotificationInteraction(toastView, onTap)
+        if (toastView is InAppNotificationToastView) {
+            scheduleInAppDismiss(durationMs)
+        }
+        toastView.translationY = -LayoutHelper.dpf(80f)
+        toastView.alpha = 0f
+        toastView.animate().translationY(0f).alpha(1f).setDuration(250).start()
+        if (toastView !is InAppNotificationToastView) {
+            handler.removeCallbacksAndMessages(null)
+            handler.postDelayed({ dismiss() }, durationMs)
+        }
+    }
 
+    private fun bindInAppNotificationInteraction(toastView: View, onTap: (() -> Unit)?) {
         if (onTap != null) {
             toastView.isClickable = true
             toastView.setOnClickListener {
@@ -64,8 +186,10 @@ class ToastOverlay(context: Context, private val theme: ThemeColors) : FrameLayo
                 dismiss()
                 onTap()
             }
+        } else {
+            toastView.setOnClickListener(null)
+            toastView.isClickable = true
         }
-
         var startY = 0f
         toastView.setOnTouchListener { _, ev ->
             when (ev.action) {
@@ -80,12 +204,6 @@ class ToastOverlay(context: Context, private val theme: ThemeColors) : FrameLayo
             }
             false
         }
-
-        toastView.translationY = -LayoutHelper.dpf(80f)
-        toastView.alpha = 0f
-        toastView.animate().translationY(0f).alpha(1f).setDuration(250).start()
-
-        handler.postDelayed({ dismiss() }, durationMs)
     }
 
     private fun dismiss() {
@@ -93,6 +211,9 @@ class ToastOverlay(context: Context, private val theme: ThemeColors) : FrameLayo
         view?.animate()?.translationY(-LayoutHelper.dpf(80f))?.alpha(0f)?.setDuration(250)
             ?.setListener(object : AnimatorListenerAdapter() {
                 override fun onAnimationEnd(animation: Animator) {
+                    if (visibleInstance === this@ToastOverlay) {
+                        visibleInstance = null
+                    }
                     removeAllViews()
                     (this@ToastOverlay.parent as? ViewGroup)?.removeView(this@ToastOverlay)
                 }
@@ -108,9 +229,11 @@ class ToastOverlay(context: Context, private val theme: ThemeColors) : FrameLayo
     ) : View(context) {
 
         private val description: String? = description?.replace('\n', ' ')?.replace('\r', ' ')
-        private var lastBuildWidth = 0
+        private var lastTextWidth = -1
 
         private val bgPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+        private val bubblePaint = Paint(Paint.ANTI_ALIAS_FLAG)
+        private val iconBgPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = 0xFFFFFFFF.toInt() }
         private val titlePaint = TextPaint(Paint.ANTI_ALIAS_FLAG).apply {
             textSize = LayoutHelper.sp(14f)
             color = android.graphics.Color.BLACK
@@ -123,68 +246,174 @@ class ToastOverlay(context: Context, private val theme: ThemeColors) : FrameLayo
         private val rect = RectF()
         private var titleLayout: StaticLayout? = null
         private var descLayout: StaticLayout? = null
-        private val radius = LayoutHelper.dpf(16f)
-        private val padH = LayoutHelper.dp(16)
-        private val padV = LayoutHelper.dp(12)
+        private val cornerRadius = LayoutHelper.dpf(20f)
+        private val minHeight = LayoutHelper.dp(60)
+        private val padLeading = LayoutHelper.dp(20)
+        private val padEnd = LayoutHelper.dp(20)
+        private val iconColumn = LayoutHelper.dp(32)
+        private val iconSize = LayoutHelper.dp(20)
+        private val iconTextGap = LayoutHelper.dp(12)
+        private val rowPadV = LayoutHelper.dp(12)
 
-        private val bgColor: Int get() = when (type) {
-            ToastType.SUCCESS -> 0xFFB6E1C6.toInt()
-            ToastType.ERROR -> 0xFFEFC3CA.toInt()
-            ToastType.INFO -> 0xFFB6D4E1.toInt()
-            ToastType.TOOLTIP -> theme.surfaceVariant
+        private val leadingDrawable: Drawable = when (type) {
+            ToastType.ERROR -> MezonIcon.circleExlaimionIcon.getDrawable(
+                context,
+                theme.error
+            )
+            else -> MezonIcon.checkmarkLargeIcon.getDrawable(
+                context,
+                theme.success
+            )
+        }
+
+        private val bgColor: Int
+            get() = when (type) {
+                ToastType.SUCCESS -> 0xFFB6E1C6.toInt()
+                ToastType.ERROR -> 0xFFEFC3CA.toInt()
+                ToastType.INFO -> 0xFFB6E1C6.toInt()
+                ToastType.TOOLTIP -> theme.secondaryLight
+            }
+
+        private val bubbleTints: Int
+            get() = when (type) {
+                ToastType.ERROR -> 0xFFE69CA0.toInt()
+                else -> 0xFF90DDB1.toInt()
+            }
+
+        init {
+            if (type == ToastType.TOOLTIP) {
+                titlePaint.color = theme.textStrong
+            }
+        }
+
+        private fun textBlockWidth(w: Int): Int {
+            if (type == ToastType.TOOLTIP) {
+                return (w - padLeading * 2).coerceAtLeast(0)
+            }
+            return (w - padLeading - iconColumn - iconTextGap - padEnd).coerceAtLeast(0)
+        }
+
+        private fun rebuildLayouts(textWidth: Int) {
+            if (textWidth <= 0) {
+                titleLayout = null
+                descLayout = null
+                return
+            }
+            if (type == ToastType.TOOLTIP) {
+                val line = if (title.isNotEmpty()) title else description.orEmpty()
+                titleLayout = StaticLayout.Builder
+                    .obtain(line, 0, line.length, titlePaint, textWidth)
+                    .setAlignment(Layout.Alignment.ALIGN_NORMAL)
+                    .setMaxLines(2)
+                    .setEllipsize(TextUtils.TruncateAt.END)
+                    .build()
+                descLayout = null
+                return
+            }
+            titleLayout = StaticLayout.Builder
+                .obtain(title, 0, title.length, titlePaint, textWidth)
+                .setAlignment(Layout.Alignment.ALIGN_NORMAL)
+                .setMaxLines(1)
+                .setEllipsize(TextUtils.TruncateAt.END)
+                .build()
+
+            descLayout = description?.let { d ->
+                StaticLayout.Builder
+                    .obtain(d, 0, d.length, descPaint, textWidth)
+                    .setAlignment(Layout.Alignment.ALIGN_NORMAL)
+                    .setMaxLines(2)
+                    .setEllipsize(TextUtils.TruncateAt.END)
+                    .build()
+            }
         }
 
         override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
             val w = MeasureSpec.getSize(widthMeasureSpec)
-            val textWidth = w - padH * 2
-
-            if (textWidth > 0 && textWidth != lastBuildWidth) {
-                lastBuildWidth = textWidth
-                titleLayout = StaticLayout.Builder
-                    .obtain(title, 0, title.length, titlePaint, textWidth)
-                    .setAlignment(Layout.Alignment.ALIGN_NORMAL)
-                    .setMaxLines(1)
-                    .setEllipsize(TextUtils.TruncateAt.END)
-                    .build()
-
-                descLayout = description?.let { d ->
-                    StaticLayout.Builder
-                        .obtain(d, 0, d.length, descPaint, textWidth)
-                        .setAlignment(Layout.Alignment.ALIGN_NORMAL)
-                        .setMaxLines(2)
-                        .setEllipsize(TextUtils.TruncateAt.END)
-                        .build()
-                }
+            val textW = textBlockWidth(w)
+            if (textW != lastTextWidth) {
+                lastTextWidth = textW
+                rebuildLayouts(textW)
             }
-
-            var h = padV
-            titleLayout?.let { h += it.height }
-            descLayout?.let { h += it.height + LayoutHelper.dp(4) }
-            h += padV
-
+            var textH = 0
+            titleLayout?.let { textH += it.height }
+            descLayout?.let { textH += it.height + LayoutHelper.dp(4) }
+            var h = if (type == ToastType.TOOLTIP) {
+                rowPadV * 2 + textH
+            } else {
+                maxOf(minHeight, rowPadV * 2 + textH, iconColumn)
+            }
+            h = h.coerceAtLeast(minHeight)
             setMeasuredDimension(w, h)
         }
 
         override fun onDraw(canvas: Canvas) {
-            rect.set(0f, 0f, width.toFloat(), height.toFloat())
+            val w = width.toFloat()
+            val h = height.toFloat()
+            rect.set(0f, 0f, w, h)
             bgPaint.color = bgColor
-            canvas.drawRoundRect(rect, radius, radius, bgPaint)
+            canvas.drawRoundRect(rect, cornerRadius, cornerRadius, bgPaint)
+            if (type != ToastType.TOOLTIP) {
+                bubblePaint.color = bubbleTints
+                val r1 = LayoutHelper.dpf(30f)
+                canvas.drawCircle(r1, r1, r1, bubblePaint)
+                val r2 = LayoutHelper.dpf(15f)
+                canvas.drawCircle(padLeading + r2, h - r2, r2, bubblePaint)
+                val r3 = LayoutHelper.dpf(5f)
+                canvas.drawCircle(w - LayoutHelper.dpf(40f), h - r3, r3, bubblePaint)
+            }
 
-            var top = padV.toFloat()
-            titleLayout?.let {
-                canvas.save()
-                canvas.translate(padH.toFloat(), top)
-                it.draw(canvas)
-                canvas.restore()
-                top += it.height
+            if (type == ToastType.TOOLTIP) {
+                val top = (h - (titleLayout?.height ?: 0)) / 2f
+                titleLayout?.let { layout ->
+                    canvas.save()
+                    canvas.translate(padLeading.toFloat(), top)
+                    layout.draw(canvas)
+                    canvas.restore()
+                }
+                return
             }
-            descLayout?.let {
-                top += LayoutHelper.dp(4)
+
+            val iconTop = (h - iconColumn) / 2f
+            val iconCenterX = padLeading + iconColumn / 2f
+            val iconCenterY = iconTop + iconColumn / 2f
+            val iconR = iconColumn / 2f
+            canvas.drawCircle(iconCenterX, iconCenterY, iconR, iconBgPaint)
+            MezonIcon.drawIcon(
+                canvas,
+                leadingDrawable,
+                iconCenterX.toInt(),
+                iconCenterY.toInt(),
+                iconSize
+            )
+
+            var textY = (h - textContentHeight()) / 2f
+            titleLayout?.let { layout ->
                 canvas.save()
-                canvas.translate(padH.toFloat(), top)
-                it.draw(canvas)
+                canvas.translate(
+                    (padLeading + iconColumn + iconTextGap).toFloat(),
+                    textY
+                )
+                layout.draw(canvas)
+                canvas.restore()
+                textY += layout.height
+            }
+            descLayout?.let { layout ->
+                textY += LayoutHelper.dp(4)
+                canvas.save()
+                canvas.translate(
+                    (padLeading + iconColumn + iconTextGap).toFloat(),
+                    textY
+                )
+                layout.draw(canvas)
                 canvas.restore()
             }
+        }
+
+        private fun textContentHeight(): Float {
+            var t = 0f
+            titleLayout?.let { t += it.height }
+            descLayout?.let { t += it.height + LayoutHelper.dp(4) }
+            return t
         }
     }
 }

--- a/app/src/main/java/com/mezon/mobile/util/MessageContentParser.kt
+++ b/app/src/main/java/com/mezon/mobile/util/MessageContentParser.kt
@@ -33,6 +33,34 @@ private val BASE_IMG: String
     get() = com.mezon.mobile.BuildConfig.MEZON_BASE_IMG_URL
 private const val EMOJI_SIZE_DP = 20
 
+private val VALID_LINK_INVITE_REGEX =
+    Regex("""https?://(?:www\.)?(?:mezon\.ai|gw\.mezon\.ai)/invite/[0-9]+""", RegexOption.IGNORE_CASE)
+private val INVITE_ID_FROM_TEXT =
+    Regex("""https?://(?:www\.)?(?:mezon\.ai|gw\.mezon\.ai)/invite/([0-9]+)""", RegexOption.IGNORE_CASE)
+
+fun contentHasNonEmptyLinkArray(content: String): Boolean {
+    return try {
+        val obj = JSONObject(content)
+        val lk = obj.optJSONArray("lk")
+        if (lk != null && lk.length() > 0) return true
+        val mk = obj.optJSONArray("mk") ?: return false
+        for (i in 0 until mk.length()) {
+            val item = mk.optJSONObject(i) ?: continue
+            if (item.optString("type", "") == "lk") return true
+        }
+        false
+    } catch (_: Exception) {
+        false
+    }
+}
+
+fun parseInviteLinkMessageId(content: String): Long? {
+    if (!contentHasNonEmptyLinkArray(content)) return null
+    val t = parseContentText(content)
+    if (!VALID_LINK_INVITE_REGEX.containsMatchIn(t)) return null
+    return INVITE_ID_FROM_TEXT.find(t)?.groupValues?.getOrNull(1)?.toLongOrNull()
+}
+
 private fun SpannableStringBuilder.setExclusiveSpan(what: Any, start: Int, end: Int) {
     if (end > start) setSpan(what, start, end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
 }

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -514,6 +514,12 @@
     <string name="discover_explore_communities">Khám phá cộng đồng</string>
     <string name="discover_members">Thành viên</string>
     <string name="discover_verified">Đã xác minh</string>
+    <string name="clan_link_invite_title">MỜI THAM GIA CLAN</string>
+    <string name="clan_link_invite_join">Tham gia</string>
+    <string name="clan_link_invite_invalid_title">Lời mời không hợp lệ</string>
+    <string name="clan_link_invite_invalid_message">Hãy thử gửi một lời mời khác!</string>
+    <string name="clan_link_invite_channel_prefix"># %1$s</string>
+    <string name="clan_link_invite_unknown_clan">Clan không xác định</string>
     <string name="discover_join_clan">Tham gia clan</string>
     <string name="discover_join_failed">Không thể tham gia clan này.</string>
     <string name="discover_how_chatty">Năng động thế nào?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -662,6 +662,12 @@
     <string name="discover_explore_communities">Explore communities</string>
     <string name="discover_members">Members</string>
     <string name="discover_verified">Verified</string>
+    <string name="clan_link_invite_title">INVITE TO JOIN A CLAN</string>
+    <string name="clan_link_invite_join">Join</string>
+    <string name="clan_link_invite_invalid_title">Invalid Invite</string>
+    <string name="clan_link_invite_invalid_message">Try sending a new invite!</string>
+    <string name="clan_link_invite_channel_prefix"># %1$s</string>
+    <string name="clan_link_invite_unknown_clan">Unknown clan</string>
     <string name="discover_join_clan">Join Clan</string>
     <string name="discover_join_failed">Could not join this clan.</string>
     <string name="discover_how_chatty">How chatty?</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,8 @@ livekit = "2.24.0"
 cameraX = "1.4.1"
 zxing = "3.5.3"
 bouncyCastle = "1.78.1"
+photoView = "2.3.0"
+appcompat = "1.7.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -62,6 +64,8 @@ androidx-camera-camera2 = { group = "androidx.camera", name = "camera-camera2", 
 androidx-camera-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "cameraX" }
 androidx-camera-view = { group = "androidx.camera", name = "camera-view", version.ref = "cameraX" }
 zxing-core = { group = "com.google.zxing", name = "core", version.ref = "zxing" }
+photoview = { group = "com.github.chrisbanes", name = "PhotoView", version.ref = "photoView" }
+androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
- Add LinkInviteBlock + gateway preview API; parse invite URLs in messages
- Replace system Toasts with MezonToast; in-app FCM toast via ToastOverlay
- ChatController reaction dedup after API; BottomSheet dismiss guard
- PhotoViewer + PhotoView; release minify/shrink + ProGuard rules
- GlobalSearch channels first-load UX; request code collision fixes