### PR TITLE
fix(chat): restore id-based timeline and drop client embed form valid

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/ChatController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChatController.kt
@@ -37,6 +37,8 @@ import com.mezon.mobile.home.profile.UserController
 import com.mezon.mobile.session.SessionManager
 import com.mezon.mobile.BuildConfig
 import com.mezon.mobile.util.MENTION_HERE_USER_ID
+import com.mezon.mobile.util.MezonSnowflake
+import com.mezon.mobile.util.firstReferenceMessageId
 import com.mezon.mobile.util.SentryReporter
 import com.mezon.mobile.util.MentionData
 import com.mezon.mobile.util.buildTextContent
@@ -65,7 +67,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.withContext
-import java.util.concurrent.atomic.AtomicInteger
 
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -73,7 +74,6 @@ import javax.inject.Singleton
 private const val TAG = "ChatController"
 private const val MAX_FORWARD_COMMENT_CHARS = 2000
 private const val PAGE_SIZE = 50
-private const val LOCAL_PROVISIONAL_MESSAGE_ID_FLOOR = 4_611_686_018_427_387_904L
 private const val DIRECTION_AFTER = 1
 private const val DIRECTION_AROUND = 2
 const val LOAD_TYPE_INITIAL = 0
@@ -108,7 +108,6 @@ class ChatController @Inject constructor(
     private val initialFetchDone = HashSet<Long>()
     private val lastMessageByChannel = LongSparseArray<Long>()
     private val pendingTempMessageByChannel = LongSparseArray<Long>()
-    private val provisionalRealtimeMessageSeq = AtomicInteger(kotlin.random.Random.nextInt(1 shl 18))
 
     private fun isAnonymousSend(clanId: Long): Boolean =
         clanId != 0L && anonymousController.get().isAnonymous(clanId)
@@ -145,14 +144,23 @@ class ChatController @Inject constructor(
     fun getLastMessageId(channelId: Long): Long =
         synchronized(this) { lastMessageByChannel.get(channelId, 0L) }
 
-    private fun allocateProvisionalRealtimeMessageId(): Long {
-        val ms = System.currentTimeMillis()
-        val seq = provisionalRealtimeMessageSeq.incrementAndGet() and 0x3FFFF
-        return (ms shl 22) or seq.toLong()
+    private fun assignMissingMessageId(msg: ChannelMessage): ChannelMessage {
+        if (msg.messageId != 0L) return msg
+        val refId = firstReferenceMessageId(msg.content)
+        if (refId > 0L) {
+            synchronized(this) {
+                val lastKnown = lastMessageByChannel.get(msg.channelId, 0L)
+                var candidate = refId + 1L
+                if (candidate <= refId) candidate = MezonSnowflake.generate()
+                if (candidate <= lastKnown) candidate = lastKnown + 1L
+                return ChannelMessage.newBuilder(msg).setMessageId(candidate).build()
+            }
+        }
+        return ChannelMessage.newBuilder(msg).setMessageId(MezonSnowflake.generate()).build()
     }
 
     private fun MessageEntity.canAdvanceServerTimeline(): Boolean {
-        return id > 0L && !isUnreadDivider && !isEphemeral && !isLocalProvisionalMessageId(id)
+        return id > 0L && !isUnreadDivider && !isEphemeral && !isSending
     }
 
     private fun ChannelMessage.canAdvanceServerTimeline(): Boolean {
@@ -163,11 +171,7 @@ class ChatController @Inject constructor(
     }
 
     private fun ChannelMessageHeader.canAdvanceServerTimeline(): Boolean {
-        return id > 0L && !isLocalProvisionalMessageId(id)
-    }
-
-    private fun isLocalProvisionalMessageId(id: Long): Boolean {
-        return id >= LOCAL_PROVISIONAL_MESSAGE_ID_FLOOR
+        return id > 0L
     }
 
     private fun updateLastMessageByChannel(channelId: Long, messages: List<MessageEntity>, latestIdFromResponse: Long = 0L) {
@@ -177,8 +181,7 @@ class ChatController @Inject constructor(
             .maxOfOrNull { it.id }
         val newestId = fromServer ?: fromMessages ?: return
         synchronized(this) {
-            val current = lastMessageByChannel.get(channelId, 0L)
-            if (newestId > current || (isLocalProvisionalMessageId(current) && !isLocalProvisionalMessageId(newestId))) {
+            if (newestId > lastMessageByChannel.get(channelId, 0L)) {
                 lastMessageByChannel.put(channelId, newestId)
             }
         }
@@ -916,7 +919,7 @@ class ChatController @Inject constructor(
             val lastServerId = lastMessageByChannel.get(channelId, 0L)
             val lastTempId = pendingTempMessageByChannel.get(channelId, 0L)
             val baseId = maxOf(lastServerId, lastTempId)
-            val tempId = if (baseId > 0L) baseId + 1L else allocateProvisionalRealtimeMessageId()
+            val tempId = if (baseId > 0L) baseId + 1L else MezonSnowflake.generate()
             pendingTempMessageByChannel.put(channelId, tempId)
             return tempId
         }
@@ -1475,14 +1478,7 @@ class ChatController @Inject constructor(
             .first { it != null }?.userId?.toLongOrNull() ?: 0L
 
         socketEventDispatcher.channelMessages.collect { raw ->
-            val resolved = resolveEphemeralSender(raw, currentUserId)
-            val msg =
-                if (resolved.messageId == 0L) {
-                    val pid = allocateProvisionalRealtimeMessageId()
-                    ChannelMessage.newBuilder(resolved).setMessageId(pid).build()
-                } else {
-                    resolved
-                }
+            val msg = assignMissingMessageId(resolveEphemeralSender(raw, currentUserId))
             val entity = msg.toMessageEntity(currentUserId)
             if (BuildConfig.DEBUG) {
                 Log.d(

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -90,6 +90,7 @@ import com.mezon.mobile.MainActivity
 import com.mezon.mobile.network.CHANNEL_TYPE_THREAD
 import com.mezon.mobile.network.CHANNEL_TYPE_DM
 import com.mezon.mobile.network.CHANNEL_TYPE_GROUP
+import com.mezon.mobile.network.sanitizeServerMessageId as sanitizeProvisionalId
 import com.mezon.mobile.network.CHANNEL_TYPE_CHANNEL
 import com.mezon.mobile.network.MezonApi
 import com.mezon.mobile.session.SessionManager
@@ -108,7 +109,7 @@ import com.mezon.mobile.util.parseContentText
 import com.mezon.mobile.util.parseMarkdownAndStrip
 import com.mezon.mobile.util.restoreInputFromContent
 import com.mezon.mobile.util.resolveStickerSourceUrl
-import com.mezon.mobile.util.EmbedFormUtil
+import com.mezon.mobile.util.firstReferenceMessageId
 import com.mezon.mobile.core.SharedConfig
 import com.mezon.mobile.home.chat.poll.ChatPollBridge
 import com.mezon.mobile.home.chat.poll.ParsedPoll
@@ -133,11 +134,11 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import com.mezon.mobile.core.SizeNotifierFrameLayout
 import com.mezon.mobile.home.chat.emoji.EmojiView
+import com.mezon.mobile.util.EmbedFormUtil
 import java.util.concurrent.ConcurrentHashMap
 
 private const val TAG = "ChatFragment"
 private const val FORWARD_NEARBY_WINDOW_SECONDS = 10 * 60L
-private const val LOCAL_PROVISIONAL_MESSAGE_ID_FLOOR = 4_611_686_018_427_387_904L
 
 /** Soft realtime when BE does not push ChatUpdate for every poll vote — GetPoll on visible rows. */
 private const val POLL_TALLY_TICK_MS = 15_000L
@@ -175,7 +176,6 @@ class ChatFragment : BaseFragment() {
         private const val REQUEST_CALL_PERMISSIONS = 9002
         private const val MENU_DM_VOICE_CALL = 8801
         private const val DM_HEADER_CALL_ICON_DP = 22f
-        private val REFERENCE_REF_ID_REGEX = Regex("\"message_ref_id\"\\s*:\\s*\"?(\\d+)\"?")
 
         fun newInstance(
             channelId: Long,
@@ -396,8 +396,8 @@ class ChatFragment : BaseFragment() {
             lastSeenMessageId = ch?.lastSeenMessageId ?: 0L
             lastSentMessageId = ch?.lastSentMessageId ?: 0L
         }
-        lastSeenMessageId = sanitizeServerMessageId(lastSeenMessageId)
-        lastSentMessageId = sanitizeServerMessageId(lastSentMessageId)
+        lastSeenMessageId = sanitizeProvisionalId(lastSeenMessageId)
+        lastSentMessageId = sanitizeProvisionalId(lastSentMessageId)
         dividerSeenMessageId = lastSeenMessageId
         val isSeenUpToDate = lastSentMessageId == 0L || lastSeenMessageId >= lastSentMessageId
         hasUnread = !isSeenUpToDate && lastSeenMessageId != 0L
@@ -471,17 +471,17 @@ class ChatFragment : BaseFragment() {
                         newMessages.add(m)
                     }
                 }
-                sortMessagesForDisplay(newMessages)
+                sortMessagesByIdDesc(newMessages)
                 newRowsCount = newMessages.size
 
                 if (direction == 1) {
                     messages.addAll(newMessages)
-                    sortMessagesForDisplay(messages)
+                    sortMessagesByIdDesc(messages)
                     hasMoreTop = moreTop
                     trimViewportNewest()
                 } else {
                     messages.addAll(0, newMessages)
-                    sortMessagesForDisplay(messages)
+                    sortMessagesByIdDesc(messages)
                     val newestReadableId = newestReadStateMessageId()
                     hasMoreBottom = if (lastSentMessageId != 0L && newestReadableId != 0L) {
                         newestReadableId < lastSentMessageId
@@ -560,7 +560,7 @@ class ChatFragment : BaseFragment() {
                     messages.clear()
                     val all = ArrayList<MessageEntity>(messagesDict.size())
                     for (i in 0 until messagesDict.size()) all.add(messagesDict.valueAt(i))
-                    sortMessagesForDisplay(all)
+                    sortMessagesByIdDesc(all)
                     messages.addAll(all)
                     pruneEmbedFormState()
                 }
@@ -590,7 +590,7 @@ class ChatFragment : BaseFragment() {
                     messages.clear()
                     val all = ArrayList<MessageEntity>(messagesDict.size())
                     for (i in 0 until messagesDict.size()) all.add(messagesDict.valueAt(i))
-                    sortMessagesForDisplay(all)
+                    sortMessagesByIdDesc(all)
                     messages.addAll(all)
                     pruneEmbedFormState()
                     hasMoreTop = moreTop
@@ -830,23 +830,15 @@ class ChatFragment : BaseFragment() {
                 return@observe
             }
             messagesDict.put(entity.id, entity)
-            val insertIndex: Int
-            val embedResponseInsertIndex = referencedEmbedResponseInsertIndex(entity)
-            if (embedResponseInsertIndex >= 0) {
-                insertIndex = embedResponseInsertIndex
-                messages.add(insertIndex, entity)
-                if (BuildConfig.DEBUG) {
-                    Log.d(
-                        TAG,
-                        "didReceiveNewMessages anchored embed response id=${entity.id} " +
-                            "ref=${referencedMessageId(entity.content)} index=$insertIndex"
-                    )
-                }
-            } else {
-                val pos = messages.indexOfFirst { compareMessageForDisplay(entity, it) < 0 }
-                insertIndex = if (pos >= 0) pos else messages.size
-                messages.add(insertIndex, entity)
+            val insertIndex = insertIndexForMessage(entity)
+            if (referencedEmbedResponseInsertIndex(entity) >= 0 && BuildConfig.DEBUG) {
+                Log.d(
+                    TAG,
+                    "didReceiveNewMessages anchored embed response id=${entity.id} " +
+                        "ref=${referencedMessageId(entity.content)} index=$insertIndex"
+                )
             }
+            messages.add(insertIndex, entity)
             val trimmed = trimViewportOldest()
             if (fragmentView != null) {
                 if (messages.size == 1 || trimmed) {
@@ -2597,25 +2589,38 @@ class ChatFragment : BaseFragment() {
         val lm = recyclerView.layoutManager as? LinearLayoutManager ?: return
         val firstPos = lm.findFirstVisibleItemPosition()
         if (firstPos == RecyclerView.NO_POSITION) return
+        val lastPos = lm.findLastVisibleItemPosition()
 
-        val msgIndex = firstPos - adapter.messagesStartRow
-        val visibleMsg = if (msgIndex in messages.indices) {
+        val firstMsgIndex = firstPos - adapter.messagesStartRow
+        val rawLastMsgIndex = if (lastPos == RecyclerView.NO_POSITION) firstMsgIndex
+            else lastPos - adapter.messagesStartRow
+        val viewportStart = firstMsgIndex.coerceAtLeast(0)
+        val viewportEnd = rawLastMsgIndex.coerceAtMost(messages.size - 1)
+        val viewportInBounds = firstMsgIndex < messages.size && viewportEnd >= viewportStart
+
+        var candidateIndex = -1
+        val visibleMsg = if (viewportInBounds) {
             var candidate: MessageEntity? = null
-            var i = msgIndex
-            while (i < messages.size && candidate == null) {
+            var i = viewportStart
+            while (i <= viewportEnd && candidate == null) {
                 val msg = messages[i]
-                if (msg.canAdvanceReadState()) candidate = msg
+                if (msg.canAdvanceReadState()) {
+                    candidate = msg
+                    candidateIndex = i
+                }
                 i++
             }
             candidate
         } else {
-            newestReadStateMessage()
+            newestReadStateMessage()?.also { found ->
+                candidateIndex = messages.indexOf(found)
+            }
         } ?: return
         if (visibleMsg.id <= lastSeenMessageId) return
 
         lastSeenMessageId = visibleMsg.id
         val remaining = if (lastSentMessageId != 0L && visibleMsg.id < lastSentMessageId) {
-            messages.count { it.canAdvanceReadState() && it.id > visibleMsg.id }
+            countNewerReadable(candidateIndex, visibleMsg.id)
         } else {
             0
         }
@@ -3097,14 +3102,9 @@ class ChatFragment : BaseFragment() {
         return if (compact.length > 160) compact.take(160) + "..." else compact
     }
 
-    private fun referencedMessageId(content: String): Long {
-        if (!content.contains("\"references\"")) return 0L
-        return REFERENCE_REF_ID_REGEX.find(content)?.groupValues?.getOrNull(1)?.toLongOrNull() ?: 0L
-    }
+    private fun referencedMessageId(content: String): Long = firstReferenceMessageId(content)
 
-    private fun debugReferencedMessageId(content: String): Long {
-        return referencedMessageId(content)
-    }
+    private fun debugReferencedMessageId(content: String): Long = referencedMessageId(content)
 
     private fun referencedEmbedResponseInsertIndex(entity: MessageEntity): Int {
         val refId = referencedMessageId(entity.content)
@@ -3127,24 +3127,11 @@ class ChatFragment : BaseFragment() {
             !isUnreadDivider &&
             !isEphemeral &&
             !isSending &&
-            !isError &&
-            !isLocalProvisionalMessageId(id)
+            !isError
     }
 
-    private fun MessageEntity.needsTimestampDisplaySort(): Boolean {
-        return isEphemeral || isLocalProvisionalMessageId(id)
-    }
-
-    private fun compareMessageForDisplay(a: MessageEntity, b: MessageEntity): Int {
-        if (a.needsTimestampDisplaySort() || b.needsTimestampDisplaySort()) {
-            val timeCompare = b.timestampSeconds.compareTo(a.timestampSeconds)
-            if (timeCompare != 0) return timeCompare
-        }
-        return b.id.compareTo(a.id)
-    }
-
-    private fun sortMessagesForDisplay(list: MutableList<MessageEntity>) {
-        list.sortWith(::compareMessageForDisplay)
+    private fun sortMessagesByIdDesc(list: MutableList<MessageEntity>) {
+        list.sortByDescending { it.id }
     }
 
     private fun newestReadStateMessage(): MessageEntity? {
@@ -3155,12 +3142,22 @@ class ChatFragment : BaseFragment() {
         return newestReadStateMessage()?.id ?: 0L
     }
 
-    private fun isLocalProvisionalMessageId(id: Long): Boolean {
-        return id >= LOCAL_PROVISIONAL_MESSAGE_ID_FLOOR
+    private fun insertIndexForMessage(entity: MessageEntity): Int {
+        referencedEmbedResponseInsertIndex(entity).takeIf { it >= 0 }?.let { return it }
+        if (messages.isEmpty() || entity.id >= messages.first().id) return 0
+        val pos = messages.indexOfFirst { entity.id > it.id }
+        return if (pos >= 0) pos else messages.size
     }
 
-    private fun sanitizeServerMessageId(id: Long): Long {
-        return if (isLocalProvisionalMessageId(id)) 0L else id
+    private fun countNewerReadable(belowIndex: Int, threshold: Long): Int {
+        if (belowIndex <= 0) return 0
+        val upper = belowIndex.coerceAtMost(messages.size)
+        var count = 0
+        for (i in 0 until upper) {
+            val m = messages[i]
+            if (m.canAdvanceReadState() && m.id > threshold) count++
+        }
+        return count
     }
 
     private fun hasEmbedControlPayload(content: String): Boolean {
@@ -3168,9 +3165,31 @@ class ChatFragment : BaseFragment() {
     }
 
     private fun looksLikeEmbedActionResponse(content: String): Boolean {
-        return content.contains("\"references\"") &&
-            content.contains("\"message_id\":\"0\"") &&
-            content.contains("\"type\":\"pre\"")
+        if (!content.contains("\"references\"") ||
+            !content.contains("\"message_id\"") ||
+            !content.contains("\"type\":\"pre\"")
+        ) return false
+        return try {
+            val obj = org.json.JSONObject(content)
+            val refs = obj.optJSONArray("references") ?: return false
+            var hasZeroRef = false
+            for (i in 0 until refs.length()) {
+                val r = refs.optJSONObject(i) ?: continue
+                val mid = r.opt("message_id")
+                if (mid == "0" || mid == 0 || mid == 0L) {
+                    hasZeroRef = true
+                    break
+                }
+            }
+            if (!hasZeroRef) return false
+            val mk = obj.optJSONArray("mk") ?: return false
+            for (i in 0 until mk.length()) {
+                if (mk.optJSONObject(i)?.optString("type") == "pre") return true
+            }
+            false
+        } catch (_: Exception) {
+            false
+        }
     }
 
     private fun debugMessageAt(index: Int): String {

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
@@ -1841,6 +1841,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
                         }
                     }
                 }
+                pressedEmbedButtonHit = null
                 val data = ogpData
                 if (data != null && x >= ogpBlockLeft && x <= ogpBlockRight && y >= ogpBlockTop && y <= ogpBlockBottom) {
                     pressedOnOgp = true

--- a/app/src/main/java/com/mezon/mobile/home/messages/EmbedAnimationRuntime.kt
+++ b/app/src/main/java/com/mezon/mobile/home/messages/EmbedAnimationRuntime.kt
@@ -34,6 +34,7 @@ internal class EmbedAnimationRuntime(
 
     private var jsonCall: Call? = null
     private var bitmapLoad: MezonImageLoader.Cancellable? = null
+    @Volatile private var loadFailed: Boolean = false
 
     private val framesByKey = mutableMapOf<String, AtlasFrame>()
     private var atlasMetaW = 1
@@ -55,6 +56,7 @@ internal class EmbedAnimationRuntime(
         atlas = null
         memoLayouts = null
         memoContentW = -1
+        loadFailed = false
         synchronized(framesByKey) {
             framesByKey.clear()
         }
@@ -142,11 +144,15 @@ internal class EmbedAnimationRuntime(
     }
 
     fun startLoading(context: android.content.Context) {
+        if (loadFailed) return
         synchronized(framesByKey) {
             if (framesByKey.isNotEmpty()) return
         }
         if (jsonCall != null) return
-        val urlJson = spec.urlPosition.trim().ifEmpty { return }
+        val urlJson = spec.urlPosition.trim().ifEmpty {
+            loadFailed = true
+            return
+        }
         val req = Request.Builder().url(urlJson).build()
         val call = httpClient.newCall(req)
         jsonCall = call
@@ -154,6 +160,7 @@ internal class EmbedAnimationRuntime(
             override fun onFailure(call: Call, e: IOException) {
                 if (call != jsonCall) return
                 jsonCall = null
+                loadFailed = true
                 parent.post { invalidateIfAlive() }
             }
 
@@ -162,6 +169,7 @@ internal class EmbedAnimationRuntime(
                     if (call != jsonCall) return
                     jsonCall = null
                     val ok = ingestAtlasBody(response.body?.string())
+                    if (!ok) loadFailed = true
                     parent.post {
                         invalidateIfAlive()
                         if (ok) {
@@ -219,7 +227,10 @@ internal class EmbedAnimationRuntime(
         }
         val reqW = min(mw, 4096).coerceAtLeast(1)
         val reqH = min(mh, 4096).coerceAtLeast(1)
-        val urlBmp = spec.urlImage.trim().ifEmpty { return }
+        val urlBmp = spec.urlImage.trim().ifEmpty {
+            loadFailed = true
+            return
+        }
         bitmapLoad?.cancel()
         bitmapLoad = MezonImageLoader.getInstance(appContext).load(
             url = urlBmp,
@@ -236,6 +247,7 @@ internal class EmbedAnimationRuntime(
                 }
             },
             onError = {
+                loadFailed = true
                 parent.post { invalidateIfAlive() }
             },
         )
@@ -311,7 +323,7 @@ internal class EmbedAnimationRuntime(
         shimmer: ShimmerEffect,
         themeDarkEmbed: Boolean,
     ) {
-        parent.postInvalidateDelayed(32)
+        if (!loadFailed) parent.postInvalidateDelayed(32)
 
         val n = max(1, spec.pool.size)
         val gap = CELL_GAP_X.toFloat()

--- a/app/src/main/java/com/mezon/mobile/home/messages/EmbedMessage.kt
+++ b/app/src/main/java/com/mezon/mobile/home/messages/EmbedMessage.kt
@@ -28,8 +28,7 @@ import com.mezon.mobile.util.EmbedRadioSpec
 import com.mezon.mobile.util.EmbedSelectSpec
 import com.mezon.mobile.util.createImgproxyUrl
 import com.mezon.mobile.util.formatEmbedRichText
-import com.mezon.mobile.util.parseEmbedActionRows
-import com.mezon.mobile.util.parseEmbedDataList
+import com.mezon.mobile.util.parseEmbedPayload
 import okhttp3.OkHttpClient
 import kotlin.math.max
 import kotlin.math.min
@@ -204,6 +203,8 @@ class EmbedMessageRenderer(
 
     private var animationRuntimeGrid: List<List<EmbedAnimationRuntime>> = emptyList()
 
+    private val radioOptionHeightCache = HashMap<Long, Int>()
+
     fun containsTouch(x: Float, y: Float): Boolean {
         if (laidOutCards.isEmpty()) return false
         for (i in 0 until embedInteractiveGeometryCount) {
@@ -238,18 +239,17 @@ class EmbedMessageRenderer(
     }
 
     fun setDataFromContent(content: String): Boolean {
-        val hasEmbedPayload = content.contains("\"embed\"")
-        val hasComponentPayload = content.contains("\"components\"")
-        if (!hasEmbedPayload && !hasComponentPayload) {
+        if (!content.contains("\"embed\"") && !content.contains("\"components\"")) {
             clear()
             return false
         }
-        embedSourceList = if (hasEmbedPayload) parseEmbedDataList(content) else emptyList()
-        actionRows = if (hasComponentPayload) parseEmbedActionRows(content) else emptyList()
-        if (embedSourceList.isEmpty() && actionRows.isEmpty()) {
+        val payload = parseEmbedPayload(content)
+        if (payload.embeds.isEmpty() && payload.actionRows.isEmpty()) {
             clear()
             return false
         }
+        embedSourceList = payload.embeds
+        actionRows = payload.actionRows
         return true
     }
 
@@ -279,6 +279,7 @@ class EmbedMessageRenderer(
         laidOutCards = emptyList()
         actionRows = emptyList()
         disposeAnimationGrid()
+        radioOptionHeightCache.clear()
         syncCardImageBundles(0)
         laidOutButtons = emptyList()
         buttonsBlockHeight = 0
@@ -624,6 +625,7 @@ class EmbedMessageRenderer(
 
     fun rebuildLayouts(textWidth: Int, context: Context) {
         disposeAnimationGrid()
+        radioOptionHeightCache.clear()
         laidOutCards = emptyList()
         if (embedSourceList.isEmpty()) {
             syncCardImageBundles(0)
@@ -1027,6 +1029,8 @@ class EmbedMessageRenderer(
     }
 
     private fun embedRadioOptionHeight(o: EmbedRadioOptionSpec, colW: Int): Int {
+        val cacheKey = radioOptionCacheKey(o, colW)
+        radioOptionHeightCache[cacheKey]?.let { return it }
         val th = theme()
         var h = RADIO_ROW_PAD_TOP
         if (o.label.isNotEmpty()) {
@@ -1050,8 +1054,12 @@ class EmbedMessageRenderer(
         }
         h += RADIO_CONTROL_ROW_H
         h += RADIO_ROW_PAD_BOTTOM
+        radioOptionHeightCache[cacheKey] = h
         return h
     }
+
+    private fun radioOptionCacheKey(o: EmbedRadioOptionSpec, colW: Int): Long =
+        (o.hashCode().toLong() and 0xFFFFFFFFL) shl 32 or (colW.toLong() and 0xFFFFFFFFL)
 
     private fun buttonBackgroundColor(theme: ThemeColors, style: EmbedButtonStyle): Int = when (style) {
         EmbedButtonStyle.PRIMARY -> theme.primary

--- a/app/src/main/java/com/mezon/mobile/home/messages/EmbedSelectOptionSheet.kt
+++ b/app/src/main/java/com/mezon/mobile/home/messages/EmbedSelectOptionSheet.kt
@@ -230,7 +230,17 @@ object EmbedSelectOptionSheet {
             }
         }
 
-        search.onTextChanged = { buildOptionRows(it) }
+        val searchHandler = android.os.Handler(android.os.Looper.getMainLooper())
+        var pendingSearch: Runnable? = null
+        search.onTextChanged = { query ->
+            pendingSearch?.let { searchHandler.removeCallbacks(it) }
+            val r = Runnable { buildOptionRows(query) }
+            pendingSearch = r
+            searchHandler.postDelayed(r, SEARCH_DEBOUNCE_MS)
+        }
+        dialog.setOnDismissListener {
+            pendingSearch?.let { searchHandler.removeCallbacks(it) }
+        }
 
         contentColumn.addView(
             search,
@@ -279,6 +289,8 @@ object EmbedSelectOptionSheet {
         dialog.setCanceledOnTouchOutside(true)
         dialog.show()
     }
+
+    private const val SEARCH_DEBOUNCE_MS = 120L
 
     private fun sheetHeightPx(context: Context): Int {
         val h = when {

--- a/app/src/main/java/com/mezon/mobile/network/ProvisionalMessageId.kt
+++ b/app/src/main/java/com/mezon/mobile/network/ProvisionalMessageId.kt
@@ -1,8 +1,3 @@
 package com.mezon.mobile.network
 
-const val LOCAL_PROVISIONAL_MESSAGE_ID_FLOOR: Long = 4_611_686_018_427_387_904L
-
-fun isLocalProvisionalMessageId(id: Long): Boolean = id >= LOCAL_PROVISIONAL_MESSAGE_ID_FLOOR
-
-fun sanitizeServerMessageId(id: Long): Long =
-    if (isLocalProvisionalMessageId(id)) 0L else id
+fun sanitizeServerMessageId(id: Long): Long = if (id > 0L) id else 0L

--- a/app/src/main/java/com/mezon/mobile/util/ContentParser.kt
+++ b/app/src/main/java/com/mezon/mobile/util/ContentParser.kt
@@ -65,6 +65,13 @@ fun parseThreadInfoFromPlainText(text: String): ParsedThreadInfo? {
 fun isEmbedOrComponentsPayload(content: String): Boolean =
     content.contains("\"embed\"") || content.contains("\"components\"")
 
+private val REFERENCE_REF_ID_REGEX = Regex("\"message_ref_id\"\\s*:\\s*\"?(\\d+)\"?")
+
+fun firstReferenceMessageId(content: String): Long {
+    if (!content.contains("\"references\"")) return 0L
+    return REFERENCE_REF_ID_REGEX.find(content)?.groupValues?.getOrNull(1)?.toLongOrNull() ?: 0L
+}
+
 fun messageHasExplicitTextBody(content: String): Boolean {
     if (content.isBlank()) return false
     return try {

--- a/app/src/main/java/com/mezon/mobile/util/MessageContentParser.kt
+++ b/app/src/main/java/com/mezon/mobile/util/MessageContentParser.kt
@@ -904,37 +904,55 @@ data class EmbedComponentButton(
 
 data class EmbedActionRow(val buttons: List<EmbedComponentButton>)
 
-fun parseEmbedActionRows(content: String): List<EmbedActionRow> {
+data class EmbedPayload(
+    val embeds: List<EmbedData>,
+    val actionRows: List<EmbedActionRow>,
+)
+
+private val EMPTY_EMBED_PAYLOAD = EmbedPayload(emptyList(), emptyList())
+
+fun parseEmbedPayload(content: String): EmbedPayload {
+    if (content.isBlank()) return EMPTY_EMBED_PAYLOAD
     return try {
         val obj = JSONObject(content)
-        val rows = obj.optJSONArray("components") ?: return emptyList()
-        val out = mutableListOf<EmbedActionRow>()
-        for (r in 0 until rows.length()) {
-            val rowObj = rows.optJSONObject(r) ?: continue
-            val comps = rowObj.optJSONArray("components") ?: continue
-            val buttons = mutableListOf<EmbedComponentButton>()
-            for (c in 0 until comps.length()) {
-                val comp = comps.optJSONObject(c) ?: continue
-                if (comp.optInt("type", -1) != MESSAGE_COMPONENT_TYPE_BUTTON) continue
-                val id = comp.optString("id", "")
-                if (id.isEmpty()) continue
-                val inner = comp.optJSONObject("component") ?: continue
-                val label = inner.optString("label", "")
-                if (label.isEmpty()) continue
-                val url = inner.optString("url", "").takeIf { it.isNotEmpty() }
-                val style = EmbedButtonStyle.fromInt(inner.optInt("style", EmbedButtonStyle.PRIMARY.value))
-                val disabled = inner.optBoolean("disable", false) ||
-                    inner.optBoolean("disabled", false) ||
-                    inner.optBoolean("isDisabled", false)
-                buttons.add(EmbedComponentButton(id, label, url, style, disabled))
-            }
-            if (buttons.isNotEmpty()) out.add(EmbedActionRow(buttons))
-        }
-        out
+        val embeds = parseEmbedDataListFromObject(obj)
+        val rows = parseEmbedActionRowsFromObject(obj)
+        if (embeds.isEmpty() && rows.isEmpty()) EMPTY_EMBED_PAYLOAD
+        else EmbedPayload(embeds, rows)
     } catch (_: Exception) {
-        emptyList()
+        EMPTY_EMBED_PAYLOAD
     }
 }
+
+private fun parseEmbedActionRowsFromObject(obj: JSONObject): List<EmbedActionRow> {
+    val rows = obj.optJSONArray("components") ?: return emptyList()
+    val out = ArrayList<EmbedActionRow>(rows.length())
+    for (r in 0 until rows.length()) {
+        val rowObj = rows.optJSONObject(r) ?: continue
+        val comps = rowObj.optJSONArray("components") ?: continue
+        val buttons = ArrayList<EmbedComponentButton>(comps.length())
+        for (c in 0 until comps.length()) {
+            val comp = comps.optJSONObject(c) ?: continue
+            if (comp.optInt("type", -1) != MESSAGE_COMPONENT_TYPE_BUTTON) continue
+            val id = comp.optString("id", "")
+            if (id.isEmpty()) continue
+            val inner = comp.optJSONObject("component") ?: continue
+            val label = inner.optString("label", "")
+            if (label.isEmpty()) continue
+            val url = inner.optString("url", "").takeIf { it.isNotEmpty() }
+            val style = EmbedButtonStyle.fromInt(inner.optInt("style", EmbedButtonStyle.PRIMARY.value))
+            val disabled = inner.optBoolean("disable", false) ||
+                inner.optBoolean("disabled", false) ||
+                inner.optBoolean("isDisabled", false)
+            buttons.add(EmbedComponentButton(id, label, url, style, disabled))
+        }
+        if (buttons.isNotEmpty()) out.add(EmbedActionRow(buttons))
+    }
+    return out
+}
+
+fun parseEmbedActionRows(content: String): List<EmbedActionRow> =
+    parseEmbedPayload(content).actionRows
 
 private fun parseDiscordEmbedColor(embed: JSONObject, colorStr: String): Int {
     if (colorStr.isNotEmpty()) {
@@ -944,32 +962,32 @@ private fun parseDiscordEmbedColor(embed: JSONObject, colorStr: String): Int {
             } catch (_: Exception) {}
         } else {
             try {
-                return 0xFFFFFF and colorStr.toDouble().toInt()
+                return opaqueRgb(colorStr.toDouble().toInt())
             } catch (_: Exception) {}
         }
     }
     if (!embed.has("color") || embed.isNull("color")) return 0
     return try {
-        0xFFFFFF and embed.getDouble("color").toInt()
+        opaqueRgb(embed.getDouble("color").toInt())
     } catch (_: Exception) {
         0
     }
 }
 
-fun parseEmbedDataList(content: String): List<EmbedData> {
-    return try {
-        val obj = JSONObject(content)
-        val embeds = obj.optJSONArray("embed") ?: return emptyList()
-        val out = ArrayList<EmbedData>(embeds.length())
-        for (i in 0 until embeds.length()) {
-            val embed = embeds.optJSONObject(i) ?: continue
-            parseEmbedJsonObject(embed)?.let { out.add(it) }
-        }
-        out
-    } catch (_: Exception) {
-        emptyList()
+private fun opaqueRgb(raw: Int): Int = (raw and 0x00FFFFFF) or 0xFF000000.toInt()
+
+private fun parseEmbedDataListFromObject(obj: JSONObject): List<EmbedData> {
+    val embeds = obj.optJSONArray("embed") ?: return emptyList()
+    val out = ArrayList<EmbedData>(embeds.length())
+    for (i in 0 until embeds.length()) {
+        val embed = embeds.optJSONObject(i) ?: continue
+        parseEmbedJsonObject(embed)?.let { out.add(it) }
     }
+    return out
 }
+
+fun parseEmbedDataList(content: String): List<EmbedData> =
+    parseEmbedPayload(content).embeds
 
 fun parseEmbedData(content: String): EmbedData? = parseEmbedDataList(content).firstOrNull()
 

--- a/app/src/main/java/com/mezon/mobile/util/MezonSnowflake.kt
+++ b/app/src/main/java/com/mezon/mobile/util/MezonSnowflake.kt
@@ -1,0 +1,16 @@
+package com.mezon.mobile.util
+
+import java.util.concurrent.atomic.AtomicInteger
+
+object MezonSnowflake {
+    private const val EPOCH_MS = 0L
+    private const val SHARD_ID = 1
+    private val sequence = AtomicInteger(1)
+
+    fun generate(timestampMs: Long = System.currentTimeMillis()): Long {
+        val ts = timestampMs - EPOCH_MS
+        val shard = SHARD_ID % 1024
+        val seq = sequence.getAndIncrement() and 0xFFF
+        return (ts shl 22) or (shard.toLong() shl 12) or seq.toLong()
+    }
+}


### PR DESCRIPTION

Use Snowflake/ref-based ids and anchor insert for embed responses; sort by message id like pre-embed. Remove local embedFormValidationError gating on submit and simplify provisional id handling.