### PR TITLE
fix(chat): hide edit for non-editable messages

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/ChatController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChatController.kt
@@ -10,6 +10,7 @@ import com.mezon.mobile.di.IoDispatcher
 import com.mezon.mobile.home.chat.AttachmentPickerItem
 import com.mezon.mobile.home.chat.AttachmentInfo
 import com.mezon.mobile.home.chat.MessageEntity
+import com.mezon.mobile.home.chat.canEditMessage
 import com.mezon.mobile.home.chat.ForwardDestination
 import com.mezon.mobile.home.chat.applyReactionEvent
 import com.mezon.mobile.home.chat.mergeChannelContentMentionsAndRefs
@@ -1449,6 +1450,7 @@ class ChatController @Inject constructor(
         hashtags: List<com.mezon.mobile.util.HashtagData>? = null,
         existingMessage: MessageEntity? = null
     ) {
+        if (existingMessage != null && !existingMessage.canEditMessage(getCurrentUserId())) return
         val mode = channelTypeToStreamMode(channelType)
         val isPublic = !isChannelPrivate
         val hasExtras = !mentions.isNullOrEmpty() || !emojiMarkers.isNullOrEmpty() ||

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -1660,6 +1660,7 @@ class ChatFragment : BaseFragment() {
                 }
             }
             override fun didLongPress(cell: ChatMessageCell, msg: MessageEntity) {
+                if (msg.isCallLogMessage()) return
                 showMessageActionSheet(msg)
             }
             override fun didClickAvatar(cell: ChatMessageCell, msg: MessageEntity) {
@@ -4771,6 +4772,7 @@ class ChatFragment : BaseFragment() {
         if (activity.isFinishing || activity.isDestroyed) return
         val userId = chatController.getCurrentUserId()
         val isMyMessage = msg.senderId == userId
+        val showEditMessage = msg.canEditMessage(userId)
         val allMedia = msg.allImageAttachments
         val hasMedia = allMedia.isNotEmpty() ||
             msg.attachmentUrl.isNotEmpty() && (msg.attachmentFiletype.startsWith("image/") || msg.attachmentFiletype.startsWith("video/"))
@@ -4789,6 +4791,7 @@ class ChatFragment : BaseFragment() {
             hasImage = hasImage,
             showForwardSingle = allowFwd,
             showForwardAllNearby = allowFwd && collectForwardNearbyMessages(msg).size > 1,
+            showEditMessage = showEditMessage,
             listener = object : MessageActionBottomSheet.MessageActionListener {
                 override fun onActionSelected(action: MessageActionBottomSheet.ActionType, message: MessageEntity) {
                     handleMessageAction(action, message)

--- a/app/src/main/java/com/mezon/mobile/home/chat/MessageActionBottomSheet.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/MessageActionBottomSheet.kt
@@ -33,6 +33,7 @@ class MessageActionBottomSheet(
     private val hasImage: Boolean = false,
     private val showForwardSingle: Boolean = true,
     private val showForwardAllNearby: Boolean = false,
+    private val showEditMessage: Boolean = false,
     private val listener: MessageActionListener
 ) : BottomSheet(context) {
 
@@ -302,7 +303,7 @@ class MessageActionBottomSheet(
             ))
         }
 
-        if (isMyMessage) {
+        if (showEditMessage) {
             actions.add(ActionItem(
                 ActionType.EditMessage,
                 context.getString(R.string.action_edit),

--- a/app/src/main/java/com/mezon/mobile/home/chat/MessageEntity.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/MessageEntity.kt
@@ -10,6 +10,7 @@ import com.mezon.mezon.api.MessageRefList
 import org.json.JSONArray
 import org.json.JSONObject
 import android.util.Log
+import com.mezon.mobile.home.call.parseCallLogMessage
 import com.mezon.mobile.home.chat.poll.isPollContentJson
 import com.mezon.mobile.network.STREAM_MODE_CHANNEL
 import com.mezon.mobile.network.STREAM_MODE_THREAD
@@ -519,4 +520,17 @@ fun applyReactionEvent(
         arr.put(obj)
     }
     return arr.toString()
+}
+
+fun MessageEntity.isCallLogMessage(): Boolean = parseCallLogMessage(content) != null
+
+fun MessageEntity.canEditMessage(currentUserId: Long): Boolean {
+    if (senderId != currentUserId) return false
+    if (isCallLogMessage()) return false
+    if (code == MessageEntity.CODE_SEND_TOKEN) return false
+    if (isPollMessage) return false
+    if (isForwarded) return false
+    if (code == MessageEntity.CODE_TOPIC) return false
+    if (runCatching { JSONObject(content).has("tp") }.getOrDefault(false)) return false
+    return true
 }


### PR DESCRIPTION
Match old mobile by blocking call log long-press and gating edit on poll, forwarded, topic, and send-token messages.