### PR TITLE
fix(chat): make photo viewer loads smoother and isolated

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/chat/MezonImageLoader.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/MezonImageLoader.kt
@@ -84,6 +84,7 @@ class MezonImageLoader private constructor(context: Context) {
     }
 
     private val lastTrimAtMs = AtomicLong(0L)
+    private val ephemeralIdGen = AtomicLong(0L)
 
     private val largeCache = object : LruCache<String, Bitmap>(totalCacheSize * 4 / 5) {
         override fun sizeOf(key: String, bitmap: Bitmap): Int = bitmap.byteCount / 1024
@@ -118,7 +119,8 @@ class MezonImageLoader private constructor(context: Context) {
         val memKey: String,
         val reqWidth: Int,
         val reqHeight: Int,
-        val animated: Boolean
+        val animated: Boolean,
+        val ephemeral: Boolean
     )
 
     init {
@@ -178,10 +180,11 @@ class MezonImageLoader private constructor(context: Context) {
         reqWidth: Int,
         reqHeight: Int,
         onSuccess: (Bitmap) -> Unit,
-        onError: ((Exception) -> Unit)? = null
+        onError: ((Exception) -> Unit)? = null,
+        noCache: Boolean = false
     ): Cancellable {
         @Suppress("UNCHECKED_CAST")
-        return loadInternal(url, reqWidth, reqHeight, animated = false,
+        return loadInternal(url, reqWidth, reqHeight, animated = false, noCache = noCache,
             onSuccess = onSuccess as (Any) -> Unit, onError = onError)
     }
 
@@ -190,10 +193,11 @@ class MezonImageLoader private constructor(context: Context) {
         reqWidth: Int,
         reqHeight: Int,
         onSuccess: (Drawable) -> Unit,
-        onError: ((Exception) -> Unit)? = null
+        onError: ((Exception) -> Unit)? = null,
+        noCache: Boolean = false
     ): Cancellable {
         @Suppress("UNCHECKED_CAST")
-        return loadInternal(url, reqWidth, reqHeight, animated = true,
+        return loadInternal(url, reqWidth, reqHeight, animated = true, noCache = noCache,
             onSuccess = onSuccess as (Any) -> Unit, onError = onError)
     }
 
@@ -217,6 +221,7 @@ class MezonImageLoader private constructor(context: Context) {
         reqWidth: Int,
         reqHeight: Int,
         animated: Boolean,
+        noCache: Boolean,
         onSuccess: (Any) -> Unit,
         onError: ((Exception) -> Unit)?
     ): Cancellable {
@@ -225,10 +230,11 @@ class MezonImageLoader private constructor(context: Context) {
             return Cancellable.EMPTY
         }
 
-        val logicalUrl = stableUrlForDiskAndMemory(url)
+        val baseLogical = stableUrlForDiskAndMemory(url)
+        val logicalUrl = if (noCache) "$baseLogical#nocache=${ephemeralIdGen.incrementAndGet()}" else baseLogical
         val memKey = cacheKey(logicalUrl, reqWidth, reqHeight)
 
-        if (!animated) {
+        if (!animated && !noCache) {
             getFromMemory(memKey)?.let { cached ->
                 runOnMain { onSuccess(cached) }
                 return Cancellable.EMPTY
@@ -244,18 +250,20 @@ class MezonImageLoader private constructor(context: Context) {
             }
         }
 
-        val urlFile = diskFileForUrl(logicalUrl)
-        if (urlFile.exists() && urlFile.length() > 0L) {
-            touchFile(urlFile)
-            if (animated) decodeAnimatedInBackground(urlFile, memKey, reqWidth, reqHeight)
-            else decodeInBackground(urlFile, memKey, reqWidth, reqHeight)
-            return Cancellable {
-                cb.cancel()
-                removePendingCallback(logicalUrl, memKey, cb)
+        if (!noCache) {
+            val urlFile = diskFileForUrl(logicalUrl)
+            if (urlFile.exists() && urlFile.length() > 0L) {
+                touchFile(urlFile)
+                if (animated) decodeAnimatedInBackground(urlFile, memKey, reqWidth, reqHeight, ephemeral = false)
+                else decodeInBackground(urlFile, memKey, reqWidth, reqHeight, ephemeral = false)
+                return Cancellable {
+                    cb.cancel()
+                    removePendingCallback(logicalUrl, memKey, cb)
+                }
             }
         }
 
-        enqueueDecodeAfterDownload(logicalUrl, memKey, reqWidth, reqHeight, animated)
+        enqueueDecodeAfterDownload(logicalUrl, memKey, reqWidth, reqHeight, animated, noCache)
         ensureNetworkFetch(url, logicalUrl)
         return Cancellable {
             cb.cancel()
@@ -268,9 +276,10 @@ class MezonImageLoader private constructor(context: Context) {
         memKey: String,
         reqWidth: Int,
         reqHeight: Int,
-        animated: Boolean
+        animated: Boolean,
+        ephemeral: Boolean
     ) {
-        val task = PendingDecode(memKey, reqWidth, reqHeight, animated)
+        val task = PendingDecode(memKey, reqWidth, reqHeight, animated, ephemeral)
         pendingDecodes.compute(logicalUrl) { _, existing ->
             val list = existing ?: mutableListOf()
             synchronized(list) { list.add(task) }
@@ -344,8 +353,8 @@ class MezonImageLoader private constructor(context: Context) {
         val copy: List<PendingDecode>
         synchronized(list) { copy = ArrayList(list) }
         for (task in copy) {
-            if (task.animated) decodeAnimatedInBackground(file, task.memKey, task.reqWidth, task.reqHeight)
-            else decodeInBackground(file, task.memKey, task.reqWidth, task.reqHeight)
+            if (task.animated) decodeAnimatedInBackground(file, task.memKey, task.reqWidth, task.reqHeight, task.ephemeral)
+            else decodeInBackground(file, task.memKey, task.reqWidth, task.reqHeight, task.ephemeral)
         }
     }
 
@@ -405,7 +414,7 @@ class MezonImageLoader private constructor(context: Context) {
         }
     }
 
-    private fun decodeInBackground(file: File, cacheKey: String, reqWidth: Int, reqHeight: Int) {
+    private fun decodeInBackground(file: File, cacheKey: String, reqWidth: Int, reqHeight: Int, ephemeral: Boolean = false) {
         DECODE_EXECUTOR.execute {
             try {
                 val opts = BitmapFactory.Options()
@@ -428,19 +437,21 @@ class MezonImageLoader private constructor(context: Context) {
                         clampBitmap(bmp, reqWidth, reqHeight)
                     }
                     bmp = applyExifRotation(file, bmp, mimeType)
-                    putToMemory(cacheKey, bmp, reqWidth, reqHeight)
+                    if (!ephemeral) putToMemory(cacheKey, bmp, reqWidth, reqHeight)
                     dispatchSuccess(cacheKey, bmp)
+                    if (ephemeral) try { file.delete() } catch (_: Throwable) {}
                 } else {
                     try { file.delete() } catch (_: Throwable) {}
                     dispatchError(cacheKey, IOException("Decode failed"))
                 }
             } catch (e: Exception) {
+                if (ephemeral) try { file.delete() } catch (_: Throwable) {}
                 dispatchError(cacheKey, e as? Exception ?: Exception(e))
             }
         }
     }
 
-    private fun decodeAnimatedInBackground(file: File, cacheKey: String, reqWidth: Int = 0, reqHeight: Int = 0) {
+    private fun decodeAnimatedInBackground(file: File, cacheKey: String, reqWidth: Int = 0, reqHeight: Int = 0, ephemeral: Boolean = false) {
         DECODE_EXECUTOR.execute {
             try {
                 val intrinsicMode = reqWidth <= 0 && reqHeight <= 0
@@ -487,6 +498,7 @@ class MezonImageLoader private constructor(context: Context) {
                         }
                         val drawable = android.graphics.drawable.BitmapDrawable(null, firstFrame)
                         dispatchSuccess(cacheKey, drawable)
+                        if (ephemeral) try { file.delete() } catch (_: Throwable) {}
                     } else {
                         dispatchError(cacheKey, IOException("Decode failed"))
                     }

--- a/app/src/main/java/com/mezon/mobile/home/chat/PhotoViewer.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/PhotoViewer.kt
@@ -15,6 +15,7 @@ import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
+import android.util.Log
 import android.util.TypedValue
 import android.view.Gravity
 import android.view.View
@@ -25,6 +26,7 @@ import android.view.WindowManager
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
+import android.widget.ProgressBar
 import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
@@ -38,6 +40,8 @@ import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.Locale
+
+private const val TAG = "PhotoViewer"
 
 class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Black_NoTitleBar_Fullscreen) {
 
@@ -164,6 +168,8 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
         urls = if (gallery.isEmpty()) listOf(url) else gallery
         currentIndex = if (index in urls.indices) index else 0
         preferDrawableLoaderForSingle = preferDrawableLoader && urls.size == 1
+        val dm = context.resources.displayMetrics
+        Log.d(TAG, "show() url=$url gallerySize=${gallery.size} index=$index thumb=${thumbBitmap?.let { "${it.width}x${it.height}" } ?: "null"} preferDrawable=$preferDrawableLoader screen=${dm.widthPixels}x${dm.heightPixels} density=${dm.density}")
 
         val single = urls.size == 1
         val thumbUrl = urls[0]
@@ -227,7 +233,11 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
         private val initialThumb: Bitmap?
     ) : RecyclerView.Adapter<PhotoPagerAdapter.ViewHolder>() {
 
-        inner class ViewHolder(val photoView: PhotoView) : RecyclerView.ViewHolder(photoView) {
+        inner class ViewHolder(
+            val container: FrameLayout,
+            val photoView: PhotoView,
+            val progressBar: ProgressBar
+        ) : RecyclerView.ViewHolder(container) {
             var pendingLoad: MezonImageLoader.Cancellable? = null
             var bindGeneration: Long = 0L
         }
@@ -274,10 +284,11 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
         }
 
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-            val photoView = PhotoView(parent.context).apply {
-                layoutParams = ViewGroup.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.MATCH_PARENT
+            val ctx = parent.context
+            val photoView = PhotoView(ctx).apply {
+                layoutParams = FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                    FrameLayout.LayoutParams.MATCH_PARENT
                 )
                 setBackgroundColor(Color.BLACK)
                 maximumScale = 4f
@@ -295,7 +306,23 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
                 setOnPhotoTapListener { _, _, _ -> toggleToolbar() }
                 setOnOutsidePhotoTapListener { toggleToolbar() }
             }
-            return ViewHolder(photoView)
+            val progress = ProgressBar(ctx).apply {
+                isIndeterminate = true
+                indeterminateTintList = android.content.res.ColorStateList.valueOf(Color.WHITE)
+                val size = LayoutHelper.dp(48)
+                layoutParams = FrameLayout.LayoutParams(size, size, Gravity.CENTER)
+                visibility = View.GONE
+            }
+            val container = FrameLayout(ctx).apply {
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+                )
+                setBackgroundColor(Color.BLACK)
+                addView(photoView)
+                addView(progress)
+            }
+            return ViewHolder(container, photoView, progress)
         }
 
         override fun onViewRecycled(holder: ViewHolder) {
@@ -303,6 +330,7 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
             holder.pendingLoad?.cancel()
             holder.pendingLoad = null
             holder.bindGeneration++
+            holder.progressBar.visibility = View.GONE
             stopAndClearPhotoView(holder.photoView)
         }
 
@@ -316,17 +344,15 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
             val bindGen = holder.bindGeneration
             stopAndClearPhotoView(photoView)
 
-            if (position == currentIndex && initialThumb != null) {
+            val hasThumb = position == currentIndex && initialThumb != null
+            if (hasThumb) {
                 photoView.setImageBitmap(initialThumb)
                 photoView.getAttacher().update()
                 photoView.setScale(1f, false)
             }
+            holder.progressBar.visibility = if (hasThumb) View.GONE else View.VISIBLE
 
-            val screenW = context.resources.displayMetrics.widthPixels
-            val screenH = context.resources.displayMetrics.heightPixels
-            val proxyMaxEdge = maxOf(screenW, screenH).coerceAtMost(2560)
             val loader = MezonImageLoader.getInstance(context)
-
             val drawableLoader = urlNeedsAnimatedDrawable(url) ||
                 (preferDrawableLoaderForSingle && urls.size == 1)
             if (drawableLoader) {
@@ -334,24 +360,43 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
                     holder.pendingLoad = loader.loadDrawable(url, 0, 0,
                         onSuccess = { drawable ->
                             if (holder.bindGeneration != bindGen) return@loadDrawable
+                            holder.progressBar.visibility = View.GONE
                             applyLoadedDrawable(holder, position, url, drawable)
+                        },
+                        onError = {
+                            if (holder.bindGeneration != bindGen) return@loadDrawable
+                            holder.progressBar.visibility = View.GONE
                         }
                     )
                 } else {
                     holder.pendingLoad = loader.load(url, 0, 0,
                         onSuccess = { bmp ->
                             if (holder.bindGeneration != bindGen) return@load
+                            holder.progressBar.visibility = View.GONE
                             applyLoadedBitmap(holder, position, url, bmp)
+                        },
+                        onError = {
+                            if (holder.bindGeneration != bindGen) return@load
+                            holder.progressBar.visibility = View.GONE
                         }
                     )
                 }
             } else {
+                val screenW = context.resources.displayMetrics.widthPixels
+                val screenH = context.resources.displayMetrics.heightPixels
+                val proxyMaxEdge = maxOf(screenW, screenH).coerceAtMost(2560)
                 val loadUrl = createImgproxyUrl(url, screenW, screenH, "fit", proxyMaxEdge)
                 holder.pendingLoad = loader.load(loadUrl, screenW, screenH,
                     onSuccess = { bmp ->
                         if (holder.bindGeneration != bindGen) return@load
+                        holder.progressBar.visibility = View.GONE
                         applyLoadedBitmap(holder, position, url, bmp)
-                    }
+                    },
+                    onError = {
+                        if (holder.bindGeneration != bindGen) return@load
+                        holder.progressBar.visibility = View.GONE
+                    },
+                    noCache = true
                 )
             }
         }


### PR DESCRIPTION
Use ephemeral no-cache image loads for photo viewer pages and show explicit loading state so full-screen browsing avoids stale cache flashes while keeping memory pressure controlled.