### PR TITLE
fix(chat): keep multi-image attachment grid from squeezing

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
@@ -636,6 +636,19 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         val maxW = if (isInPinMode) rawMaxW.coerceAtMost(maxBubbleWidth(width)) else rawMaxW
         val maxH = maxW + LayoutHelper.dp(100)
 
+        // Multi-image grids (2/3/4) use a fixed grid geometry instead of the first
+        // image's aspect ratio: cells are square-ish and center-cropped, so deriving
+        // height from a single image squeezes the thumbnails (issue mezonai/mezon#13176).
+        val gridCount = msg.allImageAttachments.size.coerceAtMost(4)
+        if (gridCount > 1) {
+            val gap = LayoutHelper.dp(2)
+            val cellW = (maxW - gap) / 2
+            photoWidth = maxW
+            // 2 images -> two square cells side by side; 3/4 -> square container.
+            photoHeight = if (gridCount == 2) cellW else maxW
+            return
+        }
+
         val firstMedia = msg.allImageAttachments.firstOrNull()
         var imgW = firstMedia?.width ?: msg.attachmentWidth
         var imgH = firstMedia?.height ?: msg.attachmentHeight
@@ -753,16 +766,9 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
     }
 
     private fun computeMediaGridHeight() {
-        val gap = LayoutHelper.dp(2)
-        mediaGridTotalH = when (mediaGridCount) {
-            1 -> photoHeight
-            2 -> photoHeight
-            3, 4 -> {
-                val halfH = photoHeight / 2
-                halfH + gap + halfH
-            }
-            else -> photoHeight
-        }
+        // drawMediaGrid always lays the grid out within photoHeight for every cell
+        // count, so the measured height must match to avoid extra vertical padding.
+        mediaGridTotalH = photoHeight
     }
 
     private var spinnerAngle = 0f


### PR DESCRIPTION
## Summary
Multiple image attachments (2/3/4) in a chat message rendered squeezed/compressed — thumbnails didn't keep a sensible ratio and the grid looked broken (mezonai/mezon#13176).

Root cause: `computePhotoSize` derived the bubble's `photoWidth`/`photoHeight` from the **first image's aspect ratio** only. The grid cells are then center-cropped (`ImageReceiver` fills via `1f / min(scaleW, scaleH)`) into those dimensions, so a portrait/landscape first image forced all cells into the wrong shape, producing the squeeze.

## Changes
- `computePhotoSize`: for grids of 2/3/4 images, use a fixed grid geometry independent of the first image — `photoWidth = maxW`, and `photoHeight` sized so cells are square-ish (two square cells side by side for 2, a square container for 3/4). Single-image behavior is unchanged.
- `computeMediaGridHeight`: simplified to `mediaGridTotalH = photoHeight`. `drawMediaGrid` already lays every cell-count out within `photoHeight`, so the previous `3/4 -> photoHeight + gap` measurement added 2dp of phantom vertical padding below the grid. Measured height now matches drawn height.

## Self-test notes
- `./gradlew :app:compileDebugKotlin` → **BUILD SUCCESSFUL** (required initializing the `mezon-protocol` submodule for proto codegen).
- Verified `ImageReceiver.drawBitmap` is center-crop-fill, confirming square cells crop cleanly with no letterboxing.
- Traced the geometry by hand for each count against `drawMediaGrid`:
  - **2 images**: `cellW = (maxW-gap)/2`, `cellH = photoHeight = cellW` → two squares side by side.
  - **4 images**: `photoHeight = maxW` → `cellH = (photoHeight-gap)/2 = cellW` → 2×2 squares.
  - **3 images**: `photoHeight = maxW` → left cell `0.6w × full-h`, two right cells `0.4w × ~0.5h` — balanced, no squeeze.
  - Drawn grid height returns `startY + photoHeight` for all counts, matching the new measured `mediaGridTotalH`.
- Note: full device/UI verification (running the app) was not possible in this environment — no signing keys / `google-services.json` / backend secrets. Geometry was validated against the draw code rather than on-device.

Fixes mezonai/mezon#13176