### PR TITLE
update: fech message via API when press FCM

### DIFF
--- a/app/src/main/java/com/mezon/mobile/MainActivity.kt
+++ b/app/src/main/java/com/mezon/mobile/MainActivity.kt
@@ -833,7 +833,8 @@ class MainActivity : BasePermissionsActivity(),
             channelType = routeMeta.channelType,
             messageId = messageId,
             isChannelPrivate = routeMeta.isPrivate,
-            parentId = routeMeta.parentId
+            parentId = routeMeta.parentId,
+            openedFromNotification = fromNotification
         )
         val params = INavigationLayout.NavigationParams(fragment)
             .setNoAnimation(noAnimation)

--- a/app/src/main/java/com/mezon/mobile/home/ChatController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChatController.kt
@@ -197,7 +197,12 @@ class ChatController @Inject constructor(
         }
     }
 
-    fun loadMessages(channelId: Long, clanId: Long, forceRefresh: Boolean = false) {
+    fun loadMessages(
+        channelId: Long,
+        clanId: Long,
+        forceRefresh: Boolean = false,
+        preferHttp: Boolean = false
+    ) {
         appScope.launch(ioDispatcher) {
             try {
                 val cacheKey = apiCacheKey("fetchMessages", clanId, channelId)
@@ -221,7 +226,12 @@ class ChatController @Inject constructor(
                 sessionManager.withAutoRefresh { session ->
                     val currentUserId = session.userId.toLongOrNull() ?: 0L
                     val response = api.listChannelMessages(
-                        session.apiUrl, session.token, channelId, clanId, limit = PAGE_SIZE
+                        session.apiUrl,
+                        session.token,
+                        channelId,
+                        clanId,
+                        limit = PAGE_SIZE,
+                        preferHttp = preferHttp
                     )
                     val allMessages = response.messagesList.map { it.toMessageEntity(currentUserId) }
                     val firstMessageReached = allMessages.any { it.code == MessageEntity.CODE_FIRST_MESSAGE }
@@ -257,7 +267,13 @@ class ChatController @Inject constructor(
         }
     }
 
-    fun loadMessagesAround(channelId: Long, clanId: Long, anchorMessageId: Long, requireExactAnchor: Boolean = false) {
+    fun loadMessagesAround(
+        channelId: Long,
+        clanId: Long,
+        anchorMessageId: Long,
+        requireExactAnchor: Boolean = false,
+        preferHttp: Boolean = false
+    ) {
         appScope.launch(ioDispatcher) {
             try {
                 val cacheKey = apiCacheKey("fetchMessages", clanId, channelId)
@@ -303,8 +319,14 @@ class ChatController @Inject constructor(
                 sessionManager.withAutoRefresh { session ->
                     val currentUserId = session.userId.toLongOrNull() ?: 0L
                     val response = api.listChannelMessages(
-                        session.apiUrl, session.token, channelId, clanId,
-                        anchorMessageId, DIRECTION_AROUND, PAGE_SIZE
+                        session.apiUrl,
+                        session.token,
+                        channelId,
+                        clanId,
+                        anchorMessageId,
+                        DIRECTION_AROUND,
+                        PAGE_SIZE,
+                        preferHttp = preferHttp
                     )
                     val allMsgs = response.messagesList.map { it.toMessageEntity(currentUserId) }
                     val firstMessageReached = allMsgs.any { it.code == MessageEntity.CODE_FIRST_MESSAGE }

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -151,6 +151,7 @@ class ChatFragment : BaseFragment() {
         private const val ARG_PARENT_ID = "parentId"
         private const val ARG_MESSAGE_ID = "message_id"
         private const val ARG_FORCE_LATEST = "force_latest"
+        private const val ARG_OPENED_FROM_NOTIFICATION = "opened_from_notification"
         private const val VIEWPORT_LIMIT = 300
         private const val PAGE_DOWN_SCROLL_THRESHOLD = 2
         private const val REQUEST_CODE_LOCATION_PERMISSION = 1002
@@ -179,7 +180,8 @@ class ChatFragment : BaseFragment() {
             messageId: Long = 0L,
             forceLatest: Boolean = false,
             isChannelPrivate: Boolean = false,
-            parentId: Long = 0L
+            parentId: Long = 0L,
+            openedFromNotification: Boolean = false
         ): ChatFragment = ChatFragment().apply {
             arguments = Bundle().apply {
                 putLong(ARG_CHANNEL_ID, channelId)
@@ -190,6 +192,7 @@ class ChatFragment : BaseFragment() {
                 if (parentId != 0L) putLong(ARG_PARENT_ID, parentId)
                 if (messageId != 0L) putLong(ARG_MESSAGE_ID, messageId)
                 if (forceLatest) putBoolean(ARG_FORCE_LATEST, true)
+                if (openedFromNotification) putBoolean(ARG_OPENED_FROM_NOTIFICATION, true)
             }
         }
     }
@@ -255,6 +258,7 @@ class ChatFragment : BaseFragment() {
     private var routeChannelPrivate = false
     private var routeParentId = 0L
     private var forceLatest = false
+    private var openedFromNotification = false
     private var startLoadFromMessageId = 0L
     private var startLoadFromMessageOffset = Int.MAX_VALUE
     private var pausedOnLastMessage = false
@@ -372,6 +376,7 @@ class ChatFragment : BaseFragment() {
         routeChannelPrivate = arguments?.getBoolean(ARG_CHANNEL_PRIVATE) ?: false
         routeParentId = arguments?.getLong(ARG_PARENT_ID) ?: 0L
         forceLatest = arguments?.getBoolean(ARG_FORCE_LATEST) ?: false
+        openedFromNotification = arguments?.getBoolean(ARG_OPENED_FROM_NOTIFICATION) ?: false
         startLoadFromMessageId = 0L
         startLoadFromMessageOffset = Int.MAX_VALUE
         needScrollRestore = false
@@ -963,7 +968,7 @@ class ChatFragment : BaseFragment() {
         observe(NotificationCenter.appDidReconnect) { _, _, _ ->
             if (isPaused) return@observe
             Log.d(TAG, "appDidReconnect: reloading messages for channel $channelId")
-            chatController.loadMessages(channelId, clanId, forceRefresh = true)
+            chatController.loadMessages(channelId, clanId, forceRefresh = true, preferHttp = false)
         }
 
         observe(NotificationCenter.scrollToBottomChat) { _, _, args ->
@@ -1030,11 +1035,7 @@ class ChatFragment : BaseFragment() {
         notificationCenter.addPostponeNotificationsCallback(postponeNewMessagesCallback)
 
         isLoading = true
-        if (forceLatest) {
-            chatController.loadMessages(channelId, clanId, forceRefresh = true)
-        } else {
-            chatController.loadMessages(channelId, clanId, forceRefresh = true)
-        }
+        chatController.loadMessages(channelId, clanId, forceRefresh = true, preferHttp = openedFromNotification)
         return true
     }
 
@@ -1901,7 +1902,7 @@ class ChatFragment : BaseFragment() {
         } else if (!isLoading) {
             isLoading = true
             showLoading()
-            chatController.loadMessages(channelId, clanId, forceRefresh = true)
+            chatController.loadMessages(channelId, clanId, forceRefresh = true, preferHttp = openedFromNotification)
         }
         mainHandler.post { refreshPollSnapshotsForStoredVotes() }
         startVisiblePollTallyRefreshLoop()
@@ -2461,7 +2462,7 @@ class ChatFragment : BaseFragment() {
             recyclerView.visibility = View.INVISIBLE
             firstLoad = true
             Log.d(TAG, "jumpToPresent: cleared list, calling loadMessages forceRefresh=true")
-            chatController.loadMessages(channelId, clanId, forceRefresh = true)
+            chatController.loadMessages(channelId, clanId, forceRefresh = true, preferHttp = false)
         }
     }
 
@@ -4863,7 +4864,13 @@ class ChatFragment : BaseFragment() {
         } else {
             Log.d(TAG, "Reply message $messageId not in list, calling loadMessagesAround")
             pendingHighlightMessageId = messageId
-            chatController.loadMessagesAround(channelId, clanId, messageId, requireExactAnchor = true)
+            chatController.loadMessagesAround(
+                channelId,
+                clanId,
+                messageId,
+                requireExactAnchor = true,
+                preferHttp = openedFromNotification
+            )
         }
     }
 

--- a/app/src/main/java/com/mezon/mobile/network/MezonApi.kt
+++ b/app/src/main/java/com/mezon/mobile/network/MezonApi.kt
@@ -407,9 +407,10 @@ class MezonApi @Inject constructor(
         apiUrl: String,
         token: String,
         method: String,
-        body: ByteArray
+        body: ByteArray,
+        preferHttp: Boolean = false
     ): ByteArray {
-        if (method in HTTP_ONLY_API_NAMES || method !in SOCKET_RPC_API_NAMES) {
+        if (preferHttp || method in HTTP_ONLY_API_NAMES || method !in SOCKET_RPC_API_NAMES) {
             return rpcOverHttp(apiUrl, token, method, body)
         }
         return try {
@@ -1373,7 +1374,8 @@ class MezonApi @Inject constructor(
         clanId: Long = 0L,
         messageId: Long = 0L,
         direction: Int = 0,
-        limit: Int = 50
+        limit: Int = 50,
+        preferHttp: Boolean = false
     ): ChannelMessageList {
         val request = listChannelMessagesRequest {
             this.channelId = channelId
@@ -1382,7 +1384,13 @@ class MezonApi @Inject constructor(
             if (direction != 0) this.direction = direction
             this.limit = limit
         }
-        val bytes = rpc(apiUrl, token, "ListChannelMessages", request.toByteArray())
+        val bytes = rpc(
+            apiUrl,
+            token,
+            "ListChannelMessages",
+            request.toByteArray(),
+            preferHttp = preferHttp
+        )
         val result = ChannelMessageList.parseFrom(bytes)
         return result
     }


### PR DESCRIPTION
**DESCRIPTION**

- Opening chat from a push notification can be slow or fail if `ListChannelMessages` still prefers the WebSocket while the socket is not ready yet.
- Normal entry (in-app navigation) is unchanged: we still try the socket first when allowed.
- This is addressed by:

1. `MezonApi.rpc()` can force HTTP when `preferHttp == true`, bypassing the socket path for whitelisted methods.
2. `openChat(..., fromNotification = true)` passes `openedFromNotification` into `ChatFragment`.
3. Initial fetches (`loadMessages`, and `loadMessagesAround` when needed) pass `preferHttp = true`, so `ListChannelMessages` goes over HTTP and does not wait on the socket.

---

**SELF TEST**

1. Cold start → tap FCM push → correct channel opens and messages load.
2. Open the same chat from inside the app (no notification path) → messages load; no regression.
3. After entering from a notification → scroll to load older/newer messages still works.
4. (Optional) Logs/proxy: first fetch from the notification path shows `POST .../mezon.api.Mezon/ListChannelMessages` (HTTP), not socket RPC.