### PR TITLE
fix(network): recover socket RPC after transport timeouts

### DIFF
--- a/app/src/main/java/com/mezon/mobile/network/MezonApi.kt
+++ b/app/src/main/java/com/mezon/mobile/network/MezonApi.kt
@@ -155,6 +155,7 @@ import kotlinx.coroutines.CompletableDeferred
 import java.io.IOException
 import java.security.MessageDigest
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 import javax.inject.Singleton
 class UnauthorizedException(message: String) : RuntimeException(message)
@@ -292,7 +293,8 @@ class MezonApi @Inject constructor(
     companion object {
         private val SERVER_KEY = BuildConfig.MEZON_API_KEY
         private const val DISCOVER_ITEMS_PER_PAGE = 6
-        private const val SOCKET_WAIT_MS = 30_000L
+        private const val SOCKET_WAIT_MS = 5_000L
+        private const val MAX_CONSECUTIVE_SOCKET_TIMEOUTS = 3
         private const val READ_SINGLE_FLIGHT_MAX_AGE_MS = 3_000L
         private val HTTP_RETRY_DELAYS_MS = longArrayOf(300L, 900L)
         private val HTTP_ONLY_API_NAMES = setOf(
@@ -340,6 +342,8 @@ class MezonApi @Inject constructor(
 
     private val linkInvitePreviewCache = android.util.LruCache<Long, LinkInvitePreview>(256)
     private val inFlightReadRpcs = ConcurrentHashMap<String, InFlightReadRpc>()
+
+    private val consecutiveSocketTimeouts = AtomicInteger(0)
 
     private fun logRpcRequest(method: String, url: String) {
         if (!BuildConfig.DEBUG) return
@@ -495,7 +499,7 @@ class MezonApi @Inject constructor(
             return rpcOverHttpWithRetry(apiUrl, token, method, body, retryableRead)
         }
         return try {
-            rpcOverSocket(method, body)
+            rpcOverSocket(method, body, token)
         } catch (e: UnauthorizedException) {
             throw e
         } catch (e: SocketRpcServerException) {
@@ -541,12 +545,21 @@ class MezonApi @Inject constructor(
         return Base64.encodeToString(digest, Base64.NO_WRAP)
     }
 
-    private suspend fun rpcOverSocket(method: String, body: ByteArray): ByteArray {
+    private suspend fun rpcOverSocket(method: String, body: ByteArray, token: String): ByteArray {
         val socket = mezonSocketLazy.get()
         if (!socket.awaitConnected(SOCKET_WAIT_MS)) {
             throw SocketRpcTransportException(
                 "WebSocket unavailable for '$method'",
                 retryOverHttp = true
+            )
+        }
+        val sessionTokenFp = if (token.isEmpty()) "?" else token.takeLast(6)
+        val socketTokenFp = socket.socketTokenFingerprint
+        if (socketTokenFp != null && socketTokenFp != sessionTokenFp) {
+            sentryReporter.logRpcWarning(
+                method,
+                "socket",
+                "TOKEN_MISMATCH session=$sessionTokenFp socket=$socketTokenFp gen=${socket.connectGen}"
             )
         }
         val started = System.currentTimeMillis()
@@ -558,6 +571,7 @@ class MezonApi @Inject constructor(
                     "SOCKET ok method=$method respBytes=${resp.size} elapsedMs=${System.currentTimeMillis() - started}"
                 )
             }
+            consecutiveSocketTimeouts.set(0)
             return resp
         } catch (e: Exception) {
             Log.w(
@@ -568,13 +582,22 @@ class MezonApi @Inject constructor(
                 sentryReporter.logRpcFailure(method, "socket", e)
             }
             if (e is UnauthorizedException) {
+                consecutiveSocketTimeouts.set(0)
                 socket.forceReconnectForAuthFailure("Socket RPC unauthorized for '$method'")
                 throw e
             }
             if (e is SocketRpcServerException || e is IllegalArgumentException) {
+                consecutiveSocketTimeouts.set(0)
                 throw e
             }
             if (isSocketTransportFailure(e)) {
+                val streak = consecutiveSocketTimeouts.incrementAndGet()
+                if (streak >= MAX_CONSECUTIVE_SOCKET_TIMEOUTS) {
+                    consecutiveSocketTimeouts.set(0)
+                    socket.forceReconnect(
+                        "consecutive socket RPC transport failures=$streak (last method='$method')"
+                    )
+                }
                 throw SocketRpcTransportException(
                     "WebSocket transport failed for '$method': ${e.message}",
                     retryOverHttp = true,

--- a/app/src/main/java/com/mezon/mobile/network/MezonSocket.kt
+++ b/app/src/main/java/com/mezon/mobile/network/MezonSocket.kt
@@ -121,6 +121,14 @@ class MezonSocket @Inject constructor(
     @Volatile private var lastPongTimeoutAtMs = 0L
     private val totalReconnectAttempts = AtomicInteger(0)
 
+    @Volatile var connectGen: Int = 0
+        private set
+    @Volatile var socketTokenFingerprint: String? = null
+        private set
+
+    private fun tokenFp(token: String?): String =
+        if (token.isNullOrEmpty()) "?" else token.takeLast(6)
+
     private val connectLock = Any()
 
     private fun cancelReconnectHealthReset() {
@@ -207,6 +215,27 @@ class MezonSocket @Inject constructor(
             heartbeatJob?.cancel()
             cancelReconnectHealthReset()
             cancelAllPending("Auth failure reconnect")
+            if (!userDisconnected) scheduleReconnect()
+        }
+    }
+
+    fun forceReconnect(reason: String) {
+        if (userDisconnected) return
+        Log.w(TAG, "forceReconnect: $reason")
+        sentryReporter.logSocketWarning("force_reconnect", "reason=$reason gen=$connectGen")
+        val ws = webSocket
+        if (ws == null) {
+            if (currentWsUrl != null && currentToken != null) scheduleReconnect()
+            return
+        }
+        val safeReason = reason.take(100)
+        try {
+            ws.close(4000, safeReason)
+        } catch (_: Exception) {
+            _connectionState.value = ConnectionState.DISCONNECTED
+            heartbeatJob?.cancel()
+            cancelReconnectHealthReset()
+            cancelAllPending("Force reconnect")
             if (!userDisconnected) scheduleReconnect()
         }
     }
@@ -608,6 +637,8 @@ class MezonSocket @Inject constructor(
             webSocket?.close(1000, "Reconnecting")
             webSocket = null
             _connectionState.value = ConnectionState.CONNECTING
+            connectGen++
+            socketTokenFingerprint = tokenFp(token)
 
             val host = if (wsUrl.startsWith("ws://") || wsUrl.startsWith("wss://")) {
                 wsUrl


### PR DESCRIPTION
Shorten socket connect wait, detect token mismatch on the active socket, and force reconnect after consecutive transport failures before HTTP fallback.