### PR TITLE
Docs: add docs and mcp servers to support ai coding agents

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "fadcat": {
+      "type": "stdio",
+      "command": "fadcat",
+      "args": ["--mcp"],
+      "env": { "PYTHONUNBUFFERED": "1" }
+    },
+    "android-mcp": {
+      "command": "uvx",
+      "args": [
+        "--python",
+        "3.13",
+        "android-mcp"
+      ]
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,10 @@ mmn-client-kotlin/build
 .idea/
 
 build/
+
+# AI agents
+.claude/skills/
+.claude/rules/
+
+.cursor/skills/
+.cursor/rules/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "fadcat": {
+      "type": "stdio",
+      "command": "fadcat",
+      "args": ["--mcp"],
+      "env": { "PYTHONUNBUFFERED": "1" }
+    },
+    "android-mcp": {
+      "command": "uvx",
+      "args": [
+        "--python",
+        "3.13",
+        "android-mcp"
+      ]
+    }
+  }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,234 @@
+# Mezon Android — Architecture
+
+This document describes how the production app is structured: modules, layers, navigation, data flow, and the main extension points. It reflects the codebase under `app/src/main/java/com/mezon/mobile/`.
+
+## High-level characteristics
+
+- **Telegram-style client**: Primary UI is custom `View` / `ViewGroup` (not Jetpack Compose for core chat chrome). Screens are `BaseFragment` subclasses managed by `ActionBarLayout` inside `MainActivity`, not the Navigation Component graph as the main shell.
+- **Controller-centric state**: Domain and chat state live in Hilt `@Singleton` **controllers** with in-memory caches (`LongSparseArray`, lists, maps). **MVVM + per-screen `StateFlow` is not** the primary pattern for main surfaces.
+- **Push-based UI updates**: Controllers emit **integer-keyed events** through `NotificationCenter`; fragments **observe** those IDs and refresh adapters or cells.
+- **Dual path to persistence**: Network and WebSocket update controllers; **Room** stores a bounded/local projection. Writes to SQLite run off the main thread (`@IoDispatcher`); UI notifications are marshaled to the main thread.
+
+---
+
+## Gradle modules
+
+| Module | Role |
+|--------|------|
+| `:app` | Android application: UI, controllers, DI, Room, networking glue. |
+| `:core-proto` | Protobuf-generated **lite** Kotlin/Java for REST (`com.mezon.mezon.api.*`) and realtime (`com.mezon.mezon.rtapi.*`). Proto inputs are symlinked from the shared protocol repo (see `core-proto/build.gradle.kts`). |
+| `:mmn-client-kotlin` | Additional Kotlin client library (included from root `settings.gradle.kts`). |
+
+Root project name: **Mezon** (`settings.gradle.kts`).
+
+---
+
+## App entry and process lifecycle
+
+- **`MezonApplication`** (`MezonApplication.kt`): `@HiltAndroidApp`; triggers Room warmup when a session exists; seeds `StartupCache` from DataStore for splash/theme/locale hints.
+- **`MainActivity`** (`MainActivity.kt`): `@AndroidEntryPoint`; hosts **`ActionBarLayout`**, **`DrawerLayoutContainer`**, session/theme/locale wiring, connection state, deep links, and voice overlay. Implements `INavigationLayout.INavigationLayoutDelegate` and observes `NotificationCenter` for app-level events.
+- **`MainTabsActivity`** and other activities: Secondary entry points (e.g. tab shell); fragments receive `inject(context)` from the hosting layout/activity when pushed.
+
+---
+
+## Layered view
+
+```mermaid
+flowchart TB
+  subgraph ui [Presentation]
+    BF[BaseFragment]
+    BC[BaseCell / custom Views]
+    TC[ThemeColors]
+    ABL[ActionBarLayout]
+  end
+  subgraph bus [Events]
+    NC[NotificationCenter]
+  end
+  subgraph domain [Domain services]
+    CTR[Controllers ChatController DialogsController ...]
+    SES[SessionManager ThemeManager LocaleManager]
+  end
+  subgraph net [Network]
+    API[MezonApi]
+    WS[MezonSocket]
+    SED[SocketEventDispatcher]
+    ACT[ApiCacheTracker]
+  end
+  subgraph data [Persistence]
+    DB[(MezonDatabase Room)]
+    DS[DataStore Preferences]
+  end
+  WS --> SED
+  SED --> CTR
+  API --> CTR
+  CTR --> NC
+  CTR --> DB
+  CTR --> DS
+  NC --> BF
+  BF --> BC
+  TC --> BC
+  BF --> TC
+  ABL --> BF
+```
+
+---
+
+## Presentation layer
+
+### `BaseFragment` (`core/BaseFragment.kt`)
+
+- **Not** `androidx.fragment.app.Fragment`. It is an abstract screen unit with its own lifecycle hooks (`onFragmentCreate`, `createView`, `onFragmentDestroy`).
+- **Hilt**: Subclasses override `onInject(FragmentEntryPoint)` and use `entryPoint()` after the host has called **`inject(context)`** (see `ActionBarLayout`, `MainActivity`, `MainTabsActivity`).
+- **`NotificationCenter`**: `observe(eventId) { … }` and `observeGlobal(eventId) { … }` register delegates; `onFragmentDestroy` removes them to avoid leaks.
+- **Chrome**: `wrapWithActionBar(title, content)` builds a vertical `LinearLayout` with `ActionBarView` and subscribes the bar to `NotificationCenter.themeChanged`.
+
+### Custom cells and lists
+
+- **`BaseCell`** (`core/BaseCell.kt`): Base type for dense, list-style rows; handles long-press/haptics, optional **RenderNode** caching (`drawCached`, `allowCaching`, `forceNotCacheNextFrame`, `updatedContent`).
+- **`ThemeColors`** (`core/ThemeColors.kt`): `@Singleton` holder of shared `TextPaint` / `Paint` and palette indices; avoids per-frame allocations in `onDraw`.
+- **`LayoutHelper`** (`core/LayoutHelper.kt`): `dp` / `sp` and linear/frame helpers used across fragments and cells.
+- Additional reusable widgets live under `ui/cells/`; feature-specific views live next to their feature packages.
+
+### Navigation
+
+- **Stack**: `ActionBarLayout` pushes/pops `BaseFragment` instances and forwards lifecycle; `INavigationLayout` abstracts the container.
+- **Routing**: Some `NavRoutes` / intents exist for specific flows; the **main chat/clan experience** is still stack-based over `BaseFragment`.
+
+---
+
+## Domain layer — controllers
+
+Controllers are **`@Singleton`** types injected via Hilt. They typically:
+
+- Own **mutable in-memory caches** synchronized where needed.
+- Call **`MezonApi`** for REST (protobuf Kotlin DSL request builders from `:core-proto`).
+- Subscribe to **`SocketEventDispatcher`** `SharedFlow`s (see `ChatController` `init` blocks).
+- Read/write **Room** via DAOs on **`@IoDispatcher`**.
+- Post **`NotificationCenter.postNotificationOnMainThread`** (or related helpers) after state changes that the UI should reflect.
+
+Representative types (non-exhaustive):
+
+- **Chat & dialogs**: `ChatController`, `DialogsController`, `MessagesController`, `PinMessageController`, …
+- **Clans & channels**: `ClansController`, `ChannelController`, `UserClanController`, `ChannelAppController`, …
+- **Profile & social**: `UserController`, `AccountController`, `FriendController`, `DeviceController`, …
+- **Realtime extras**: `VoiceController`, `ConnectionController`, `EmojiController`, …
+
+**`FragmentEntryPoint`** (`di/FragmentEntryPoint.kt`) is the **narrow API** from `BaseFragment` subclasses to these singletons (and dispatchers/scopes), keeping fragments free of constructor injection.
+
+---
+
+## Event bus — `NotificationCenter` (`core/NotificationCenter.kt`)
+
+- **Per-account instances**: `NotificationCenter.getInstance(account)` with `MAX_ACCOUNT_COUNT = 4`.
+- **Global bus**: `NotificationCenter.getGlobalInstance()` for cross-account or app-global signals.
+- **Event IDs**: `companion object` values assigned via `nextId()` (monotonic integers). Examples include `messagesDidLoad`, `messageDidUpdate`, `dialogsNeedReload`, `themeChanged`, `connectionStateChanged`, etc.
+- **Observers**: Implement `NotificationCenterDelegate.didReceivedNotification(id, account, vararg args)`; UI code registers with `addObserver` (wrapped by `BaseFragment.observe`).
+
+New features should **add one new ID per logical event** in this companion rather than reusing unrelated IDs with ad-hoc payloads.
+
+---
+
+## Data persistence
+
+### Room (`data/db/`)
+
+- **`MezonDatabase`**: WAL journal mode (`DatabaseModule`), version and entities defined in `MezonDatabase.kt`.
+- **Entities** (current): `MessageEntity`, `DirectMessage`, `ClanEntity`, `ClanChannelEntity`, `NotificationEntity`, `FavoriteChannelEntity`, `ChannelAppEntity` (see `@Database` annotation).
+- **DAOs**: `MessageDao`, `DirectMessageDao`, `ClanDao`, `ClanChannelDao`, `NotificationDao`, `FavoriteChannelDao`, `ChannelAppDao` — exposed through `DatabaseModule` providers.
+
+Controllers are responsible for **bounded queries** (e.g. capped message windows per channel) where the product requires offline-first or fast cold display.
+
+### DataStore
+
+- **Session and preferences**: `AppModule` provides a `DataStore<Preferences>` (`mezon_session`). `SessionManager` and related types own token, API base URL, and user-visible settings flows.
+
+---
+
+## Network layer
+
+### REST — `MezonApi` (`network/MezonApi.kt`)
+
+- Large façade over generated **`com.mezon.mezon.api.*`** types; methods take `apiUrl`, `token`, and proto builders.
+- Callers typically run inside `SessionManager.withAutoRefresh` or equivalent session-aware coroutine boundaries.
+
+### WebSocket — `MezonSocket` (`network/MezonSocket.kt`)
+
+- OkHttp **WebSocket**; protobuf **`Envelope`** framing with `com.mezon.mezon.rtapi.*` payloads.
+- Handles reconnect, heartbeats, join/leave chat/clan, and outbound helpers (`channelMessageSend`, `markAsRead`, voice/WebRTC forwarding, etc.).
+
+### `SocketEventDispatcher` (`network/SocketEventDispatcher.kt`)
+
+- **`@Singleton`** demultiplexer: parses inbound `Envelope` traffic from `MezonSocket` and exposes **typed `SharedFlow`s** (`channelMessages`, `typingEvents`, `messageReactions`, `lastSeenMessageEvents`, …).
+- **Controllers must not** re-parse raw envelopes for event types already exposed here — collect the appropriate flow under `@ApplicationScope` to avoid duplicate logic.
+
+### `ApiCacheTracker` (`network/ApiCacheTracker.kt`)
+
+- Coalesces **duplicate REST** attempts in hot paths (pattern integrated in controllers such as `ChatController.loadMessages`). Prefer extending this mechanism over one-off process-wide caches that fight eviction rules.
+
+### Other
+
+- **`NetworkMonitor`**: Connectivity signals for offline-first branches.
+- **Ktor `HttpClient`**: Provided in `AppModule` for components that use Ktor (alongside OkHttp for WebSocket).
+
+---
+
+## Dependency injection (Hilt)
+
+| Piece | Location |
+|-------|----------|
+| Application | `MezonApplication` — `@HiltAndroidApp` |
+| Singleton module | `di/AppModule.kt` — dispatchers, `@ApplicationScope`, DataStore, `NotificationCenter.getInstance(0)`, OkHttp, Ktor client |
+| Database | `di/DatabaseModule.kt` — `MezonDatabase`, DAOs |
+| Qualifiers | `di/CoroutineDispatchers.kt` — `@IoDispatcher`, `@MainDispatcher`; `@ApplicationScope` scope type |
+| Fragment access | `di/FragmentEntryPoint.kt` — explicit accessors for controllers and dispatchers |
+
+**Note:** `provideNotificationCenter()` binds account **0** for default Hilt injection; multi-account code paths use `NotificationCenter.getInstance(account)` directly where needed.
+
+---
+
+## Session, theme, and locale
+
+- **`SessionManager`**: Auth session, API URL, token refresh; surfaces `Flow`s consumed by controllers and UI gates.
+- **`ThemeManager`** / **`ThemeColors`**: Theme mode resolution; `NotificationCenter.themeChanged` notifies fragments and action bars.
+- **`LocaleManager`**: Language configuration; coordinates with `NotificationCenter.languageChanged` where applicable.
+- **`AutoNightConfig`**: Scheduled night theme behavior (wired from `MainActivity`).
+
+---
+
+## Authentication and push
+
+- **`auth/`**: Login/OTP fragments (`LoginFragment`, `OTPVerificationFragment`) and **`AuthRepository`** for credential exchange; still integrated with `BaseFragment` + stack navigation.
+- **`notification/`**: FCM (`MezonFirebaseService`), **`FcmRepository`**, and in-app notification helpers (`NotificationHelper`) alongside `NotificationStore` / `NotificationEntity` persistence.
+
+---
+
+## How to extend the app safely
+
+1. **New screen**: Add a `BaseFragment` subclass, implement `onInject`, register `observe` in `onFragmentCreate`, build hierarchy in `createView`; use `wrapWithActionBar` when you need standard top chrome.
+2. **New feature state**: Prefer a **`@Singleton` controller** (or extend an existing one), add **Room** only if persistence is required, expose **`NotificationCenter`** events for UI.
+3. **New realtime behavior**: Extend **`SocketEventDispatcher`** and **`MezonSocket`** only if a new envelope type needs parsing; otherwise consume existing flows from a controller.
+4. **New REST surface**: Add/extend **`MezonApi`** methods aligned with `:core-proto` generated types; respect **`ApiCacheTracker`** for list-heavy endpoints.
+
+For AI-assisted edits, the repository also maintains **Cursor/Claude rules** and **skills** (data flow, UI, naming) that restate constraints for agents; this document is the human-readable map of the same architecture.
+
+---
+
+## Directory map (abbreviated)
+
+```
+com.mezon.mobile/
+├── MainActivity.kt, MezonApplication.kt
+├── auth/
+├── core/           # BaseFragment, BaseCell, ActionBarLayout, NotificationCenter, ThemeColors, LayoutHelper, …
+├── data/db/        # Room database, DAOs, entities declared on database
+├── di/             # Hilt modules, FragmentEntryPoint, qualifiers
+├── home/           # Chat, clans, dialogs, voice, wallet, profile, friends, … + *Controller.kt
+├── network/        # MezonApi, MezonSocket, SocketEventDispatcher, ApiCacheTracker, …
+├── notification/
+├── session/        # SessionManager, ThemeManager, LocaleManager, …
+├── ui/             # Shared cells, theme helpers
+├── util/
+└── wallet/
+```
+
+Generated API types are referenced as **`com.mezon.mezon.api.*`** (REST) and **`com.mezon.mezon.rtapi.*`** (realtime) from the `:core-proto` module.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to Mezon Android
+
+This guide describes **who does what**, how we expect **human** and **AI-assisted** changes to land, and where to read before touching the codebase.
+
+---
+
+## Roles
+
+### Maintainers
+
+- Set direction for larger refactors, protocol bumps, and release readiness.
+- Review merge requests for correctness, architecture fit, and risk on **chat, realtime, and persistence** paths.
+- Keep shared docs ([Architecture](./ARCHITECTURE.md), [MCP](./MCP.md), README) consistent with reality.
+
+### Contributors (engineers)
+
+- Ship **focused** changes: one concern per merge request when practical.
+- Follow existing patterns in the same package (controllers, `NotificationCenter`, `BaseFragment`, `BaseCell`, Room).
+- Run a **debug build** (and relevant tests) before requesting review; note gaps if the environment is incomplete (e.g. missing `google-services.json`).
+- Do **not** commit secrets, `local.properties`, or generated paths that are machine-specific. See [README.MD](../README.MD) for Firebase and `mezon.secrets.properties`.
+
+## Suggested workflow
+
+1. **Branch** from the integration branch your team uses (e.g. `main` or `develop`).
+2. **Implement** with small, reviewable commits and clear messages.
+3. **Open a merge request** with:
+   - What changed and **why** (plain language).
+   - How to test (screens, flows, or `./gradlew` commands).
+   - Known limitations (e.g. protocol symlink not updated, feature flag).
+4. **Respond to review** with follow-up commits or comments; avoid force-push noise unless your team standard says otherwise.
+
+---
+
+## Build and checks
+
+From the repository root (see [README.MD — Build and test](../README.MD#build-and-test)):
+
+```bash
+./gradlew assembleDebug
+./gradlew test
+```
+
+Fix compile and lint issues introduced by your change. If CI differs from local results, note that in the MR.
+
+---
+
+## Documentation and AI artifacts
+
+- User-facing or technical doc updates belong in **`docs/`** when they help the whole team (you may be asked to add a short note when behavior changes).
+- **Cursor rules** (`.cursor/rules/`) and **agent skills** (`.claude/skills/`) are optional but should stay **aligned** with [ARCHITECTURE.md](./ARCHITECTURE.md) when you change conventions; avoid duplicating long prose in three places unless necessary.
+
+---
+
+## Getting help
+
+- Architecture and layering: [ARCHITECTURE.md](./ARCHITECTURE.md).
+- Local setup and protos: [README.MD](../README.MD).
+- Editor MCP (debug/automation): [MCP.md](./MCP.md).
+
+For product or API semantics, follow your team’s channel for Mezon protocol and backend contracts.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,234 @@
+# MCP servers
+
+This repo can use [Model Context Protocol](https://modelcontextprotocol.io/) servers while working in **Cursor**, **[Claude Code](https://code.claude.com/docs/en/mcp)**, or any other MCP-capable client:
+
+| Server | Purpose |
+|--------|---------|
+| **[FadCat](https://github.com/anonfaded/FadCat)** | Logcat, device listing, log search/analysis, FadCam media tooling, performance helpers — debugging-oriented. |
+| **[android-mcp](https://github.com/CursorTouch/Android-MCP)** | UI automation via **ADB** + **uiautomator2** (tap, swipe, type, device state, notifications) — device control like a user. |
+
+The checked-in **Cursor** project config lives at **[`.cursor/mcp.json`](../.cursor/mcp.json)**. **Claude Code** does not read that file; it uses **[`.mcp.json`](#claude-code)** at the repository root (project scope) or **`~/.claude.json`** (user/local scope). After installing the binaries below, restart the IDE or MCP connections as needed.
+
+---
+
+## Shared prerequisites
+
+1. **Android device or emulator** — API level in line with the app (Android **10+** for `android-mcp` per upstream).
+2. **USB debugging** (physical device) or running emulator — accept the **RSA fingerprint** prompt when `adb` connects.
+3. **`adb` on `PATH`** — from Android SDK platform-tools. Verify:
+
+   ```bash
+   adb version
+   adb devices
+   ```
+
+   You should see at least one device in `device` state (not `unauthorized`). If stuck: `adb kill-server && adb start-server`, reconnect cable, retry.
+
+FadCat can use a **bundled ADB** on supported installs; `android-mcp` still expects a working ADB/uiautomator2 setup for automation.
+
+---
+
+## FadCat — install and setup
+
+FadCat runs an **stdio MCP server** with:
+
+```bash
+fadcat --mcp
+```
+
+### Install the `fadcat` command
+
+1. **Recommended:** install from the **[GitHub releases](https://github.com/anonfaded/FadCat/releases)** for your OS (macOS / Linux / Windows). Use the packaged build so the `fadcat` CLI is registered.
+2. **From source (developers):** clone [FadCat](https://github.com/anonfaded/FadCat), then:
+
+   ```bash
+   pip3 install -r requirements.txt
+   python3 FadCat.py
+   ```
+
+   For MCP without the GUI entrypoint, follow FadCat’s “Local Dev” MCP snippet using `python3 -m src.mcp` and `PYTHONPATH` pointing at the repo — see their README **MCP Setup (IDE)**.
+
+3. Confirm the CLI is visible to Cursor’s environment:
+
+   ```bash
+   which fadcat
+   fadcat --mcp
+   ```
+
+   (The second command starts the server; it will appear to “hang” — that is normal for stdio MCP; stop with Ctrl+C when testing manually.)
+
+### Cursor / MCP config
+
+Use the same shape as [`.cursor/mcp.json`](../.cursor/mcp.json):
+
+```json
+{
+  "mcpServers": {
+    "fadcat": {
+      "type": "stdio",
+      "command": "fadcat",
+      "args": ["--mcp"],
+      "env": { "PYTHONUNBUFFERED": "1" }
+    }
+  }
+}
+```
+
+- **`PYTHONUNBUFFERED`**: avoids buffered stdout breaking the MCP stdio protocol.
+- If `fadcat` is not on the default PATH Cursor inherits, set `"command"` to an **absolute path** to the executable.
+
+**Docs:** [FadCat README — MCP Setup](https://github.com/anonfaded/FadCat#-_-mcp-setup-ide)
+
+---
+
+## Android-MCP — install and setup
+
+[Android-MCP](https://pypi.org/project/android-mcp/) is published on PyPI. It declares **Python ≥ 3.13** and depends on **uiautomator2** (and related libraries).
+
+### 1. Install `uv` (recommended) or use `pipx`
+
+The project config uses **`uvx`** so a global `pip install` is not required:
+
+```bash
+# macOS / Linux (example — see https://docs.astral.sh/uv/getting-started/installation/)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Verify:
+
+```bash
+uvx --version
+```
+
+### 2. One-shot run (what Cursor runs)
+
+This matches [`.cursor/mcp.json`](../.cursor/mcp.json):
+
+```bash
+uvx --python 3.13 android-mcp
+```
+
+The first time, `uvx` downloads Python 3.13 (if needed) and the `android-mcp` package into its cache.
+
+### 3. Device automation prerequisites (uiautomator2)
+
+Upstream expects **uiautomator2** on the device side. If tools fail to control the UI, open the **[Android-MCP repository](https://github.com/CursorTouch/Android-MCP)** and follow their **Installation** / **Getting Started** (clone + `uv sync` path, or `uiautomator2` init steps) until `adb devices` shows your device and their quick tests pass.
+
+Typical checklist:
+
+- Emulator or device with **developer options** + **USB debugging**.
+- `adb devices` shows `device`.
+- Run any **ATX/uiautomator2** init command their README specifies (often required once per device).
+
+### Cursor / MCP config
+
+```json
+{
+  "mcpServers": {
+    "android-mcp": {
+      "command": "uvx",
+      "args": [
+        "--python",
+        "3.13",
+        "android-mcp"
+      ]
+    }
+  }
+}
+```
+
+If `uvx` is not on PATH inside Cursor, replace `"command"` with the absolute path from `which uvx`.
+
+**Security note:** this server can drive the real device UI. Prefer **emulators** or **non-production** devices when letting agents execute tool calls.
+
+---
+
+## Enabling MCP in Cursor
+
+1. **Project-level:** keep [`.cursor/mcp.json`](../.cursor/mcp.json) at the repo root (already committed here).
+2. **User-level:** Cursor also supports global MCP settings in the app; use the same `mcpServers` JSON if you want these servers available in every workspace.
+3. After edits, **restart Cursor** or use the command palette action to refresh MCP connections (wording may vary by version).
+4. In the MCP panel, confirm **fadcat** and **android-mcp** show as connected; if not, open the log output and fix `command not found`, Python, or ADB errors.
+
+---
+
+## Claude Code
+
+[Claude Code](https://code.claude.com/) stores MCP servers separately from **Claude Desktop** (`claude_desktop_config.json` on macOS under `~/Library/Application Support/Claude/`, etc.). For this CLI/editor flow, use **project** `.mcp.json`, **`claude mcp`**, or entries in **`~/.claude.json`**, per the [official MCP docs](https://code.claude.com/docs/en/mcp).
+
+### Project file: `.mcp.json`
+
+Add a **`.mcp.json`** file at the **repository root** (same level as `app/`) so everyone on the team can share the same definitions. The format matches the `mcpServers` object you use elsewhere:
+
+```json
+{
+  "mcpServers": {
+    "fadcat": {
+      "type": "stdio",
+      "command": "fadcat",
+      "args": ["--mcp"],
+      "env": { "PYTHONUNBUFFERED": "1" }
+    },
+    "android-mcp": {
+      "command": "uvx",
+      "args": ["--python", "3.13", "android-mcp"]
+    }
+  }
+}
+```
+
+- Claude Code may **prompt for approval** the first time it loads project-scoped servers. To reset those choices: `claude mcp reset-project-choices`.
+- You can use **`${VAR}`** / **`${VAR:-default}`** in `command`, `args`, and `env` for machine-specific paths (see [env expansion](https://code.claude.com/docs/en/mcp#environment-variable-expansion-in-mcpjson)).
+
+Optional: keep this file in git next to [`.cursor/mcp.json`](../.cursor/mcp.json) so Cursor and Claude Code stay aligned (two entries to update when paths change).
+
+### CLI: `claude mcp add` (stdio, project scope)
+
+From the repo root, after [installing Claude Code](https://code.claude.com/docs/en/setup):
+
+```bash
+# FadCat — options must come before the server name; `--` separates the spawn command
+claude mcp add --transport stdio --scope project --env PYTHONUNBUFFERED=1 fadcat -- fadcat --mcp
+
+# android-mcp via uvx
+claude mcp add --transport stdio --scope project android-mcp -- uvx --python 3.13 android-mcp
+```
+
+Manage and debug:
+
+```bash
+claude mcp list
+claude mcp get fadcat
+```
+
+Inside an active Claude Code session, use the **`/mcp`** command to inspect server status and authentication.
+
+**User-wide servers** (all projects): use `--scope user` instead of `project`; configuration is merged into **`~/.claude.json`**, not `.mcp.json`.
+
+### Settings reference
+
+- Claude Code settings overview: [https://code.claude.com/docs/en/settings](https://code.claude.com/docs/en/settings)
+- MCP configuration (scopes, transports, examples): [https://code.claude.com/docs/en/mcp](https://code.claude.com/docs/en/mcp)
+
+---
+
+## Quick troubleshooting
+
+| Symptom | What to check |
+|--------|----------------|
+| `fadcat: command not found` | Install from releases or add the install dir to PATH; use full path in `mcp.json`. |
+| FadCat MCP hangs or no tools | Ensure `type: "stdio"`, `args: ["--mcp"]`, and `PYTHONUNBUFFERED=1`. |
+| `uvx` not found | Install [uv](https://docs.astral.sh/uv/); restart terminal/Cursor. |
+| android-mcp import or Python errors | PyPI requires **Python 3.13+**; align `--python 3.13` with an installed runtime. |
+| Device offline / unauthorized | Cable, authorize debugging, `adb kill-server && adb start-server`. |
+| Taps do nothing | Complete **uiautomator2** / ATX setup per [Android-MCP](https://github.com/CursorTouch/Android-MCP); disable overlays blocking accessibility if needed. |
+| Claude Code ignores MCP | Use **`.mcp.json`** at repo root or `~/.claude.json`, not Claude Desktop’s `claude_desktop_config.json`. Run `claude mcp list` from the project. Approve project servers if prompted; try `claude mcp reset-project-choices` if stuck. |
+
+---
+
+## References
+
+- FadCat: [https://github.com/anonfaded/FadCat](https://github.com/anonfaded/FadCat)
+- Android-MCP: [https://github.com/CursorTouch/Android-MCP](https://github.com/CursorTouch/Android-MCP) · [PyPI `android-mcp`](https://pypi.org/project/android-mcp/)
+- Cursor MCP: [https://docs.cursor.com](https://docs.cursor.com) (MCP / context section)
+- Claude Code MCP: [https://code.claude.com/docs/en/mcp](https://code.claude.com/docs/en/mcp)


### PR DESCRIPTION
### What's my change?
- Add docs to support ai coding agents
- Add mcp servers to support provide context to read debug log and execute test command on android device

### Testing
- This image are showing the ai agent to reading logcat log from **Android Studio** via Fadcat
<img width="1256" height="1006" alt="fadcat-mcp" src="https://github.com/user-attachments/assets/39c552c1-a858-43d2-a34f-6bbf3473491b" />

- This image are showing the ai agent to reading screen content of **Virtual Android Device** via Android-MCP
<img width="1010" height="1005" alt="android-mcp" src="https://github.com/user-attachments/assets/1f0394fb-8227-4241-bf6b-c19677ffe1c7" />

- This video are showing the ai agent is interacting on screen of **Virtual Android Device** via Android-MCP

https://github.com/user-attachments/assets/1c55148d-2ace-4081-ac24-244943e1699c