### PR TITLE
fix(chat): parse legacy attachments and reply content like RN

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/ChatController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChatController.kt
@@ -436,9 +436,8 @@ class ChatController @Inject constructor(
                         session.apiUrl, session.token, channelId, clanId,
                         newestMessageId, DIRECTION_AFTER, PAGE_SIZE
                     )
-                    val newer = response.messagesList
+                    val newerRenderable = response.messagesList
                         .map { it.toMessageEntity(currentUserId) }
-                    val newerRenderable = newer
                         .filter { it.isRenderable }
                         .sortedBy { it.id }
 

--- a/app/src/main/java/com/mezon/mobile/home/ChatController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChatController.kt
@@ -418,13 +418,11 @@ class ChatController @Inject constructor(
     }
 
     fun loadMoreBottom(channelId: Long, clanId: Long, newestMessageId: Long) {
-        Log.d(TAG, "loadMoreBottom channelId=$channelId newestMessageId=$newestMessageId")
         appScope.launch(ioDispatcher) {
             try {
                 if (!networkMonitor.isOnline.value) {
                     val fromDb = messageDao.getMessagesAfter(channelId, newestMessageId, PAGE_SIZE)
                     val hasMoreBottom = fromDb.size >= PAGE_SIZE
-                    Log.d(TAG, "loadMoreBottom offline fallback: ${fromDb.size} from DB")
                     notificationCenter.postNotificationOnMainThread(
                         NotificationCenter.messagesDidLoad, channelId, ArrayList(fromDb),
                         false, hasMoreBottom, false, 0L, LOAD_TYPE_MORE_BOTTOM
@@ -454,7 +452,6 @@ class ChatController @Inject constructor(
                         messageDao.upsertAll(newerRenderable)
                         messageDao.trimAround(channelId, newestMessageId, PAGE_SIZE * 2)
                     }
-                    Log.d(TAG, "loadMoreBottom: count=${newerRenderable.size} hasMoreBottom=$hasMoreBottom hasLastSentMessage=${response.hasLastSentMessage()} serverLastSentId=$serverLastSentId rawCount=${response.messagesList.size} newerRange=${newerRenderable.minOfOrNull { it.id }}..${newerRenderable.maxOfOrNull { it.id }}")
                     notificationCenter.postNotificationOnMainThread(
                         NotificationCenter.messagesDidLoad, channelId, ArrayList(newerRenderable), false, hasMoreBottom, false, 0L, LOAD_TYPE_MORE_BOTTOM
                     )

--- a/app/src/main/java/com/mezon/mobile/home/ChatController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChatController.kt
@@ -440,6 +440,7 @@ class ChatController @Inject constructor(
                     )
                     val newer = response.messagesList
                         .map { it.toMessageEntity(currentUserId) }
+                    val newerRenderable = newer
                         .filter { it.isRenderable }
                         .sortedBy { it.id }
 
@@ -448,14 +449,14 @@ class ChatController @Inject constructor(
                         response.hasLastSentMessage() &&
                         response.lastSentMessage.canAdvanceServerTimeline()
                     ) response.lastSentMessage.id else 0L
-                    updateLastMessageByChannel(channelId, newer, serverLastSentId)
-                    if (newer.isNotEmpty()) {
-                        messageDao.upsertAll(newer)
+                    updateLastMessageByChannel(channelId, newerRenderable, serverLastSentId)
+                    if (newerRenderable.isNotEmpty()) {
+                        messageDao.upsertAll(newerRenderable)
                         messageDao.trimAround(channelId, newestMessageId, PAGE_SIZE * 2)
                     }
-                    Log.d(TAG, "loadMoreBottom: count=${newer.size} hasMoreBottom=$hasMoreBottom hasLastSentMessage=${response.hasLastSentMessage()} serverLastSentId=$serverLastSentId rawCount=${response.messagesList.size} newerRange=${newer.minOfOrNull { it.id }}..${newer.maxOfOrNull { it.id }}")
+                    Log.d(TAG, "loadMoreBottom: count=${newerRenderable.size} hasMoreBottom=$hasMoreBottom hasLastSentMessage=${response.hasLastSentMessage()} serverLastSentId=$serverLastSentId rawCount=${response.messagesList.size} newerRange=${newerRenderable.minOfOrNull { it.id }}..${newerRenderable.maxOfOrNull { it.id }}")
                     notificationCenter.postNotificationOnMainThread(
-                        NotificationCenter.messagesDidLoad, channelId, ArrayList(newer), false, hasMoreBottom, false, 0L, LOAD_TYPE_MORE_BOTTOM
+                        NotificationCenter.messagesDidLoad, channelId, ArrayList(newerRenderable), false, hasMoreBottom, false, 0L, LOAD_TYPE_MORE_BOTTOM
                     )
                 }
             } catch (e: Exception) {

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -5095,7 +5095,7 @@ class ChatFragment : BaseFragment() {
             }
             MessageActionBottomSheet.ActionType.CopyText -> {
                 val ctx = getContext() ?: return
-                val plainText = parseContentText(msg.content).ifBlank { msg.content }
+                val plainText = parseContentText(msg.content)
                 val clipboard = ctx.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
                 clipboard.setPrimaryClip(android.content.ClipData.newPlainText("message", plainText))
                 MezonToast.show(this, ToastOverlay.ToastType.INFO, getString(R.string.message_toast_copy_text))

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
@@ -185,6 +185,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
     private var errorLayout: StaticLayout? = null
     private var hasReply = false
     private var parsedContent: String = ""
+    private var hasExplicitTextBody: Boolean = false
     private var timeText: String = ""
     var channelType: Int = 0
     var clanId: Long = 0L
@@ -460,6 +461,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
 
             if (newMsg != null) messageEntity = newMsg
             parsedContent = parseContentText(msg.content)
+            hasExplicitTextBody = messageHasExplicitTextBody(msg.content)
             timeText = formatRelativeTime(msg.timestampSeconds)
             drawPhotoImage = msg.hasAnyMedia
             val isAudioAtt = msg.isAudioAttachment && !msg.hasAnyMedia
@@ -511,6 +513,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             val newParsed = parseContentText(msg.content)
             if (newParsed != parsedContent || msg.content != prevRaw) {
                 parsedContent = newParsed
+                hasExplicitTextBody = messageHasExplicitTextBody(msg.content)
                 rebuildLayout = true
             }
         }
@@ -1125,7 +1128,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         val hasText = !hasCallLogCard && !msg.isPollMessage && !hasShareContactCard &&
             parsedContent.isNotBlank() && parsedContent != "[file]" && parsedContent != "[embed]" &&
             parsedContent != "[contact]" &&
-            (!hasEmbedPayload || messageHasExplicitTextBody(msg.content))
+            (!hasEmbedPayload || hasExplicitTextBody)
         contentLayout = if (hasText) {
             val content = msg.content
             val linkColor = theme.blurple

--- a/app/src/main/java/com/mezon/mobile/home/chat/MessageEntity.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/MessageEntity.kt
@@ -3,6 +3,8 @@ package com.mezon.mobile.home.chat
 import androidx.room.Entity
 import androidx.room.Index
 import com.mezon.mezon.api.ChannelMessage
+import com.mezon.mezon.api.ListChannelTimelineAttachment
+import com.mezon.mezon.api.MessageAttachment
 import com.mezon.mezon.api.MessageAttachmentList
 import com.mezon.mezon.api.MessageMentionList
 import com.mezon.mezon.api.MessageReactionList
@@ -365,25 +367,118 @@ private data class ParsedAttachment(
 
 private fun parseAllAttachments(bytes: com.google.protobuf.ByteString): List<ParsedAttachment> {
     if (bytes.isEmpty) return emptyList()
-    return try {
+    val raw = bytes.toByteArray()
+    val first = raw[0]
+    if (first == '['.code.toByte() || first == '{'.code.toByte()) {
+        parseAttachmentsFromLegacyBytes(bytes)?.let { if (it.isNotEmpty()) return it }
+    }
+    parseAttachmentsFromProto(bytes)?.let { if (it.isNotEmpty()) return it }
+    parseAttachmentsFromLegacyBytes(bytes)?.let { if (it.isNotEmpty()) return it }
+    return emptyList()
+}
+
+private fun parseAttachmentsFromProto(bytes: com.google.protobuf.ByteString): List<ParsedAttachment>? {
+    try {
         val list = MessageAttachmentList.parseFrom(bytes)
-        if (list.attachmentsCount == 0) return emptyList()
-        list.attachmentsList.map { a ->
+        if (list.attachmentsCount > 0) {
+            return list.attachmentsList.map { it.toParsedAttachment() }
+        }
+    } catch (_: Exception) {
+    }
+    try {
+        val single = MessageAttachment.parseFrom(bytes)
+        if (single.url.isNotEmpty()) return listOf(single.toParsedAttachment())
+    } catch (_: Exception) {
+    }
+    try {
+        val list = ListChannelTimelineAttachment.parseFrom(bytes)
+        if (list.attachmentsCount == 0) return null
+        return list.attachmentsList.mapNotNull { a ->
+            val url = a.fileUrl
+            if (url.isBlank()) return@mapNotNull null
             ParsedAttachment(
-                url = a.url,
-                filename = a.filename,
-                filetype = a.filetype,
+                url = url,
+                filename = a.fileName,
+                filetype = a.fileType,
                 width = a.width,
                 height = a.height,
                 thumbnail = a.thumbnail,
-                size = a.size,
+                size = a.fileSize.toInt(),
                 duration = a.duration
             )
         }
     } catch (_: Exception) {
-        emptyList()
+    }
+    return null
+}
+
+private fun parseAttachmentsFromLegacyBytes(bytes: com.google.protobuf.ByteString): List<ParsedAttachment>? {
+    val jsonStr = try {
+        bytes.toStringUtf8()
+    } catch (_: Exception) {
+        return null
+    }
+    if (jsonStr.isBlank() || jsonStr == "[]") return emptyList()
+    return parseAttachmentsFromJsonString(jsonStr)
+}
+
+private fun parseAttachmentsFromJsonString(jsonStr: String): List<ParsedAttachment>? {
+    val arr = try {
+        val obj = JSONObject(jsonStr)
+        obj.optJSONArray("attachments") ?: JSONArray().apply { put(obj) }
+    } catch (_: Exception) {
+        try {
+            JSONArray(jsonStr)
+        } catch (_: Exception) {
+            return tryAlternateAttachmentJson(jsonStr)
+        }
+    }
+    val parsed = (0 until arr.length()).mapNotNull { i ->
+        val item = arr.optJSONObject(i) ?: return@mapNotNull null
+        parsedAttachmentFromJson(item)
+    }.filter { it.url.isNotEmpty() }
+    return parsed
+}
+
+private fun tryAlternateAttachmentJson(jsonStr: String): List<ParsedAttachment>? {
+    return try {
+        val normalized = jsonStr.replace("\n", "\\n").replace("\r", "\\r")
+        parseAttachmentsFromJsonString(normalized)
+    } catch (_: Exception) {
+        null
     }
 }
+
+private fun parsedAttachmentFromJson(obj: JSONObject): ParsedAttachment {
+    val url = obj.optString("url").ifBlank { obj.optString("file_url") }
+    val thumb = obj.optString("thumbnail").ifBlank { obj.optString("thumb") }
+    val size = when {
+        obj.has("size") -> obj.optInt("size")
+        obj.has("file_size") -> obj.optInt("file_size")
+        else -> 0
+    }
+    return ParsedAttachment(
+        url = url,
+        filename = obj.optString("filename").ifBlank { obj.optString("file_name") },
+        filetype = obj.optString("filetype").ifBlank { obj.optString("file_type") },
+        width = obj.optInt("width"),
+        height = obj.optInt("height"),
+        thumbnail = thumb,
+        size = size,
+        duration = obj.optInt("duration")
+    )
+}
+
+private fun MessageAttachment.toParsedAttachment() = ParsedAttachment(
+    url = url,
+    filename = filename,
+    filetype = filetype,
+    width = width,
+    height = height,
+    thumbnail = thumbnail,
+    size = size,
+    duration = duration
+)
 
 internal fun mergeChannelContentMentionsAndRefs(
     content: String,

--- a/app/src/main/java/com/mezon/mobile/home/chat/MessageEntity.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/MessageEntity.kt
@@ -11,7 +11,6 @@ import com.mezon.mezon.api.MessageReactionList
 import com.mezon.mezon.api.MessageRefList
 import org.json.JSONArray
 import org.json.JSONObject
-import android.util.Log
 import com.mezon.mobile.home.call.parseCallLogMessage
 import com.mezon.mobile.home.chat.poll.isPollContentJson
 import com.mezon.mobile.network.STREAM_MODE_CHANNEL

--- a/app/src/main/java/com/mezon/mobile/home/chat/MessageEntity.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/MessageEntity.kt
@@ -3,8 +3,6 @@ package com.mezon.mobile.home.chat
 import androidx.room.Entity
 import androidx.room.Index
 import com.mezon.mezon.api.ChannelMessage
-import com.mezon.mezon.api.ListChannelTimelineAttachment
-import com.mezon.mezon.api.MessageAttachment
 import com.mezon.mezon.api.MessageAttachmentList
 import com.mezon.mezon.api.MessageMentionList
 import com.mezon.mezon.api.MessageReactionList
@@ -366,118 +364,25 @@ private data class ParsedAttachment(
 
 private fun parseAllAttachments(bytes: com.google.protobuf.ByteString): List<ParsedAttachment> {
     if (bytes.isEmpty) return emptyList()
-    val raw = bytes.toByteArray()
-    val first = raw[0]
-    if (first == '['.code.toByte() || first == '{'.code.toByte()) {
-        parseAttachmentsFromLegacyBytes(bytes)?.let { if (it.isNotEmpty()) return it }
-    }
-    parseAttachmentsFromProto(bytes)?.let { if (it.isNotEmpty()) return it }
-    parseAttachmentsFromLegacyBytes(bytes)?.let { if (it.isNotEmpty()) return it }
-    return emptyList()
-}
-
-private fun parseAttachmentsFromProto(bytes: com.google.protobuf.ByteString): List<ParsedAttachment>? {
-    try {
+    return try {
         val list = MessageAttachmentList.parseFrom(bytes)
-        if (list.attachmentsCount > 0) {
-            return list.attachmentsList.map { it.toParsedAttachment() }
-        }
-    } catch (_: Exception) {
-    }
-    try {
-        val single = MessageAttachment.parseFrom(bytes)
-        if (single.url.isNotEmpty()) return listOf(single.toParsedAttachment())
-    } catch (_: Exception) {
-    }
-    try {
-        val list = ListChannelTimelineAttachment.parseFrom(bytes)
-        if (list.attachmentsCount == 0) return null
-        return list.attachmentsList.mapNotNull { a ->
-            val url = a.fileUrl
-            if (url.isBlank()) return@mapNotNull null
+        if (list.attachmentsCount == 0) return emptyList()
+        list.attachmentsList.map { a ->
             ParsedAttachment(
-                url = url,
-                filename = a.fileName,
-                filetype = a.fileType,
+                url = a.url,
+                filename = a.filename,
+                filetype = a.filetype,
                 width = a.width,
                 height = a.height,
                 thumbnail = a.thumbnail,
-                size = a.fileSize.toInt(),
+                size = a.size,
                 duration = a.duration
             )
         }
     } catch (_: Exception) {
-    }
-    return null
-}
-
-private fun parseAttachmentsFromLegacyBytes(bytes: com.google.protobuf.ByteString): List<ParsedAttachment>? {
-    val jsonStr = try {
-        bytes.toStringUtf8()
-    } catch (_: Exception) {
-        return null
-    }
-    if (jsonStr.isBlank() || jsonStr == "[]") return emptyList()
-    return parseAttachmentsFromJsonString(jsonStr)
-}
-
-private fun parseAttachmentsFromJsonString(jsonStr: String): List<ParsedAttachment>? {
-    val arr = try {
-        val obj = JSONObject(jsonStr)
-        obj.optJSONArray("attachments") ?: JSONArray().apply { put(obj) }
-    } catch (_: Exception) {
-        try {
-            JSONArray(jsonStr)
-        } catch (_: Exception) {
-            return tryAlternateAttachmentJson(jsonStr)
-        }
-    }
-    val parsed = (0 until arr.length()).mapNotNull { i ->
-        val item = arr.optJSONObject(i) ?: return@mapNotNull null
-        parsedAttachmentFromJson(item)
-    }.filter { it.url.isNotEmpty() }
-    return parsed
-}
-
-private fun tryAlternateAttachmentJson(jsonStr: String): List<ParsedAttachment>? {
-    return try {
-        val normalized = jsonStr.replace("\n", "\\n").replace("\r", "\\r")
-        parseAttachmentsFromJsonString(normalized)
-    } catch (_: Exception) {
-        null
+        emptyList()
     }
 }
-
-private fun parsedAttachmentFromJson(obj: JSONObject): ParsedAttachment {
-    val url = obj.optString("url").ifBlank { obj.optString("file_url") }
-    val thumb = obj.optString("thumbnail").ifBlank { obj.optString("thumb") }
-    val size = when {
-        obj.has("size") -> obj.optInt("size")
-        obj.has("file_size") -> obj.optInt("file_size")
-        else -> 0
-    }
-    return ParsedAttachment(
-        url = url,
-        filename = obj.optString("filename").ifBlank { obj.optString("file_name") },
-        filetype = obj.optString("filetype").ifBlank { obj.optString("file_type") },
-        width = obj.optInt("width"),
-        height = obj.optInt("height"),
-        thumbnail = thumb,
-        size = size,
-        duration = obj.optInt("duration")
-    )
-}
-
-private fun MessageAttachment.toParsedAttachment() = ParsedAttachment(
-    url = url,
-    filename = filename,
-    filetype = filetype,
-    width = width,
-    height = height,
-    thumbnail = thumbnail,
-    size = size,
-    duration = duration
-)
 
 internal fun mergeChannelContentMentionsAndRefs(
     content: String,

--- a/app/src/main/java/com/mezon/mobile/util/ContentParser.kt
+++ b/app/src/main/java/com/mezon/mobile/util/ContentParser.kt
@@ -108,7 +108,7 @@ fun messageHasExplicitTextBody(content: String): Boolean {
     if (content.isBlank()) return false
     val trimmed = content.trim()
     if (!trimmed.startsWith("{")) return true
-    parseContentObject(trimmed)?.let { return textFromContentObject(it, preview = false).isNotBlank() }
+    parseContentObject(trimmed)?.let { return it.optString("t").isNotBlank() }
     return extractTopLevelTextFromRegex(trimmed).isNotBlank()
 }
 

--- a/app/src/main/java/com/mezon/mobile/util/ContentParser.kt
+++ b/app/src/main/java/com/mezon/mobile/util/ContentParser.kt
@@ -15,21 +15,6 @@ private fun unescapeJsonText(text: String, singleLine: Boolean): String {
     return s.trim()
 }
 
-private fun parseEmbedPreview(obj: JSONObject): String {
-    val embedArr = obj.optJSONArray("embed") ?: return ""
-    if (embedArr.length() == 0) return ""
-    val embed = embedArr.optJSONObject(0) ?: return ""
-    val title = embed.optString("title", "").trim()
-    if (title.isNotBlank()) return title
-    val description = embed.optString("description", "").trim()
-    if (description.isNotBlank()) return description
-    val fields = embed.optJSONArray("fields") ?: return ""
-    if (fields.length() == 0) return ""
-    val firstVal = fields.optJSONObject(0)?.optString("value", "")?.trim().orEmpty()
-    if (firstVal == SHARE_CONTACT_KEY) return "[contact]"
-    return ""
-}
-
 private fun parseStructuredContentText(obj: JSONObject): String {
     val t = unescapeJsonText(obj.optString("t", ""), singleLine = false)
     if (t.isNotBlank()) return t
@@ -47,6 +32,56 @@ private fun parseStructuredContentPreview(obj: JSONObject): String {
     if (embedPreview.isNotBlank()) return embedPreview
     if (obj.has("lk")) return "[link]"
     if (obj.has("attachments")) return "[file]"
+    return ""
+}
+
+private fun extractLegacyContentText(trimmed: String): String {
+    if (trimmed.startsWith("{")) {
+        return try {
+            parseStructuredContentText(JSONObject(trimmed))
+        } catch (_: Exception) {
+            extractTopLevelTextFromRegex(trimmed)
+        }
+    }
+    val match = CONTENT_REGEX.find(trimmed)
+    val fromRegex = match?.groupValues?.getOrNull(1)?.let { unescapeJsonText(it, singleLine = false) }
+    if (!fromRegex.isNullOrBlank()) return fromRegex
+    if (trimmed.contains("\"references\"")) return ""
+    return trimmed
+}
+
+private fun extractLegacyContentPreview(trimmed: String): String {
+    if (trimmed.startsWith("{")) {
+        return try {
+            parseStructuredContentPreview(JSONObject(trimmed))
+        } catch (_: Exception) {
+            extractTopLevelTextFromRegex(trimmed).replace("\n", " ").take(200)
+        }
+    }
+    val match = CONTENT_REGEX.find(trimmed)
+    val fromRegex = match?.groupValues?.getOrNull(1)?.let { unescapeJsonText(it, singleLine = true) }
+    if (!fromRegex.isNullOrBlank()) return fromRegex
+    if (trimmed.contains("\"references\"")) return ""
+    return trimmed.replace("\n", " ").take(200)
+}
+
+private fun extractTopLevelTextFromRegex(trimmed: String): String {
+    val match = CONTENT_REGEX.find(trimmed) ?: return ""
+    return unescapeJsonText(match.groupValues.getOrNull(1).orEmpty(), singleLine = false)
+}
+
+private fun parseEmbedPreview(obj: JSONObject): String {
+    val embedArr = obj.optJSONArray("embed") ?: return ""
+    if (embedArr.length() == 0) return ""
+    val embed = embedArr.optJSONObject(0) ?: return ""
+    val title = embed.optString("title", "").trim()
+    if (title.isNotBlank()) return title
+    val description = embed.optString("description", "").trim()
+    if (description.isNotBlank()) return description
+    val fields = embed.optJSONArray("fields") ?: return ""
+    if (fields.length() == 0) return ""
+    val firstVal = fields.optJSONObject(0)?.optString("value", "")?.trim().orEmpty()
+    if (firstVal == SHARE_CONTACT_KEY) return "[contact]"
     return ""
 }
 
@@ -77,17 +112,7 @@ fun messageHasExplicitTextBody(content: String): Boolean {
     return try {
         val trimmed = content.trim()
         if (!trimmed.startsWith("{")) return true
-        val match = CONTENT_REGEX.find(content)
-        val viaRegex = match?.groupValues?.getOrNull(1)
-            ?.replace("\\/", "/")
-            ?.replace("\\r\\n", "\n")
-            ?.replace("\\r", "\n")
-            ?.replace("\\n", "\n")
-            ?.replace("\\\"", "\"")
-            ?.trim()
-        if (!viaRegex.isNullOrBlank()) return true
-        val t = unescapeJsonText(JSONObject(trimmed).optString("t", ""), singleLine = false)
-        t.isNotBlank()
+        parseStructuredContentText(JSONObject(trimmed)).isNotBlank()
     } catch (_: Exception) {
         true
     }
@@ -95,46 +120,12 @@ fun messageHasExplicitTextBody(content: String): Boolean {
 
 fun parseContentText(content: String): String {
     if (content.isBlank()) return ""
-    return try {
-        val trimmed = content.trim()
-        val match = CONTENT_REGEX.find(content)
-        val text = match?.groupValues?.getOrNull(1)
-            ?.replace("\\/", "/")
-            ?.replace("\\r\\n", "\n")
-            ?.replace("\\r", "\n")
-            ?.replace("\\n", "\n")
-            ?.replace("\\\"", "\"")
-            ?.trim()
-        if (!text.isNullOrBlank()) return text
-        if (trimmed.startsWith("{")) {
-            return parseStructuredContentText(JSONObject(trimmed))
-        }
-        trimmed
-    } catch (_: Exception) {
-        content.trim()
-    }
+    return extractLegacyContentText(content.trim())
 }
 
 fun parseContentPreview(content: String): String {
     if (content.isBlank()) return ""
-    return try {
-        val trimmed = content.trim()
-        val match = CONTENT_REGEX.find(content)
-        val text = match?.groupValues?.getOrNull(1)
-            ?.replace("\\/", "/")
-            ?.replace("\\r\\n", " ")
-            ?.replace("\\r", " ")
-            ?.replace("\\n", " ")
-            ?.replace("\\\"", "\"")
-            ?.trim()
-        if (!text.isNullOrBlank()) return text
-        if (trimmed.startsWith("{")) {
-            return parseStructuredContentPreview(JSONObject(trimmed))
-        }
-        trimmed.replace("\n", " ").take(200)
-    } catch (_: Exception) {
-        content.trim().replace("\n", " ").take(200)
-    }
+    return extractLegacyContentPreview(content.trim())
 }
 
 const val MENTION_HERE_USER_ID = "1775731111020111321"

--- a/app/src/main/java/com/mezon/mobile/util/ContentParser.kt
+++ b/app/src/main/java/com/mezon/mobile/util/ContentParser.kt
@@ -8,66 +8,63 @@ import org.json.JSONObject
 
 private val CONTENT_REGEX = Regex("\"t\"\\s*:\\s*\"((?:[^\"\\\\]|\\\\.)*)\"")
 
-
-private fun unescapeJsonText(text: String, singleLine: Boolean): String {
-    var s = text.replace("\\/", "/").replace("\\\"", "\"")
-    s = if (singleLine) s.replace("\\n", " ") else s.replace("\\n", "\n")
-    return s.trim()
+private fun parseContentObject(raw: String): JSONObject? {
+    if (raw.isEmpty() || raw == "[]" || !raw.startsWith("{")) return null
+    return try {
+        JSONObject(raw)
+    } catch (_: Exception) {
+        try {
+            JSONObject(raw.replace("\n", "\\n").replace("\r", "\\r"))
+        } catch (_: Exception) {
+            null
+        }
+    }
 }
 
-private fun parseStructuredContentText(obj: JSONObject): String {
-    val t = unescapeJsonText(obj.optString("t", ""), singleLine = false)
-    if (t.isNotBlank()) return t
+private fun textFromContentObject(obj: JSONObject, preview: Boolean): String {
+    val t = obj.optString("t", "").trim()
+    if (t.isNotBlank()) {
+        return if (preview) t.replace("\n", " ").take(200) else t
+    }
     val embedPreview = parseEmbedPreview(obj)
-    if (embedPreview.isNotBlank()) return embedPreview
+    if (embedPreview.isNotBlank()) {
+        return if (preview) embedPreview.replace("\n", " ").take(200) else embedPreview
+    }
     if (obj.has("lk")) return "[link]"
     if (obj.has("attachments")) return "[file]"
     return ""
-}
-
-private fun parseStructuredContentPreview(obj: JSONObject): String {
-    val t = unescapeJsonText(obj.optString("t", ""), singleLine = true)
-    if (t.isNotBlank()) return t
-    val embedPreview = parseEmbedPreview(obj)
-    if (embedPreview.isNotBlank()) return embedPreview
-    if (obj.has("lk")) return "[link]"
-    if (obj.has("attachments")) return "[file]"
-    return ""
-}
-
-private fun extractLegacyContentText(trimmed: String): String {
-    if (trimmed.startsWith("{")) {
-        return try {
-            parseStructuredContentText(JSONObject(trimmed))
-        } catch (_: Exception) {
-            extractTopLevelTextFromRegex(trimmed)
-        }
-    }
-    val match = CONTENT_REGEX.find(trimmed)
-    val fromRegex = match?.groupValues?.getOrNull(1)?.let { unescapeJsonText(it, singleLine = false) }
-    if (!fromRegex.isNullOrBlank()) return fromRegex
-    if (trimmed.contains("\"references\"")) return ""
-    return trimmed
-}
-
-private fun extractLegacyContentPreview(trimmed: String): String {
-    if (trimmed.startsWith("{")) {
-        return try {
-            parseStructuredContentPreview(JSONObject(trimmed))
-        } catch (_: Exception) {
-            extractTopLevelTextFromRegex(trimmed).replace("\n", " ").take(200)
-        }
-    }
-    val match = CONTENT_REGEX.find(trimmed)
-    val fromRegex = match?.groupValues?.getOrNull(1)?.let { unescapeJsonText(it, singleLine = true) }
-    if (!fromRegex.isNullOrBlank()) return fromRegex
-    if (trimmed.contains("\"references\"")) return ""
-    return trimmed.replace("\n", " ").take(200)
 }
 
 private fun extractTopLevelTextFromRegex(trimmed: String): String {
     val match = CONTENT_REGEX.find(trimmed) ?: return ""
-    return unescapeJsonText(match.groupValues.getOrNull(1).orEmpty(), singleLine = false)
+    return match.groupValues.getOrNull(1).orEmpty().trim()
+}
+
+private fun extractContentText(trimmed: String, preview: Boolean): String {
+    parseContentObject(trimmed)?.let { return textFromContentObject(it, preview) }
+    if (trimmed.startsWith("{")) {
+        val fromRegex = extractTopLevelTextFromRegex(trimmed)
+        if (fromRegex.isNotBlank()) {
+            return if (preview) fromRegex.replace("\n", " ").take(200) else fromRegex
+        }
+        return ""
+    }
+    val match = CONTENT_REGEX.find(trimmed)
+    val fromRegex = match?.groupValues?.getOrNull(1)?.trim()
+    if (!fromRegex.isNullOrBlank()) {
+        return if (preview) fromRegex.replace("\n", " ").take(200) else fromRegex
+    }
+    if (isStructuralJsonPayload(trimmed)) return ""
+    return if (preview) trimmed.replace("\n", " ").take(200) else trimmed
+}
+
+private fun isStructuralJsonPayload(trimmed: String): Boolean {
+    if (!trimmed.startsWith("[")) return false
+    return try {
+        JSONArray(trimmed).length() >= 0
+    } catch (_: Exception) {
+        false
+    }
 }
 
 private fun parseEmbedPreview(obj: JSONObject): String {
@@ -109,23 +106,20 @@ fun firstReferenceMessageId(content: String): Long {
 
 fun messageHasExplicitTextBody(content: String): Boolean {
     if (content.isBlank()) return false
-    return try {
-        val trimmed = content.trim()
-        if (!trimmed.startsWith("{")) return true
-        parseStructuredContentText(JSONObject(trimmed)).isNotBlank()
-    } catch (_: Exception) {
-        true
-    }
+    val trimmed = content.trim()
+    if (!trimmed.startsWith("{")) return true
+    parseContentObject(trimmed)?.let { return textFromContentObject(it, preview = false).isNotBlank() }
+    return extractTopLevelTextFromRegex(trimmed).isNotBlank()
 }
 
 fun parseContentText(content: String): String {
     if (content.isBlank()) return ""
-    return extractLegacyContentText(content.trim())
+    return extractContentText(content.trim(), preview = false)
 }
 
 fun parseContentPreview(content: String): String {
     if (content.isBlank()) return ""
-    return extractLegacyContentPreview(content.trim())
+    return extractContentText(content.trim(), preview = true)
 }
 
 const val MENTION_HERE_USER_ID = "1775731111020111321"


### PR DESCRIPTION
Decode historical attachment bytes with proto and JSON fallbacks, and read bubble text from content.t only so reply messages render without dumping references JSON.