### PR TITLE
feat(chat): share contact (#183)

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/call/CallLogMessageInfo.kt
+++ b/app/src/main/java/com/mezon/mobile/home/call/CallLogMessageInfo.kt
@@ -103,7 +103,7 @@ fun messagePreviewForDialog(
 ): String {
     val base = parseContentPreview(content)
     if (base.isNotBlank()) {
-        if (base == "[contact]") {
+        if (base.equals("[contact]", ignoreCase = true)) {
             return "[${context.getString(R.string.message_attachment_contact)}]"
         }
         return base

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatAdapter.kt
@@ -18,6 +18,8 @@ class ChatAdapter(
 
     var pollBridge: com.mezon.mobile.home.chat.poll.ChatPollBridge? = null
     var shareContactOnlineResolver: ((Long) -> Boolean)? = null
+    var shareContactBlockedResolver: ((Long) -> Boolean)? = null
+    var shareContactCallEnabledResolver: (() -> Boolean)? = null
     var displayRoleResolver: ((Long) -> UserDisplayRole?)? = null
     var onTopicClick: ((topicId: Long, rootMessageId: Long) -> Unit)? = null
     var topicCreatorResolver: ((Long) -> Pair<String, String>?)? = null
@@ -236,6 +238,8 @@ class ChatAdapter(
                 holder.cell.delegate = cellDelegate
                 holder.cell.pollBridge = pollBridge
                 holder.cell.shareContactOnlineResolver = shareContactOnlineResolver
+                holder.cell.shareContactBlockedResolver = shareContactBlockedResolver
+                holder.cell.shareContactCallEnabledResolver = shareContactCallEnabledResolver
                 holder.cell.loadLinkInvitePreview = loadLinkInvitePreview
                 holder.cell.isCombined = computeCombined(idx)
                 holder.cell.currentUserId = currentUserId.toLongOrNull() ?: 0L

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -1991,6 +1991,8 @@ open class ChatFragment : BaseFragment() {
             friendController.friends.value.find { it.user.id == userId }?.user?.online == true ||
                 userClanController.getUserById(userId)?.isOnline == true
         }
+        adapter.shareContactBlockedResolver = { userId -> isShareContactUserBlocked(userId) }
+        adapter.shareContactCallEnabledResolver = { !callController.isCallSessionActive() }
         refreshSystemMessageMemberGateCache()
         recyclerView.adapter = adapter
 
@@ -5304,7 +5306,17 @@ open class ChatFragment : BaseFragment() {
         sheet.show()
     }
 
+    private fun isShareContactUserBlocked(userId: Long): Boolean =
+        friendController.isUserBlocked(userId) ||
+            friendController.allFriendRelations.value.any {
+                it.user.id == userId && it.state == FRIEND_STATE_BLOCKED
+            }
+
     private fun openShareContactDm(data: ShareContactData) {
+        if (isShareContactUserBlocked(data.userId)) {
+            MezonToast.show(this, ToastOverlay.ToastType.ERROR, getString(R.string.no_permission_call_blocked))
+            return
+        }
         fragmentScope.launch {
             val dmId = dialogsController.getOrCreateDm(data.userId)
             withContext(mainDispatcher) {
@@ -5328,10 +5340,7 @@ open class ChatFragment : BaseFragment() {
             MezonToast.show(this, ToastOverlay.ToastType.ERROR, getString(R.string.cannot_call_yourself))
             return
         }
-        val blocked = friendController.allFriendRelations.value.any {
-            it.user.id == data.userId && it.state == FRIEND_STATE_BLOCKED
-        }
-        if (blocked) {
+        if (isShareContactUserBlocked(data.userId)) {
             MezonToast.show(this, ToastOverlay.ToastType.ERROR, getString(R.string.no_permission_call_blocked))
             return
         }

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
@@ -146,6 +146,8 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
     private var hasPollCard = false
     var pollBridge: ChatPollBridge? = null
     var shareContactOnlineResolver: ((Long) -> Boolean)? = null
+    var shareContactBlockedResolver: ((Long) -> Boolean)? = null
+    var shareContactCallEnabledResolver: (() -> Boolean)? = null
     private val shareContactLayout = ShareContactCardLayout(context).also {
         it.invalidateCallback = { invalidate() }
     }
@@ -1142,14 +1144,30 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         if (hasShareContactCard) {
             val scData = shareContactParsed!!
             val isOnline = shareContactOnlineResolver?.invoke(scData.userId) == true
-            shareContactLayout.prepare(scData, theme, bubbleMaxW, isOnline)
+            val blocked = shareContactBlockedResolver?.invoke(scData.userId) == true
+            val callEnabled = shareContactCallEnabledResolver?.invoke() != false
+            val messageEnabled = !blocked
+            val blockedNotice = if (blocked) {
+                context.getString(com.mezon.mobile.R.string.share_contact_blocked_notice)
+            } else {
+                null
+            }
+            shareContactLayout.prepare(
+                scData,
+                theme,
+                bubbleMaxW,
+                isOnline,
+                messageEnabled = messageEnabled,
+                callEnabled = callEnabled && !blocked,
+                blockedNotice = blockedNotice
+            )
         } else {
             shareContactLayout.clear()
         }
         val hasEmbedPayload = !hasCallLogCard && !hasShareContactCard && isEmbedOrComponentsPayload(msg.content)
         val hasText = !hasCallLogCard && !msg.isPollMessage && !hasShareContactCard &&
             parsedContent.isNotBlank() && parsedContent != "[file]" && parsedContent != "[embed]" &&
-            parsedContent != "[contact]" &&
+            !parsedContent.equals("[contact]", ignoreCase = true) &&
             (!hasEmbedPayload || hasExplicitTextBody)
         contentLayout = if (hasText) {
             val content = msg.content

--- a/app/src/main/java/com/mezon/mobile/home/chat/ShareContactCardLayout.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ShareContactCardLayout.kt
@@ -48,6 +48,9 @@ class ShareContactCardLayout(private val context: Context) {
     private var actionRowHeight = 0
     private var textBlockTop = 0f
     private var showOnline = false
+    private var messageEnabled = true
+    private var callEnabled = true
+    private var blockedNoticeLayout: StaticLayout? = null
     private var pressedAction = ShareContactHit.None
     private var rippleLight = false
 
@@ -68,9 +71,19 @@ class ShareContactCardLayout(private val context: Context) {
         invalidateCallback?.invoke()
     }
 
-    fun prepare(data: ShareContactData, theme: ThemeColors, maxBubbleWidth: Int, isOnline: Boolean = false) {
+    fun prepare(
+        data: ShareContactData,
+        theme: ThemeColors,
+        maxBubbleWidth: Int,
+        isOnline: Boolean = false,
+        messageEnabled: Boolean = true,
+        callEnabled: Boolean = true,
+        blockedNotice: String? = null
+    ) {
         cardWidth = (maxBubbleWidth * 0.9f).toInt().coerceAtLeast(LayoutHelper.dp(200))
         showOnline = isOnline
+        this.messageEnabled = messageEnabled
+        this.callEnabled = callEnabled
         rippleLight = theme.resolvedMode == com.mezon.mobile.ui.theme.ThemeMode.LIGHT
         val innerPadH = LayoutHelper.dp(12)
         val headerPadV = LayoutHelper.dp(16)
@@ -97,6 +110,16 @@ class ShareContactCardLayout(private val context: Context) {
             .setMaxLines(1)
             .setEllipsize(TextUtils.TruncateAt.END)
             .build()
+        val notice = blockedNotice?.trim().orEmpty()
+        blockedNoticeLayout = if (notice.isNotEmpty()) {
+            NOTICE_PAINT.color = theme.redStrong
+            StaticLayout.Builder.obtain(notice, 0, notice.length, NOTICE_PAINT, textBlockW)
+                .setMaxLines(2)
+                .setEllipsize(TextUtils.TruncateAt.END)
+                .build()
+        } else {
+            null
+        }
 
         avatarDrawable.setInfo(data.userId, data.username)
         loadAvatar(data.avatarUrl)
@@ -106,29 +129,39 @@ class ShareContactCardLayout(private val context: Context) {
         dividerPaint.color = theme.border
         actionTopDividerPaint.color = theme.borderDim
         onlineDotPaint.color = theme.onlineGreen
-        actionTint = theme.tabLabelInactive
+        val actionsEnabled = messageEnabled || callEnabled
+        actionTint = if (actionsEnabled) theme.tabLabelInactive else theme.textDisabled
 
-        val textStackH = (displayLayout?.height ?: 0) + USERNAME_GAP + (usernameLayout?.height ?: 0)
+        val noticeH = if (blockedNoticeLayout != null) {
+            BLOCKED_NOTICE_GAP + (blockedNoticeLayout?.height ?: 0)
+        } else {
+            0
+        }
+        val textStackH = (displayLayout?.height ?: 0) + USERNAME_GAP + (usernameLayout?.height ?: 0) + noticeH
         val headerContentH = maxOf(AVATAR_SIZE, textStackH)
         headerHeight = headerPadV * 2 + headerContentH
         textBlockTop = headerPadV + (headerContentH - textStackH) / 2f
 
+        val callTint = if (callEnabled) actionTint else theme.textDisabled
+        val messageTint = if (messageEnabled) actionTint else theme.textDisabled
         callIcon = MezonIcon.phoneCallIcon.getDrawable(context).mutate().apply {
-            setColorFilter(actionTint, android.graphics.PorterDuff.Mode.SRC_IN)
+            setColorFilter(callTint, android.graphics.PorterDuff.Mode.SRC_IN)
         }
         messageIcon = MezonIcon.chatIcon.getDrawable(context).mutate().apply {
-            setColorFilter(actionTint, android.graphics.PorterDuff.Mode.SRC_IN)
+            setColorFilter(messageTint, android.graphics.PorterDuff.Mode.SRC_IN)
         }
 
         val callLabel = context.getString(R.string.user_profile_voice_call)
         val msgLabel = context.getString(R.string.share_contact_message)
-        ACTION_PAINT.color = actionTint
+        ACTION_PAINT.color = callTint
         callLabelLayout = StaticLayout.Builder.obtain(callLabel, 0, callLabel.length, ACTION_PAINT, LayoutHelper.dp(140))
             .setMaxLines(1)
             .build()
+        ACTION_PAINT.color = messageTint
         messageLabelLayout = StaticLayout.Builder.obtain(msgLabel, 0, msgLabel.length, ACTION_PAINT, LayoutHelper.dp(140))
             .setMaxLines(1)
             .build()
+        ACTION_PAINT.color = callTint
 
         val labelH = maxOf(callLabelLayout?.height ?: 0, messageLabelLayout?.height ?: 0)
         actionRowHeight = ACTION_ROW_PAD_V * 2 + maxOf(ACTION_ICON_SIZE, labelH)
@@ -174,12 +207,19 @@ class ShareContactCardLayout(private val context: Context) {
             canvas.translate(textLeft, textY + USERNAME_GAP)
             it.draw(canvas)
             canvas.restore()
+            textY += USERNAME_GAP + it.height
+        }
+        blockedNoticeLayout?.let {
+            canvas.save()
+            canvas.translate(textLeft, textY + BLOCKED_NOTICE_GAP)
+            it.draw(canvas)
+            canvas.restore()
         }
 
-        if (pressedAction == ShareContactHit.Call) {
+        if (callEnabled && pressedAction == ShareContactHit.Call) {
             drawActionRipple(canvas, callHitRect)
         }
-        if (pressedAction == ShareContactHit.Message) {
+        if (messageEnabled && pressedAction == ShareContactHit.Message) {
             drawActionRipple(canvas, messageHitRect)
         }
         drawActionButton(canvas, callHitRect, callIcon, callLabelLayout)
@@ -260,8 +300,8 @@ class ShareContactCardLayout(private val context: Context) {
 
     fun hitTest(localX: Float, localY: Float): ShareContactHit {
         if (profileHitRect.contains(localX, localY)) return ShareContactHit.Profile
-        if (callHitRect.contains(localX, localY)) return ShareContactHit.Call
-        if (messageHitRect.contains(localX, localY)) return ShareContactHit.Message
+        if (callEnabled && callHitRect.contains(localX, localY)) return ShareContactHit.Call
+        if (messageEnabled && messageHitRect.contains(localX, localY)) return ShareContactHit.Message
         return ShareContactHit.None
     }
 
@@ -299,6 +339,9 @@ class ShareContactCardLayout(private val context: Context) {
         avatarCancellable = null
         currentAvatarUrl = ""
         showOnline = false
+        messageEnabled = true
+        callEnabled = true
+        blockedNoticeLayout = null
         pressedAction = ShareContactHit.None
         displayLayout = null
         usernameLayout = null
@@ -321,6 +364,10 @@ class ShareContactCardLayout(private val context: Context) {
         private val AVATAR_GAP = LayoutHelper.dp(12)
         private val TEXT_RIGHT_PAD = LayoutHelper.dp(10)
         private val USERNAME_GAP = LayoutHelper.dp(2)
+        private val BLOCKED_NOTICE_GAP = LayoutHelper.dp(4)
+        private val NOTICE_PAINT = TextPaint(Paint.ANTI_ALIAS_FLAG).apply {
+            textSize = LayoutHelper.sp(11f)
+        }
         private val CARD_RADIUS = LayoutHelper.dpf(12f)
         private val ACTION_ROW_PAD_V = LayoutHelper.dp(10)
         private val ACTION_ICON_SIZE = LayoutHelper.dp(18)

--- a/app/src/main/java/com/mezon/mobile/home/chat/ShareContactFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ShareContactFragment.kt
@@ -262,8 +262,9 @@ class ShareContactFragment : BaseFragment() {
     }
 
     private fun reloadFriends() {
+        val myId = chatController.getCurrentUserId()
         allFriends = friendController.friends.value
-            .filter { it.state == FRIEND_STATE_FRIEND }
+            .filter { it.state == FRIEND_STATE_FRIEND && it.user.id != myId }
             .sortedBy { f ->
                 f.user.displayName.ifBlank { f.user.username }.lowercase(Locale.getDefault())
             }

--- a/app/src/main/java/com/mezon/mobile/util/ContentParser.kt
+++ b/app/src/main/java/com/mezon/mobile/util/ContentParser.kt
@@ -21,10 +21,29 @@ private fun parseContentObject(raw: String): JSONObject? {
     }
 }
 
+const val SHARE_CONTACT_PREVIEW_LABEL = "[Contact]"
+
+private fun JSONObject.hasShareContactEmbed(): Boolean {
+    val embedArr = optJSONArray("embed") ?: return false
+    if (embedArr.length() == 0) return false
+    val embed = embedArr.optJSONObject(0) ?: return false
+    val fields = embed.optJSONArray("fields") ?: return false
+    for (i in 0 until fields.length()) {
+        val f = fields.optJSONObject(i) ?: continue
+        if (f.optString("name", "") == "key" && f.optString("value", "").trim() == SHARE_CONTACT_KEY) {
+            return true
+        }
+    }
+    return false
+}
+
 private fun textFromContentObject(obj: JSONObject, preview: Boolean): String {
     val t = obj.optString("t", "").trim()
     if (t.isNotBlank()) {
         return if (preview) t.replace("\n", " ").take(200) else t
+    }
+    if (obj.hasShareContactEmbed()) {
+        return if (preview) SHARE_CONTACT_PREVIEW_LABEL else ""
     }
     val embedPreview = parseEmbedPreview(obj)
     if (embedPreview.isNotBlank()) {
@@ -77,8 +96,12 @@ private fun parseEmbedPreview(obj: JSONObject): String {
     if (description.isNotBlank()) return description
     val fields = embed.optJSONArray("fields") ?: return ""
     if (fields.length() == 0) return ""
-    val firstVal = fields.optJSONObject(0)?.optString("value", "")?.trim().orEmpty()
-    if (firstVal == SHARE_CONTACT_KEY) return "[contact]"
+    for (i in 0 until fields.length()) {
+        val f = fields.optJSONObject(i) ?: continue
+        if (f.optString("name", "") == "key" && f.optString("value", "").trim() == SHARE_CONTACT_KEY) {
+            return SHARE_CONTACT_PREVIEW_LABEL
+        }
+    }
     return ""
 }
 

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1252,4 +1252,5 @@
     <string name="contact_shared_error">Không thể chia sẻ danh thiếp</string>
     <string name="cannot_call_yourself">Bạn không thể gọi chính mình.</string>
     <string name="no_permission_call_blocked">Bạn không thể thực hiện hành động này.</string>
+    <string name="share_contact_blocked_notice">Người dùng này đã bị chặn</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1009,6 +1009,7 @@
     <string name="contact_shared_error">Failed to share contact</string>
     <string name="cannot_call_yourself">You cannot call yourself.</string>
     <string name="no_permission_call_blocked">You cannot perform this action.</string>
+    <string name="share_contact_blocked_notice">This user is blocked</string>
     <string name="share_location_title">Send this location to %s</string>
     <string name="share_location_coordinate">Coordinate (%1$.6f, %2$.6f)</string>
     <string name="share_location_cancel">Cancel</string>


### PR DESCRIPTION
## Summary

Implements share-contact polish and QA fixes for #183 on top of the existing attach-menu flow, friend picker, contact card UI, and send/receive pipeline.

- **Edit**: contact-card messages no longer prefill `[contact]` in the composer; added caption text is preserved and shown after save.
- **Reply preview**: shows `[Contact]` instead of lowercase `[contact]`.
- **Edge cases**: cannot share yourself (filtered from picker); blocked users show an on-card notice with Message/Call disabled; Call is disabled while another call is active.

## Test plan

- [ ] Attach menu → Share contact → searchable friend list → send card in DM, group, and clan channels
- [ ] Receive contact card: avatar, display name, username render correctly
- [ ] Message opens/creates DM; Call starts voice call when allowed
- [ ] Edit a contact message: empty input, add text, save — caption appears with card
- [ ] Reply to contact message: preview shows `[Contact]`
- [ ] Self is not listed in share picker
- [ ] Shared blocked user: notice on card; Message/Call taps do nothing useful
- [ ] During active call: Call action on card is disabled

Closes #183


Made with [Cursor](https://cursor.com)