### PR TITLE
fix(chat): restore thread header, OGP, group avatar, and seed flows

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/ChatController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChatController.kt
@@ -45,12 +45,15 @@ import com.mezon.mobile.util.MentionData
 import com.mezon.mobile.util.buildTextContent
 import com.mezon.mobile.util.EmojiMarker
 import com.mezon.mobile.util.MarkdownMarker
+import com.mezon.mobile.util.OgpMarker
 import com.mezon.mobile.util.ShareContactData
 import com.mezon.mobile.util.buildShareContactContent
 import com.mezon.mobile.util.buildTextContentWithEmojis
 import com.mezon.mobile.util.mergePendingMentionsIntoContent
 import com.mezon.mobile.util.mergeShareContactEmbedIntoContent
 import com.mezon.mobile.util.isShareContactMessage
+import com.mezon.mobile.util.isEmbedOrComponentsPayload
+import com.mezon.mobile.util.parseContentText
 import com.mezon.mezon.api.ChannelMessage
 import com.mezon.mezon.api.CreatePollResponse
 import com.mezon.mobile.home.chat.poll.buildPollMessageContent
@@ -320,6 +323,8 @@ class ChatController @Inject constructor(
                         session.token,
                         channelId,
                         clanId,
+                        messageId = messageId,
+                        direction = DIRECTION_AROUND,
                         limit = PAGE_SIZE
                     )
                     val entity = response.messagesList
@@ -740,15 +745,16 @@ class ChatController @Inject constructor(
         mentions: List<MentionData>? = null,
         emojiMarkers: List<EmojiMarker>? = null,
         markdownMarkers: List<MarkdownMarker>? = null,
+        ogpMarker: OgpMarker? = null,
         hashtags: List<com.mezon.mobile.util.HashtagData>? = null,
         topicId: Long = 0L
     ) {
         val mode = channelTypeToStreamMode(channelType)
         val isPublic = !isChannelPrivate
         val cacheKey = messageCacheKey(channelId, topicId)
-        val hasContentExtras = !emojiMarkers.isNullOrEmpty() || !markdownMarkers.isNullOrEmpty() || !hashtags.isNullOrEmpty()
+        val hasContentExtras = !emojiMarkers.isNullOrEmpty() || !markdownMarkers.isNullOrEmpty() || ogpMarker != null || !hashtags.isNullOrEmpty()
         val content = if (!hasContentExtras) buildTextContent(text)
-            else buildTextContentWithEmojis(text, null, emojiMarkers, markdownMarkers, hashtags)
+            else buildTextContentWithEmojis(text, null, emojiMarkers, markdownMarkers, hashtags, ogpMarker)
         val mentionEveryone = mentions?.any { it.userId == ID_MENTION_HERE } == true
         val protoMentions = mentions?.map { m ->
             messageMention {
@@ -1248,15 +1254,16 @@ class ChatController @Inject constructor(
         mentions: List<MentionData>? = null,
         hashtags: List<com.mezon.mobile.util.HashtagData>? = null,
         emojiMarkers: List<EmojiMarker>? = null,
+        ogpMarker: OgpMarker? = null,
         topicId: Long = 0L
     ) {
         val mode = channelTypeToStreamMode(channelType)
         val isPublic = !isChannelPrivate
         val cacheKey = messageCacheKey(channelId, topicId)
-        val hasContentExtras = !hashtags.isNullOrEmpty() || !emojiMarkers.isNullOrEmpty()
+        val hasContentExtras = !hashtags.isNullOrEmpty() || !emojiMarkers.isNullOrEmpty() || ogpMarker != null
         val wireBase = when {
             text.isBlank() -> "{\"t\":\"\"}"
-            hasContentExtras -> buildTextContentWithEmojis(text, null, emojiMarkers, null, hashtags)
+            hasContentExtras -> buildTextContentWithEmojis(text, null, emojiMarkers, null, hashtags, ogpMarker)
             else -> buildTextContent(text)
         }
         val optimisticContent = mergePendingMentionsIntoContent(
@@ -2212,6 +2219,55 @@ class ChatController @Inject constructor(
             } finally {
                 pendingKey?.let { clearPendingApiReaction(it) }
             }
+        }
+    }
+
+    suspend fun sendThreadSeedMessage(
+        channelId: Long,
+        clanId: Long,
+        channelType: Int,
+        isChannelPrivate: Boolean,
+        seed: MessageEntity
+    ): Boolean {
+        val wire = seed.content
+        val attProtos = attachmentsFromEntity(seed)
+        val hasText = parseContentText(wire).trim().isNotEmpty() ||
+            isEmbedOrComponentsPayload(wire) ||
+            wire.contains("\"lk\"")
+        if (!hasText && attProtos.isEmpty()) return true
+        val mode = channelTypeToStreamMode(channelType)
+        val isPublic = !isChannelPrivate
+        val mentionsProto = mentionsFromForwardContent(wire).takeUnless { it.isEmpty() }
+        val mentionsData = messageMentionsToData(mentionsProto)
+        return try {
+            sessionManager.withAutoRefresh { session ->
+                ensureActiveArchivedThreadIfNeeded(session.apiUrl, session.token, channelId, clanId, channelType)
+                ensureMentionedUsersInThread(
+                    session.apiUrl,
+                    session.token,
+                    channelId,
+                    clanId,
+                    channelType,
+                    mentionsData
+                )
+                val request = channelMessageSend {
+                    this.clanId = clanId
+                    this.channelId = channelId
+                    this.mode = mode
+                    this.isPublic = isPublic
+                    this.content = wire
+                    this.code = seed.code
+                    mentionsProto?.let { if (it.isNotEmpty()) mentions.addAll(it) }
+                    if (attProtos.isNotEmpty()) attachments.addAll(attProtos)
+                    mentionEveryone = extractMentionEveryoneFromForwardContent(wire)
+                }
+                channelSend(session.apiUrl, session.token, request)
+                markForwardTargetUsed(channelId, channelType)
+            }
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "sendThreadSeedMessage failed channel=$channelId msg=${seed.id}", e)
+            false
         }
     }
 

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -11,11 +11,13 @@ import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
 import android.graphics.Rect
 import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.Drawable
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.text.Editable
+import android.text.Html
 import android.text.SpannableString
 import android.text.Spanned
 import android.text.TextWatcher
@@ -56,6 +58,7 @@ import com.mezon.mobile.home.ChatController
 import com.mezon.mobile.home.TopicBadgeTracker
 import com.mezon.mobile.home.TopicController
 import com.mezon.mobile.home.chat.thread.CreateThreadFragment
+import com.mezon.mobile.home.chat.CreateThreadSeedStash
 import com.mezon.mobile.home.chat.thread.ThreadListFragment
 import com.mezon.mobile.home.ClanMember
 import com.mezon.mobile.home.LOAD_TYPE_INITIAL
@@ -117,6 +120,8 @@ import com.mezon.mobile.util.parseMarkdownAndStrip
 import com.mezon.mobile.util.restoreInputFromContent
 import com.mezon.mobile.util.resolveStickerSourceUrl
 import com.mezon.mobile.util.firstReferenceMessageId
+import com.mezon.mobile.util.createImgproxyUrl
+import com.mezon.mobile.util.OgpMarker
 import com.mezon.mobile.core.SharedConfig
 import com.mezon.mobile.home.chat.poll.ChatPollBridge
 import com.mezon.mobile.home.chat.poll.CreatePollFragment
@@ -149,6 +154,8 @@ import com.mezon.mobile.home.chat.emoji.EmojiView
 import com.mezon.mobile.util.EmbedFormUtil
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
+import java.net.HttpURLConnection
+import java.net.URL
 
 private const val TAG = "ChatFragment"
 private const val FORWARD_NEARBY_WINDOW_SECONDS = 10 * 60L
@@ -192,6 +199,10 @@ open class ChatFragment : BaseFragment() {
         private const val REQUEST_CALL_PERMISSIONS = 9002
         private const val MENU_DM_VOICE_CALL = 8801
         private const val DM_HEADER_CALL_ICON_DP = 22f
+        private val INPUT_OGP_IMAGE_SIZE = LayoutHelper.dp(40f)
+        private val INPUT_OGP_BAR_CORNER = LayoutHelper.dp(12f).toFloat()
+        private val INPUT_OGP_URL_REGEX = Regex("""https?://[^\s]+""", RegexOption.IGNORE_CASE)
+        private val INPUT_OGP_META_TAG_REGEX = Regex("""<meta\s+[^>]*>""", RegexOption.IGNORE_CASE)
 
         fun newInstance(
             channelId: Long,
@@ -338,6 +349,17 @@ open class ChatFragment : BaseFragment() {
     private var editBar: LinearLayout? = null
     private var editNameView: TextView? = null
     private var editCloseButton: ImageButton? = null
+    private var inputOgpBar: LinearLayout? = null
+    private var inputOgpImage: ImageView? = null
+    private var inputOgpTitle: TextView? = null
+    private var inputOgpDesc: TextView? = null
+    private var inputOgpClose: ImageButton? = null
+    private var inputOgpUrl: String? = null
+    private var inputOgpPreviewData: InputOgpPreview? = null
+    private var dismissedInputOgpUrl: String? = null
+    private var failedInputOgpUrl: String? = null
+    private var inputOgpFetchJob: Job? = null
+    private var inputOgpImageLoad: MezonImageLoader.Cancellable = MezonImageLoader.Cancellable.EMPTY
 
     private lateinit var userClanController: UserClanController
     private lateinit var userController: com.mezon.mobile.home.profile.UserController
@@ -1039,6 +1061,12 @@ open class ChatFragment : BaseFragment() {
             }
         }
 
+        observe(NotificationCenter.channelsDidLoad) { _, _, args ->
+            if (fragmentView == null || isPaused || isTopicMode) return@observe
+            val changedClanId = args.firstOrNull() as? Long ?: return@observe
+            if (changedClanId != clanId || clanId == 0L) return@observe
+            refreshClanHeaderFromChannel()
+        }
 
         observe(NotificationCenter.updateInterfaces) { _, _, args ->
             if (fragmentView == null) return@observe
@@ -1124,6 +1152,21 @@ open class ChatFragment : BaseFragment() {
             emojiButton.setColorFilter(themeColors.getColor(com.mezon.mobile.core.ThemeColors.key_icon_secondary))
             micButton.setColorFilter(themeColors.getColor(com.mezon.mobile.core.ThemeColors.key_icon_secondary))
             attachmentPreviewScroll?.setBackgroundColor(themeColors.surface)
+            inputOgpBar?.background = android.graphics.drawable.GradientDrawable().apply {
+                setColor(themeColors.tertiary)
+                cornerRadius = INPUT_OGP_BAR_CORNER
+            }
+            inputOgpImage?.background = android.graphics.drawable.GradientDrawable().apply {
+                setColor(themeColors.surface)
+                cornerRadius = LayoutHelper.dp(8f).toFloat()
+            }
+            inputOgpTitle?.setTextColor(themeColors.onSurface)
+            inputOgpDesc?.setTextColor(themeColors.onSurfaceVariant)
+            inputOgpClose?.let { btn ->
+                val d = MezonIcon.closeSmallBold.getDrawable(btn.context)
+                d.colorFilter = PorterDuffColorFilter(themeColors.onSurfaceVariant, PorterDuff.Mode.SRC_IN)
+                btn.setImageDrawable(d)
+            }
             replyBar?.setBackgroundColor(themeColors.surface)
             replyNameView?.setTextColor(themeColors.onSurface)
             replyCloseButton?.let { btn ->
@@ -1316,7 +1359,7 @@ open class ChatFragment : BaseFragment() {
             if (clanChannelHeader) {
                 val iconEnum = resolveChannelIcon(entity)
                 val iconPx = channelTitleIconSizePx()
-                val d = iconEnum.getDrawable(context, themeColors)
+                val d = channelTitleIconDrawable(context, iconEnum)
                 setTitleStartIcon(d, iconPx, LayoutHelper.dp(6))
                 setTitle(channelName)
                 setSubtitleStartPadding(0)
@@ -1568,6 +1611,90 @@ open class ChatFragment : BaseFragment() {
         }
         innerLayout.addView(channelAppHotbar, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT))
 
+        inputOgpBar = LinearLayout(context).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            visibility = View.GONE
+            setPadding(LayoutHelper.dp(10f), LayoutHelper.dp(8f), LayoutHelper.dp(10f), LayoutHelper.dp(8f))
+            background = android.graphics.drawable.GradientDrawable().apply {
+                setColor(themeColors.tertiary)
+                cornerRadius = INPUT_OGP_BAR_CORNER
+            }
+        }
+        innerLayout.addView(
+            inputOgpBar,
+            LayoutHelper.createLinear(
+                LayoutHelper.MATCH_PARENT,
+                LayoutHelper.WRAP_CONTENT,
+                0f,
+                Gravity.CENTER_VERTICAL,
+                8f,
+                0f,
+                8f,
+                6f
+            )
+        )
+
+        inputOgpImage = ImageView(context).apply {
+            scaleType = ImageView.ScaleType.CENTER_CROP
+            visibility = View.GONE
+            val shape = android.graphics.drawable.GradientDrawable().apply {
+                setColor(themeColors.surface)
+                cornerRadius = LayoutHelper.dp(8f).toFloat()
+            }
+            background = shape
+            clipToOutline = true
+        }
+        inputOgpBar?.addView(
+            inputOgpImage,
+            LinearLayout.LayoutParams(INPUT_OGP_IMAGE_SIZE, INPUT_OGP_IMAGE_SIZE).apply {
+                marginEnd = LayoutHelper.dp(10f)
+            }
+        )
+
+        val inputOgpTextWrap = LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+        }
+        inputOgpBar?.addView(
+            inputOgpTextWrap,
+            LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+        )
+
+        inputOgpTitle = TextView(context).apply {
+            setTextColor(themeColors.onSurface)
+            textSize = 13f
+            maxLines = 1
+            ellipsize = android.text.TextUtils.TruncateAt.END
+        }
+        inputOgpTextWrap.addView(inputOgpTitle)
+
+        inputOgpDesc = TextView(context).apply {
+            setTextColor(themeColors.onSurfaceVariant)
+            textSize = 12f
+            maxLines = 1
+            ellipsize = android.text.TextUtils.TruncateAt.END
+        }
+        inputOgpTextWrap.addView(inputOgpDesc)
+
+        inputOgpClose = ImageButton(context).apply {
+            val drawable = MezonIcon.closeSmallBold.getDrawable(context)
+            drawable.colorFilter = PorterDuffColorFilter(themeColors.onSurfaceVariant, PorterDuff.Mode.SRC_IN)
+            setImageDrawable(drawable)
+            setBackgroundColor(Color.TRANSPARENT)
+            scaleType = ImageView.ScaleType.CENTER_INSIDE
+            setPadding(LayoutHelper.dp(12f), LayoutHelper.dp(12f), LayoutHelper.dp(12f), LayoutHelper.dp(12f))
+            setOnClickListener {
+                dismissedInputOgpUrl = inputOgpUrl
+                clearInputOgpPreview()
+            }
+        }
+        inputOgpBar?.addView(
+            inputOgpClose,
+            LinearLayout.LayoutParams(INPUT_OGP_IMAGE_SIZE, INPUT_OGP_IMAGE_SIZE).apply {
+                marginStart = LayoutHelper.dp(6f)
+            }
+        )
+
         inputBar = LinearLayout(context).apply {
             orientation = LinearLayout.HORIZONTAL
             gravity = Gravity.BOTTOM
@@ -1717,6 +1844,7 @@ open class ChatFragment : BaseFragment() {
                 pruneMentionTrackersAgainstText()
                 pruneHashtagTrackersAgainstText()
                 updateSendButtonState()
+                updateInputOgpPreview(s?.toString().orEmpty())
                 checkSuggestionTrigger()
             }
         })
@@ -2135,6 +2263,8 @@ open class ChatFragment : BaseFragment() {
         if (clanId == 0L) {
             refreshDmHeaderTitleFromDialog()
             refreshWelcomeFromDialog()
+        } else if (!isTopicMode) {
+            refreshClanHeaderFromChannel()
         }
     }
 
@@ -2144,6 +2274,8 @@ open class ChatFragment : BaseFragment() {
             if (clanId == 0L) {
                 refreshDmHeaderTitleFromDialog()
                 refreshWelcomeFromDialog()
+            } else if (!isTopicMode) {
+                refreshClanHeaderFromChannel()
             }
         }
         if (pendingDisplayRoleUiRefresh) {
@@ -2526,6 +2658,19 @@ open class ChatFragment : BaseFragment() {
         editingMessage = null
         mentionTrackers.clear()
         hashtagTrackers.clear()
+        inputOgpFetchJob?.cancel()
+        inputOgpFetchJob = null
+        inputOgpImageLoad.cancel()
+        inputOgpImageLoad = MezonImageLoader.Cancellable.EMPTY
+        inputOgpBar = null
+        inputOgpImage = null
+        inputOgpTitle = null
+        inputOgpDesc = null
+        inputOgpClose = null
+        inputOgpUrl = null
+        inputOgpPreviewData = null
+        dismissedInputOgpUrl = null
+        failedInputOgpUrl = null
         suggestionsPopup = null
         suggestionsAdapter = null
         EmbedFormUtil.clearAll()
@@ -3637,7 +3782,7 @@ open class ChatFragment : BaseFragment() {
         val bar = actionBar as? ActionBarView ?: return
         val iconEnum = resolveChannelIcon(entity)
         val iconPx = channelTitleIconSizePx()
-        val d = iconEnum.getDrawable(bar.context, themeColors)
+        val d = channelTitleIconDrawable(bar.context, iconEnum)
         bar.setTitleStartIcon(d, iconPx, LayoutHelper.dp(6))
         bar.setTitle(channelName)
         bar.setSubtitleStartPadding(0)
@@ -3659,15 +3804,14 @@ open class ChatFragment : BaseFragment() {
         } else {
             bar.setSubtitle(null)
         }
+        bar.requestLayout()
     }
 
     private fun refreshThreadWelcomeCreator() {
         if (channelType != CHANNEL_TYPE_THREAD || !::adapter.isInitialized) return
         val creator = messages.lastOrNull { it.isNormalMessage && it.senderId != 0L }
         val nextName = if (creator != null) {
-            val member = memberResolver.resolveMember(creator.senderId, clanId, channelId, channelType)
-            member?.let { it.clanNick.ifBlank { it.displayName.ifBlank { it.username } } }
-                ?: creator.senderName
+            resolveCreatorDisplayName(creator.senderId, creator.senderName)
         } else {
             ""
         }
@@ -3676,6 +3820,28 @@ open class ChatFragment : BaseFragment() {
             adapter.welcomeCreatorName = sanitized
             adapter.notifyWelcomeCellChanged()
         }
+    }
+
+    private fun resolveCreatorDisplayName(userId: Long, fallbackName: String): String {
+        if (userId == 0L) return fallbackName
+        val member = if (clanId != 0L) {
+            memberResolver.resolveClanScopedMember(userId, clanId, channelId, channelType)
+        } else {
+            memberResolver.resolveMember(userId, clanId, channelId, channelType)
+        }
+        val clanNick = member?.clanNick?.trim().orEmpty()
+        if (clanNick.isNotBlank()) return clanNick
+        val fromMessage = fallbackName.trim()
+        if (fromMessage.isNotBlank()) return fromMessage
+        val memberDisplay = member?.displayName?.trim().orEmpty()
+        if (memberDisplay.isNotBlank()) return memberDisplay
+        if (userId == userController.userId) {
+            val self = userController.displayName.trim()
+            if (self.isNotBlank()) return self
+        }
+        val global = userClanController.getUserById(userId)?.displayName?.trim().orEmpty()
+        if (global.isNotBlank()) return global
+        return fallbackName
     }
 
     private fun refreshWelcomeFromDialog() {
@@ -3958,6 +4124,16 @@ open class ChatFragment : BaseFragment() {
         val mdResult = parseMarkdownAndStrip(text)
         val cleanedText = mdResult.cleanedText
         val mdMarkers = mdResult.markers.ifEmpty { null }
+        val ogpMarker = buildInputOgpMarker(cleanedText, inputOgpPreviewData)
+        val filteredMdMarkers = if (ogpMarker == null) mdMarkers else {
+            mdMarkers
+                ?.filterNot {
+                    it.type == "lk" &&
+                        it.s < ogpMarker.e &&
+                        ogpMarker.s < it.e
+                }
+                ?.ifEmpty { null }
+        }
 
         val fromTrackers = mentionTrackers.mapNotNull { m ->
             val inTrimmed = mentionOffsetsForTrimmed(rawInput, text, m) ?: return@mapNotNull null
@@ -3995,14 +4171,14 @@ open class ChatFragment : BaseFragment() {
             val emojiMarkers = buildEmojiMarkers(cleanedText)
             chatController.editMessage(
                 channelId, clanId, channelType, isPrivate, editMsg.id,
-                cleanedText, mentions, emojiMarkers, mdMarkers, hashtags,
+                cleanedText, mentions, emojiMarkers, filteredMdMarkers, hashtags,
                 existingMessage = editMsg
             )
             clearEditState()
             return
         }
 
-        Log.d(TAG, "sendMessage channelId=$channelId clanId=$clanId channelType=$channelType isPrivate=$isPrivate textLen=${cleanedText.length} attachments=${pendingAttachments.size} hasReply=${references != null} mdMarkers=${mdMarkers?.size ?: 0} hashtags=${hashtags?.size ?: 0}")
+        Log.d(TAG, "sendMessage channelId=$channelId clanId=$clanId channelType=$channelType isPrivate=$isPrivate textLen=${cleanedText.length} attachments=${pendingAttachments.size} hasReply=${references != null} mdMarkers=${filteredMdMarkers?.size ?: 0} ogp=${ogpMarker != null} hashtags=${hashtags?.size ?: 0}")
 
         if (pendingAttachments.isNotEmpty()) {
             val ctx = getContext() ?: return
@@ -4015,6 +4191,7 @@ open class ChatFragment : BaseFragment() {
                 mentions,
                 hashtags,
                 emojiMarkers,
+                ogpMarker,
                 topicId = topicId
             )
             clearPendingAttachments()
@@ -4022,7 +4199,7 @@ open class ChatFragment : BaseFragment() {
             val emojiMarkers = buildEmojiMarkers(cleanedText)
             chatController.sendMessage(
                 channelId, clanId, channelType, isPrivate, cleanedText,
-                references, mentions, emojiMarkers, mdMarkers, hashtags,
+                references, mentions, emojiMarkers, filteredMdMarkers, ogpMarker, hashtags,
                 topicId = topicId
             )
         }
@@ -4030,6 +4207,9 @@ open class ChatFragment : BaseFragment() {
         emojiObjPicked.clear()
         mentionTrackers.clear()
         hashtagTrackers.clear()
+        dismissedInputOgpUrl = null
+        failedInputOgpUrl = null
+        clearInputOgpPreview()
         clearReplyState()
     }
 
@@ -4534,6 +4714,224 @@ open class ChatFragment : BaseFragment() {
         } else {
             micButton.visibility = if (canSend && !showSend) View.VISIBLE else View.GONE
         }
+    }
+
+    private data class InputOgpPreview(
+        val url: String,
+        val title: String,
+        val description: String,
+        val imageUrl: String
+    )
+
+    private fun updateInputOgpPreview(rawText: String) {
+        val candidate = extractFirstInputUrl(rawText)
+        if (candidate == null) {
+            inputOgpUrl = null
+            dismissedInputOgpUrl = null
+            failedInputOgpUrl = null
+            clearInputOgpPreview()
+            return
+        }
+        if (dismissedInputOgpUrl != null && dismissedInputOgpUrl == candidate) {
+            return
+        }
+        if (failedInputOgpUrl != null && failedInputOgpUrl == candidate) {
+            return
+        }
+        if (candidate == inputOgpUrl && inputOgpBar?.visibility == View.VISIBLE) {
+            return
+        }
+        inputOgpUrl = candidate
+        showInputOgpLoading(candidate)
+        inputOgpFetchJob?.cancel()
+        inputOgpFetchJob = fragmentScope.launch(mainDispatcher) {
+            delay(320)
+            val preview = withContext(ioDispatcher) { fetchInputOgpPreview(candidate) }
+            if (!isActive) return@launch
+            if (inputOgpUrl != candidate) return@launch
+            if (preview == null) {
+                failedInputOgpUrl = candidate
+                clearInputOgpPreview()
+                return@launch
+            }
+            renderInputOgpPreview(preview)
+        }
+    }
+
+    private fun showInputOgpLoading(url: String) {
+        inputOgpBar?.visibility = View.VISIBLE
+        inputOgpTitle?.text = getString(R.string.common_loading_data)
+        inputOgpDesc?.text = url
+        inputOgpImageLoad.cancel()
+        inputOgpImageLoad = MezonImageLoader.Cancellable.EMPTY
+        inputOgpImage?.setImageDrawable(null)
+        inputOgpImage?.visibility = View.GONE
+    }
+
+    private fun clearInputOgpPreview() {
+        inputOgpFetchJob?.cancel()
+        inputOgpFetchJob = null
+        inputOgpPreviewData = null
+        inputOgpImageLoad.cancel()
+        inputOgpImageLoad = MezonImageLoader.Cancellable.EMPTY
+        inputOgpImage?.setImageDrawable(null)
+        inputOgpImage?.visibility = View.GONE
+        inputOgpTitle?.text = ""
+        inputOgpDesc?.text = ""
+        inputOgpBar?.visibility = View.GONE
+    }
+
+    private fun renderInputOgpPreview(preview: InputOgpPreview) {
+        inputOgpPreviewData = preview
+        inputOgpBar?.visibility = View.VISIBLE
+        inputOgpTitle?.text = preview.title.ifBlank { preview.url }
+        inputOgpDesc?.text = preview.description.ifBlank { preview.url }
+        inputOgpImageLoad.cancel()
+        inputOgpImageLoad = MezonImageLoader.Cancellable.EMPTY
+        if (preview.imageUrl.isBlank()) {
+            inputOgpImage?.setImageDrawable(null)
+            inputOgpImage?.visibility = View.GONE
+            return
+        }
+        val imgView = inputOgpImage ?: return
+        imgView.visibility = View.VISIBLE
+        val requestUrl = createImgproxyUrl(preview.imageUrl, INPUT_OGP_IMAGE_SIZE, INPUT_OGP_IMAGE_SIZE, "fill")
+        val targetUrl = requestUrl.ifBlank { preview.imageUrl }
+        val loader = MezonImageLoader.getInstance(imgView.context)
+        inputOgpImageLoad = loader.load(
+            targetUrl,
+            INPUT_OGP_IMAGE_SIZE,
+            INPUT_OGP_IMAGE_SIZE,
+            onSuccess = { bmp ->
+                if (inputOgpUrl != preview.url) return@load
+                imgView.setImageBitmap(bmp)
+                imgView.visibility = View.VISIBLE
+            },
+            onError = {
+                if (inputOgpUrl != preview.url) return@load
+                imgView.setImageDrawable(null)
+                imgView.visibility = View.GONE
+            }
+        )
+    }
+
+    private fun fetchInputOgpPreview(url: String): InputOgpPreview? {
+        return try {
+            val conn = (URL(url).openConnection() as? HttpURLConnection) ?: return null
+            conn.instanceFollowRedirects = true
+            conn.connectTimeout = 5000
+            conn.readTimeout = 6000
+            conn.requestMethod = "GET"
+            conn.setRequestProperty("User-Agent", "Mozilla/5.0")
+            conn.connect()
+            val contentType = conn.contentType
+            if (contentType != null && !contentType.contains("html", ignoreCase = true)) {
+                conn.disconnect()
+                return null
+            }
+            val html = conn.inputStream.bufferedReader().use { reader ->
+                val sb = StringBuilder()
+                val buffer = CharArray(4096)
+                var total = 0
+                val maxChars = 200_000
+                while (true) {
+                    val read = reader.read(buffer)
+                    if (read <= 0) break
+                    sb.append(buffer, 0, read)
+                    total += read
+                    if (total >= maxChars) break
+                }
+                sb.toString()
+            }
+            conn.disconnect()
+            if (html.isBlank()) return null
+            val ogTitle = findMetaContent(html, "og:title")
+            val ogDesc = findMetaContent(html, "og:description")
+            val ogImage = findMetaContent(html, "og:image")
+            val titleTag = Regex("""<title[^>]*>(.*?)</title>""", setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
+                .find(html)
+                ?.groupValues
+                ?.getOrNull(1)
+                ?.let(::decodeHtml)
+                .orEmpty()
+                .trim()
+            val title = ogTitle.ifBlank { titleTag }
+            val desc = ogDesc.trim()
+            val image = ogImage.trim()
+            if (title.isBlank() || desc.isBlank() || image.isBlank()) return null
+            InputOgpPreview(url = url, title = title, description = desc, imageUrl = image)
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun findMetaContent(html: String, key: String): String {
+        for (match in INPUT_OGP_META_TAG_REGEX.findAll(html)) {
+            val tag = match.value
+            val property = extractMetaAttr(tag, "property")
+            val name = extractMetaAttr(tag, "name")
+            val content = extractMetaAttr(tag, "content")
+            if (content.isBlank()) continue
+            if (property.equals(key, ignoreCase = true) || name.equals(key, ignoreCase = true)) {
+                return decodeHtml(content).trim()
+            }
+        }
+        return ""
+    }
+
+    private fun extractMetaAttr(tag: String, attr: String): String {
+        val re = Regex("""$attr\s*=\s*(['"])(.*?)\1""", RegexOption.IGNORE_CASE)
+        return re.find(tag)?.groupValues?.getOrNull(2).orEmpty()
+    }
+
+    private fun decodeHtml(raw: String): String {
+        return Html.fromHtml(raw, Html.FROM_HTML_MODE_LEGACY).toString()
+    }
+
+    private fun extractFirstInputUrl(rawText: String): String? {
+        val match = INPUT_OGP_URL_REGEX.find(rawText) ?: return null
+        var candidate = match.value.trim()
+        while (candidate.isNotEmpty() && candidate.last() in ".,;:!?)]}\\\"") {
+            candidate = candidate.dropLast(1)
+        }
+        return candidate.takeIf { it.startsWith("http://", true) || it.startsWith("https://", true) }
+    }
+
+    private fun buildInputOgpMarker(cleanedText: String, preview: InputOgpPreview?): OgpMarker? {
+        val p = preview ?: return null
+        if (cleanedText.isBlank()) return null
+        val targetUrl = p.url.trim()
+        if (targetUrl.isEmpty()) return null
+        val startByExact = cleanedText.indexOf(targetUrl)
+        val match = INPUT_OGP_URL_REGEX.find(cleanedText)
+        val start = when {
+            startByExact >= 0 -> startByExact
+            match != null -> match.range.first
+            else -> -1
+        }
+        if (start < 0) return null
+        val urlInText = if (startByExact >= 0) targetUrl else {
+            var detected = match!!.value.trim()
+            while (detected.isNotEmpty() && detected.last() in ".,;:!?)]}\\\"") {
+                detected = detected.dropLast(1)
+            }
+            detected
+        }
+        if (urlInText.isEmpty()) return null
+        val end = (start + urlInText.length).coerceAtMost(cleanedText.length)
+        if (end <= start) return null
+        val title = p.title.trim()
+        val description = p.description.trim()
+        val image = p.imageUrl.trim()
+        if (title.isEmpty() || description.isEmpty() || image.isEmpty()) return null
+        return OgpMarker(
+            s = start,
+            e = end,
+            index = start,
+            title = title,
+            description = description,
+            image = image
+        )
     }
 
     @SuppressWarnings("ClickableViewAccessibility")
@@ -5565,22 +5963,26 @@ open class ChatFragment : BaseFragment() {
                     MezonToast.show(this, ToastOverlay.ToastType.ERROR, getString(R.string.channel_permissions_no_access))
                     return
                 }
-                presentFragment(
-                    CreateThreadFragment.newInstance(
-                        channelId,
-                        channelName,
-                        clanId
-                    )
-                )
-            }
-            MessageActionBottomSheet.ActionType.TopicDiscussion -> {
-                if (!canShowTopicDiscussionInMessageMenu(msg)) return
+                CreateThreadSeedStash.pendingSeedMessage = msg
                 presentFragment(
                     CreateThreadFragment.newInstance(
                         channelId,
                         channelName,
                         clanId,
                         seedMessageId = msg.id
+                    )
+                )
+            }
+            MessageActionBottomSheet.ActionType.TopicDiscussion -> {
+                if (!canShowTopicDiscussionInMessageMenu(msg)) return
+                CreateThreadSeedStash.pendingSeedMessage = msg
+                presentFragment(
+                    CreateThreadFragment.newInstance(
+                        channelId,
+                        channelName,
+                        clanId,
+                        seedMessageId = msg.id,
+                        useTopicFlow = true
                     )
                 )
             }
@@ -6261,6 +6663,14 @@ open class ChatFragment : BaseFragment() {
 
     private fun channelTitleIconSizePx(): Int = LayoutHelper.dp(20)
 
+    private fun channelTitleIconDrawable(context: Context, iconEnum: MezonIcon): Drawable {
+        val drawable = iconEnum.getDrawable(context, themeColors)
+        if (!iconEnum.shouldKeepOriginalFill()) {
+            drawable.colorFilter = PorterDuffColorFilter(themeColors.textStrong, PorterDuff.Mode.SRC_IN)
+        }
+        return drawable
+    }
+
     private fun buildChannelTitle(context: Context): CharSequence {
         val isDmChannel = channelType == CHANNEL_TYPE_DM || channelType == CHANNEL_TYPE_GROUP
         if (isDmChannel || clanId == 0L) return channelName
@@ -6275,7 +6685,7 @@ open class ChatFragment : BaseFragment() {
         if (isThread) {
             span.usePaintColor = false
         } else {
-            span.overrideColor = themeColors.onSurface
+            span.overrideColor = themeColors.textStrong
         }
 
         val text = SpannableString("\u200B $channelName")

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
@@ -267,6 +267,21 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
     private var ogpBlockTop = 0
     private var ogpBlockRight = 0
     private var ogpBlockBottom = 0
+    private val ogpCardRect = RectF()
+    private val ogpCardPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.FILL
+    }
+    private val ogpAccentPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.FILL
+    }
+    private val ogpTitlePaint = TextPaint(Paint.ANTI_ALIAS_FLAG).apply {
+        textSize = LayoutHelper.sp(14f)
+        typeface = Typeface.DEFAULT_BOLD
+        isFakeBoldText = true
+    }
+    private val ogpDescPaint = TextPaint(Paint.ANTI_ALIAS_FLAG).apply {
+        textSize = LayoutHelper.sp(12f)
+    }
 
     private var pressedOnInviteJoin = false
 
@@ -1255,19 +1270,23 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         } else null
         if (ogpData != null) {
             val ogp = ogpData!!
-            val ogpTextW = (textWidth * 0.9f).toInt().coerceAtLeast(1)
+            val ogpTextW = (textWidth - OGP_ACCENT_W - OGP_PADDING * 2).coerceAtLeast(1)
+            ogpTitlePaint.color = theme.textLink
+            ogpTitlePaint.textSize = currentContentPaint.textSize
+            ogpDescPaint.color = theme.colorText
+            ogpDescPaint.textSize = theme.chatTimePaint.textSize
             val truncTitle = if (ogp.title.length > OGP_MAX_CHARS) ogp.title.substring(0, OGP_MAX_CHARS) else ogp.title
-            ogpTitleLayout = StaticLayout.Builder.obtain(truncTitle, 0, truncTitle.length, currentContentPaint, ogpTextW)
+            ogpTitleLayout = StaticLayout.Builder.obtain(truncTitle, 0, truncTitle.length, ogpTitlePaint, ogpTextW)
                 .setMaxLines(2)
                 .setEllipsize(TextUtils.TruncateAt.END)
                 .build()
             val truncDesc = if (ogp.description.length > OGP_MAX_CHARS) ogp.description.substring(0, OGP_MAX_CHARS) else ogp.description
-            ogpDescLayout = StaticLayout.Builder.obtain(truncDesc, 0, truncDesc.length, theme.chatTimePaint, ogpTextW)
+            ogpDescLayout = StaticLayout.Builder.obtain(truncDesc, 0, truncDesc.length, ogpDescPaint, ogpTextW)
                 .setMaxLines(2)
                 .setEllipsize(TextUtils.TruncateAt.END)
                 .build()
-            ogpImageW = (textWidth * 0.6f).toInt().coerceAtLeast(LayoutHelper.dp(120))
-            ogpImageH = (ogpImageW * 0.6f).toInt().coerceAtLeast(LayoutHelper.dp(80))
+            ogpImageW = ogpTextW
+            ogpImageH = min((ogpImageW * 0.6f).toInt(), OGP_IMAGE_MAX_H).coerceAtLeast(1)
             ogpImage.setRoundRadius(OGP_RADIUS.toInt())
             val proxiedImg = createImgproxyUrl(ogp.image, ogpImageW, ogpImageH, "fill")
             ogpImage.setImage(proxiedImg, null, context)
@@ -1346,7 +1365,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         }
 
         val replyW = if (hasReply) cachedReplyNameW + cachedReplyTextW + REPLY_AVATAR_SIZE + REPLY_H_GAP * 2 else 0f
-        val ogpW = if (ogpData != null) maxOf(cachedOgpTitleW, cachedOgpDescW, ogpImageW.toFloat()) else 0f
+        val ogpW = if (ogpData != null) maxOf(cachedOgpTitleW, cachedOgpDescW, ogpImageW.toFloat()) + OGP_ACCENT_W + OGP_PADDING * 2 else 0f
         val fileW = if (drawFileAttachment) fileRowWidth.toFloat() else 0f
         val audioW = if (drawAudioAttachment) audioPillWidth.toFloat() else 0f
         val embedW = if (hasEmbedContent) (bubbleMaxW).toFloat() else 0f
@@ -1515,6 +1534,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         }
         if (ogpData != null) {
             h += GAP_V_INNER
+            h += OGP_PADDING * 2
             ogpTitleLayout?.let { block -> h += block.height + GAP_V_INNER }
             ogpDescLayout?.let { block -> h += block.height + GAP_V_INNER }
             h += ogpImageH + GAP_V_INNER
@@ -2212,6 +2232,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
                     }
                     if (ogpData != null) {
                         reacBaseY += GAP_V_INNER
+                        reacBaseY += OGP_PADDING * 2
                         ogpTitleLayout?.let { reacBaseY += it.height + GAP_V_INNER }
                         ogpDescLayout?.let { reacBaseY += it.height + GAP_V_INNER }
                         reacBaseY += ogpImageH + GAP_V_INNER
@@ -3017,30 +3038,41 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
     }
 
     private fun drawOgpBlock(canvas: Canvas, left: Float, top: Float): Float {
-        val data = ogpData ?: return top
-        var y = top
+        if (ogpData == null) return top
+        val innerLeft = left + OGP_ACCENT_W + OGP_PADDING
+        var y = top + OGP_PADDING
+        val contentW = maxOf(cachedOgpTitleW, cachedOgpDescW, ogpImageW.toFloat())
+        val cardRight = left + OGP_ACCENT_W + OGP_PADDING * 2 + contentW
+        val cardBottom = top + OGP_PADDING * 2 +
+            (ogpTitleLayout?.let { it.height + GAP_V_INNER } ?: 0) +
+            (ogpDescLayout?.let { it.height + GAP_V_INNER } ?: 0) +
+            ogpImageH
+        ogpCardPaint.color = theme.border
+        ogpAccentPaint.color = theme.blurple
+        ogpCardRect.set(left, top, cardRight, cardBottom)
+        canvas.drawRoundRect(ogpCardRect, OGP_CARD_RADIUS, OGP_CARD_RADIUS, ogpCardPaint)
+        canvas.drawRect(left, top, left + OGP_ACCENT_W, cardBottom, ogpAccentPaint)
         ogpBlockLeft = left.toInt()
-        ogpBlockTop = y.toInt()
+        ogpBlockTop = top.toInt()
         ogpTitleLayout?.let {
             canvas.save()
-            canvas.translate(left, y)
+            canvas.translate(innerLeft, y)
             it.draw(canvas)
             canvas.restore()
             y += it.height + GAP_V_INNER
         }
         ogpDescLayout?.let {
             canvas.save()
-            canvas.translate(left, y)
+            canvas.translate(innerLeft, y)
             it.draw(canvas)
             canvas.restore()
             y += it.height + GAP_V_INNER
         }
-        ogpImage.setImageCoords(left, y, ogpImageW.toFloat(), ogpImageH.toFloat())
+        ogpImage.setImageCoords(innerLeft, y, ogpImageW.toFloat(), ogpImageH.toFloat())
         ogpImage.draw(canvas)
-        y += ogpImageH
-        ogpBlockRight = (left + maxOf(cachedOgpTitleW, cachedOgpDescW, ogpImageW.toFloat())).toInt()
-        ogpBlockBottom = y.toInt()
-        return y
+        ogpBlockRight = cardRight.toInt()
+        ogpBlockBottom = cardBottom.toInt()
+        return cardBottom
     }
 
     private var gridExtraCount = 0
@@ -4205,6 +4237,10 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         private val LINK_INVITE_V_MARGIN = LayoutHelper.dp(12) 
         private val MEDIA_RADIUS = LayoutHelper.dp(12).toFloat()
         private val OGP_RADIUS = LayoutHelper.dp(8).toFloat()
+        private val OGP_CARD_RADIUS = LayoutHelper.dp(4).toFloat()
+        private val OGP_PADDING = LayoutHelper.dp(10)
+        private val OGP_ACCENT_W = LayoutHelper.dp(4)
+        private val OGP_IMAGE_MAX_H = LayoutHelper.dp(150)
         private const val OGP_MAX_CHARS = 200
         private val PLAY_BTN_SIZE = LayoutHelper.dp(48).toFloat()
         private val REPLY_AVATAR_SIZE = LayoutHelper.dp(16)

--- a/app/src/main/java/com/mezon/mobile/home/chat/CreateThreadSeedStash.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/CreateThreadSeedStash.kt
@@ -1,0 +1,12 @@
+package com.mezon.mobile.home.chat
+
+internal object CreateThreadSeedStash {
+
+    var pendingSeedMessage: MessageEntity? = null
+
+    fun takeSeedMessage(expectedId: Long): MessageEntity? {
+        val msg = pendingSeedMessage
+        pendingSeedMessage = null
+        return msg?.takeIf { it.id == expectedId }
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/home/chat/WelcomeMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/WelcomeMessageCell.kt
@@ -3,6 +3,8 @@ package com.mezon.mobile.home.chat
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Paint
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
 import android.graphics.RectF
 import android.graphics.drawable.Drawable
 import android.text.StaticLayout
@@ -71,15 +73,16 @@ class WelcomeMessageCell(context: Context, private val theme: ThemeColors) : Vie
 
     private fun resolveChannelIcon(): Drawable? {
         if (isDM) return null
-        if (isThread) {
-            return if (isPrivate) {
-                MezonIcon.threadLockIcon.getDrawable(context, theme)
-            } else {
-                MezonIcon.threadIcon.getDrawable(context)
-            }
+        val iconEnum = if (isThread) {
+            if (isPrivate) MezonIcon.threadLockIcon else MezonIcon.threadIcon
+        } else {
+            if (isPrivate) MezonIcon.channelTextLock else MezonIcon.channelText
         }
-        val icon = if (isPrivate) MezonIcon.channelTextLock else MezonIcon.channelText
-        return icon.getDrawable(context)
+        val drawable = iconEnum.getDrawable(context, theme)
+        if (!iconEnum.shouldKeepOriginalFill()) {
+            drawable.colorFilter = PorterDuffColorFilter(theme.tabLabelInactive, PorterDuff.Mode.SRC_IN)
+        }
+        return drawable
     }
 
     private fun loadAvatar() {

--- a/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/ChannelInfoFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/ChannelInfoFragment.kt
@@ -2,8 +2,11 @@ package com.mezon.mobile.home.chat.channelinfo
 
 import android.app.Activity
 import android.app.Dialog
+import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
 import android.graphics.drawable.GradientDrawable
@@ -36,8 +39,7 @@ import com.mezon.mobile.home.UserClanController
 import com.mezon.mobile.home.clans.ChannelController
 import com.mezon.mobile.home.clans.ChannelPermissionController
 import com.mezon.mobile.home.clans.PermissionPolicy
-import com.mezon.mobile.home.messages.GroupAvatar
-import com.mezon.mobile.home.messages.isDefaultGroupAvatarUrl
+
 import com.mezon.mobile.home.clans.CHANNEL_TYPE_APP
 import com.mezon.mobile.home.clans.CHANNEL_TYPE_STREAMING
 import com.mezon.mobile.home.profile.UserController
@@ -46,13 +48,14 @@ import com.mezon.mobile.network.CHANNEL_TYPE_DM
 import com.mezon.mobile.network.CHANNEL_TYPE_GROUP
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import com.mezon.mobile.home.chat.thread.ThreadListFragment
 import com.mezon.mobile.home.messages.NewGroupFragment
 import com.mezon.mobile.home.PinMessageController
 import com.mezon.mobile.MainActivity
 import com.mezon.mobile.search.GlobalSearchFragment
 import com.mezon.mobile.ui.cells.ActionBarView
-import com.mezon.mobile.ui.cells.AvatarView
+
 import com.mezon.mobile.ui.cells.MezonIcon
 import com.mezon.mobile.ui.cells.ScreenStateView
 import com.mezon.mobile.util.CreateChannelNameValidator
@@ -68,6 +71,7 @@ class ChannelInfoFragment : BaseFragment() {
         private const val ARG_PARENT_ID = "parentId"
         private const val REQUEST_CODE_PICK_GROUP_AVATAR = 9124
         private const val MAX_GROUP_AVATAR_BYTES = 8 * 1024 * 1024
+        private const val GROUP_AVATAR_PREVIEW_MAX_SIDE = 512
 
         fun newInstance(
             channelId: Long,
@@ -105,7 +109,7 @@ class ChannelInfoFragment : BaseFragment() {
     private lateinit var permissionPolicy: PermissionPolicy
     private var settingsActionGap: View? = null
     private var settingsActionView: View? = null
-    private var dmHeaderAvatarView: AvatarView? = null
+    private var dmHeaderAvatarView: DmHeaderAvatarView? = null
     private var editGroupSheet: DmGroupEditBottomSheet? = null
 
     private lateinit var channelFilesController: ChannelFilesController
@@ -250,7 +254,7 @@ class ChannelInfoFragment : BaseFragment() {
         val chatActionBar = ActionBarView(context, themeColors).apply {
             setBackClickListener { finishFragment() }
             setBackgroundColor(themeColors.surface)
-            setCenterTitle(false)
+            setCenterTitle(true)
             if (isDm) {
                 setTitle(channelName)
                 setTitleStartIcon(null, 0, 0)
@@ -340,27 +344,15 @@ class ChannelInfoFragment : BaseFragment() {
         val avatarUrl = dm?.avatarUrl ?: ""
         val displayName = dm?.displayName?.ifBlank { dm.label } ?: channelName
 
+        val placeholderKey = dm?.avatarPlaceholderKey() ?: displayName
+        val av = DmHeaderAvatarView(context).apply {
+            setSizeDp(avatarSize)
+            bind(channelType, channelId, avatarUrl, placeholderKey)
+        }
+        dmHeaderAvatarView = av
+        avatarContainer.addView(av, LayoutHelper.createFrame(avatarSize, avatarSize, Gravity.CENTER))
         if (channelType == CHANNEL_TYPE_GROUP) {
-            val av = AvatarView(context).apply {
-                setSizeDp(avatarSize)
-                setInfo(channelId, channelName)
-                if (!isDefaultGroupAvatarUrl(avatarUrl)) {
-                    setImageUrl(avatarUrl)
-                } else {
-                    setPhoto(GroupAvatar.bitmap(context))
-                }
-            }
-            dmHeaderAvatarView = av
-            avatarContainer.addView(av, LayoutHelper.createFrame(avatarSize, avatarSize, Gravity.CENTER))
             avatarContainer.setOnClickListener { showGroupEditSheet(context) }
-        } else {
-            val av = AvatarView(context).apply {
-                setSizeDp(avatarSize)
-                setInfo(channelId, displayName)
-                setImageUrl(avatarUrl)
-            }
-            dmHeaderAvatarView = av
-            avatarContainer.addView(av, LayoutHelper.createFrame(avatarSize, avatarSize, Gravity.CENTER))
         }
 
         container.addView(avatarContainer, LayoutHelper.createLinear(
@@ -720,23 +712,58 @@ class ChannelInfoFragment : BaseFragment() {
         val context = getContext() ?: return
         val resolver = context.contentResolver
         val sheet = editGroupSheet ?: return
-        sheet.setUploading(true)
         fragmentScope.launch(Dispatchers.Main.immediate) {
+            val preview = withContext(Dispatchers.IO) {
+                decodeGroupAvatarPreview(resolver, uri, GROUP_AVATAR_PREVIEW_MAX_SIDE)
+            }
+            if (preview != null) {
+                sheet.setPreviewBitmap(preview)
+            }
+            sheet.setUploading(true)
             val result = dialogsController.uploadDmGroupAvatar(uri, resolver, MAX_GROUP_AVATAR_BYTES)
             sheet.setUploading(false)
             when (result) {
                 is DmGroupAvatarUploadResult.Success -> sheet.setDraftAvatar(result.url)
-                DmGroupAvatarUploadResult.TooLarge -> Toast.makeText(
-                    context,
-                    getString(R.string.clan_image_too_large, MAX_GROUP_AVATAR_BYTES / (1024 * 1024)),
-                    Toast.LENGTH_SHORT
-                ).show()
-                DmGroupAvatarUploadResult.Failed -> Toast.makeText(
-                    context,
-                    getString(R.string.dm_group_update_failed),
-                    Toast.LENGTH_SHORT
-                ).show()
+                DmGroupAvatarUploadResult.TooLarge -> {
+                    sheet.setPreviewBitmap(null)
+                    Toast.makeText(
+                        context,
+                        getString(R.string.clan_image_too_large, MAX_GROUP_AVATAR_BYTES / (1024 * 1024)),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+                DmGroupAvatarUploadResult.Failed -> {
+                    sheet.setPreviewBitmap(null)
+                    Toast.makeText(
+                        context,
+                        getString(R.string.dm_group_update_failed),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
             }
+        }
+    }
+
+    private fun decodeGroupAvatarPreview(
+        resolver: ContentResolver,
+        uri: Uri,
+        maxSide: Int
+    ): Bitmap? {
+        return try {
+            val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            resolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, bounds) }
+            if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null
+            var sampleSize = 1
+            while (bounds.outWidth / sampleSize > maxSide || bounds.outHeight / sampleSize > maxSide) {
+                sampleSize *= 2
+            }
+            val options = BitmapFactory.Options().apply {
+                inSampleSize = sampleSize
+                inPreferredConfig = Bitmap.Config.ARGB_8888
+            }
+            resolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, options) }
+        } catch (_: Exception) {
+            null
         }
     }
 
@@ -774,20 +801,8 @@ class ChannelInfoFragment : BaseFragment() {
             actionBar?.setTitle(displayName)
         }
         val avatarUrl = dm?.avatarUrl.orEmpty()
-        val avatar = dmHeaderAvatarView ?: return
-        if (channelType == CHANNEL_TYPE_GROUP) {
-            avatar.setInfo(channelId, displayName)
-            if (isDefaultGroupAvatarUrl(avatarUrl)) {
-                avatar.setImageUrl(null)
-                avatar.setPhoto(GroupAvatar.bitmap(avatar.context))
-            } else {
-                avatar.setPhoto(null)
-                avatar.setImageUrl(avatarUrl)
-            }
-        } else {
-            avatar.setInfo(channelId, displayName)
-            avatar.setImageUrl(avatarUrl)
-        }
+        val placeholderKey = dm?.avatarPlaceholderKey() ?: displayName
+        dmHeaderAvatarView?.bind(channelType, channelId, avatarUrl, placeholderKey)
     }
 
     private fun refreshClanHeader() {
@@ -804,18 +819,24 @@ class ChannelInfoFragment : BaseFragment() {
         val iconPx = LayoutHelper.dp(20)
         val iconDrawable = iconEnum.getDrawable(bar.context, themeColors)
         if (!iconEnum.shouldKeepOriginalFill()) {
-            iconDrawable.colorFilter = PorterDuffColorFilter(themeColors.onSurface, PorterDuff.Mode.SRC_IN)
+            iconDrawable.colorFilter = PorterDuffColorFilter(themeColors.textStrong, PorterDuff.Mode.SRC_IN)
         }
         bar.setTitle(channelName)
         bar.setTitleStartIcon(iconDrawable, iconPx, LayoutHelper.dp(6))
+        bar.requestLayout()
     }
 
     override fun onResume() {
         super.onResume()
         if (isDm) {
             refreshDmHeader()
+            reloadMembers()
+            if (channelType == CHANNEL_TYPE_GROUP) {
+                dialogsController.loadDmParticipants(channelId, force = true)
+            }
         } else {
             refreshClanHeader()
+            reloadMembers()
         }
     }
 

--- a/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/DmGroupEditBottomSheet.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/DmGroupEditBottomSheet.kt
@@ -1,6 +1,7 @@
 package com.mezon.mobile.home.chat.channelinfo
 
 import android.content.Context
+import android.graphics.Bitmap
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
 import android.graphics.Typeface
@@ -40,6 +41,7 @@ class DmGroupEditBottomSheet(
 
     private val initialAvatar = normalizeAvatar(initialAvatarUrl)
     private var draftAvatar = initialAvatar
+    private var previewBitmap: Bitmap? = null
     private var uploading = false
     private var saving = false
 
@@ -49,6 +51,7 @@ class DmGroupEditBottomSheet(
     private lateinit var nameInput: EditText
     private lateinit var clearButton: ImageView
     private lateinit var saveButton: TextView
+    private lateinit var nameCounterText: TextView
 
     init {
         containerHeight = (AndroidUtilities.displaySize.y * 0.9f).toInt()
@@ -56,9 +59,15 @@ class DmGroupEditBottomSheet(
     }
 
     fun setDraftAvatar(url: String) {
+        previewBitmap = null
         draftAvatar = normalizeAvatar(url)
         bindAvatar()
         updateSaveState()
+    }
+
+    fun setPreviewBitmap(bitmap: Bitmap?) {
+        previewBitmap = bitmap
+        bindAvatar()
     }
 
     fun setUploading(value: Boolean) {
@@ -101,6 +110,10 @@ class DmGroupEditBottomSheet(
             LayoutHelper.WRAP_CONTENT
         ))
 
+        val labelRow = LinearLayout(context).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+        }
         val label = TextView(context).apply {
             text = context.getString(R.string.dm_group_name)
             setTextColor(themeColors.onSurface)
@@ -108,7 +121,14 @@ class DmGroupEditBottomSheet(
             setTypeface(Typeface.DEFAULT, Typeface.BOLD)
             includeFontPadding = false
         }
-        outer.addView(label, LayoutHelper.createLinear(
+        labelRow.addView(label, LayoutHelper.createLinear(0, LayoutHelper.WRAP_CONTENT, 1f))
+        nameCounterText = TextView(context).apply {
+            setTextColor(themeColors.onSurfaceVariant)
+            setTextSize(TypedValue.COMPLEX_UNIT_SP, 12f)
+            includeFontPadding = false
+        }
+        labelRow.addView(nameCounterText, LayoutHelper.createLinear(LayoutHelper.WRAP_CONTENT, LayoutHelper.WRAP_CONTENT))
+        outer.addView(labelRow, LayoutHelper.createLinear(
             LayoutHelper.MATCH_PARENT,
             LayoutHelper.WRAP_CONTENT,
             bottomMargin = 10f
@@ -144,6 +164,7 @@ class DmGroupEditBottomSheet(
 
         bindAvatar()
         updateClearButton()
+        updateNameCounter()
         updateSaveState()
         return outer
     }
@@ -187,6 +208,7 @@ class DmGroupEditBottomSheet(
                     onPickAvatar()
                 } else {
                     draftAvatar = ""
+                    previewBitmap = null
                     bindAvatar()
                     updateSaveState()
                 }
@@ -233,6 +255,7 @@ class DmGroupEditBottomSheet(
                 override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
                 override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                     updateClearButton()
+                    updateNameCounter()
                     updateSaveState()
                 }
                 override fun afterTextChanged(s: Editable?) = Unit
@@ -261,11 +284,13 @@ class DmGroupEditBottomSheet(
 
     private fun bindAvatar() {
         avatarView.setInfo(0L, nameInputOrInitial())
-        if (draftAvatar.isBlank()) {
+        val preview = previewBitmap
+        if (preview != null) {
+            avatarView.setPhoto(preview)
+        } else if (draftAvatar.isBlank()) {
             avatarView.setImageUrl(null)
             avatarView.setPhoto(GroupAvatar.bitmap(context))
         } else {
-            avatarView.setPhoto(null)
             avatarView.setImageUrl(draftAvatar)
         }
         avatarActionText.text = if (shouldShowUploadAction()) {
@@ -285,9 +310,15 @@ class DmGroupEditBottomSheet(
         val trimmed = nameInput.text?.toString().orEmpty().trim()
         val nameChanged = trimmed.isNotEmpty() && trimmed != initialName
         val avatarChanged = draftAvatar != initialAvatar
-        val enabled = (nameChanged || avatarChanged) && !uploading && !saving
+        val enabled = trimmed.isNotEmpty() && (nameChanged || avatarChanged) && !uploading && !saving
         saveButton.isEnabled = enabled
         saveButton.alpha = if (enabled) 1f else 0.5f
+    }
+
+    private fun updateNameCounter() {
+        if (!::nameCounterText.isInitialized || !::nameInput.isInitialized) return
+        val length = nameInput.text?.length ?: 0
+        nameCounterText.text = context.getString(R.string.poll_question_counter, length, 64)
     }
 
     private fun shouldShowUploadAction(): Boolean =

--- a/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/DmHeaderAvatarView.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/DmHeaderAvatarView.kt
@@ -1,0 +1,77 @@
+package com.mezon.mobile.home.chat.channelinfo
+
+import android.content.Context
+import android.graphics.Canvas
+import android.view.View
+import com.mezon.mobile.core.AvatarDrawable
+import com.mezon.mobile.core.LayoutHelper
+import com.mezon.mobile.home.messages.ChannelAvatarLoadState
+import com.mezon.mobile.home.messages.ChannelAvatarRequest
+import com.mezon.mobile.home.messages.loadChannelAvatar
+
+class DmHeaderAvatarView(context: Context) : View(context) {
+
+    private val avatarDrawable = AvatarDrawable()
+    private val loadState = ChannelAvatarLoadState()
+    private var attached = false
+    private var sizeDp = 50
+    private var channelType = 0
+    private var channelId = 0L
+    private var avatarUrl = ""
+    private var placeholderKey = ""
+
+    fun setSizeDp(dp: Int) {
+        if (sizeDp == dp) return
+        sizeDp = dp
+        requestLayout()
+        bindAvatar()
+    }
+
+    fun bind(channelType: Int, channelId: Long, avatarUrl: String, placeholderKey: String) {
+        this.channelType = channelType
+        this.channelId = channelId
+        this.avatarUrl = avatarUrl
+        this.placeholderKey = placeholderKey
+        bindAvatar()
+    }
+
+    private fun bindAvatar() {
+        loadChannelAvatar(
+            context,
+            avatarDrawable,
+            ChannelAvatarRequest(
+                channelType = channelType,
+                avatarUrl = avatarUrl,
+                avatarId = channelId,
+                placeholderKey = placeholderKey,
+                sizePx = LayoutHelper.dp(sizeDp)
+            ),
+            loadState,
+            attached
+        ) { invalidate() }
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        attached = true
+        bindAvatar()
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        attached = false
+        loadState.cancel()
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val size = LayoutHelper.dp(sizeDp)
+        setMeasuredDimension(size, size)
+    }
+
+    override fun hasOverlappingRendering(): Boolean = false
+
+    override fun onDraw(canvas: Canvas) {
+        avatarDrawable.setBounds(0, 0, width, height)
+        avatarDrawable.draw(canvas)
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/home/chat/thread/CreateThreadFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/thread/CreateThreadFragment.kt
@@ -88,10 +88,14 @@ import com.mezon.mobile.home.chat.EmojiController
 import com.mezon.mobile.util.FileUtils
 import com.mezon.mobile.util.HashtagData
 import com.mezon.mobile.util.MentionData
-import com.mezon.mobile.util.parseContentText
+import com.mezon.mobile.util.isEmbedOrComponentsPayload
+import com.mezon.mobile.util.parseContentPreview
 import com.mezon.mobile.util.parseMarkdownAndStrip
+import com.mezon.mobile.home.chat.AttachmentInfo
+import com.mezon.mobile.home.chat.CreateThreadSeedStash
+import com.mezon.mobile.home.chat.isMediaAttachment
+import com.mezon.mobile.home.sharing.ForwardPreviewThumbHost
 import com.mezon.mobile.util.resolveStickerSourceUrl
-import com.mezon.mezon.api.messageRef
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
@@ -106,19 +110,22 @@ class CreateThreadFragment : BaseFragment() {
         private const val ARG_PARENT_LABEL = "parentLabel"
         private const val ARG_CLAN_ID = "clanId"
         private const val ARG_SEED_MESSAGE_ID = "seedMessageId"
+        private const val ARG_USE_TOPIC_FLOW = "useTopicFlow"
         private const val REQUEST_CODE_PICK_FILE = 1012
 
         fun newInstance(
             parentChannelId: Long,
             parentLabel: String,
             clanId: Long,
-            seedMessageId: Long = 0L
+            seedMessageId: Long = 0L,
+            useTopicFlow: Boolean = false
         ): CreateThreadFragment = CreateThreadFragment().apply {
             arguments = Bundle().apply {
                 putLong(ARG_PARENT_CHANNEL_ID, parentChannelId)
                 putString(ARG_PARENT_LABEL, parentLabel)
                 putLong(ARG_CLAN_ID, clanId)
                 if (seedMessageId != 0L) putLong(ARG_SEED_MESSAGE_ID, seedMessageId)
+                if (useTopicFlow) putBoolean(ARG_USE_TOPIC_FLOW, true)
             }
         }
     }
@@ -127,6 +134,7 @@ class CreateThreadFragment : BaseFragment() {
     private var parentLabel = ""
     private var clanId = 0L
     private var seedMessageId = 0L
+    private var useTopicFlow = false
 
     private lateinit var chatController: ChatController
     private lateinit var topicController: TopicController
@@ -205,7 +213,8 @@ class CreateThreadFragment : BaseFragment() {
     private var nameTouched = false
     private var submitAttempted = false
 
-    private val fromMessageFlow: Boolean get() = seedMessageId != 0L
+    private val fromTopicFlow: Boolean get() = useTopicFlow && seedMessageId != 0L
+    private val hasSeedMessage: Boolean get() = seedMessageId != 0L
 
     override fun onFragmentCreate(): Boolean {
         super.onFragmentCreate()
@@ -213,6 +222,7 @@ class CreateThreadFragment : BaseFragment() {
         parentLabel = arguments?.getString(ARG_PARENT_LABEL) ?: ""
         clanId = arguments?.getLong(ARG_CLAN_ID) ?: 0L
         seedMessageId = arguments?.getLong(ARG_SEED_MESSAGE_ID) ?: 0L
+        useTopicFlow = arguments?.getBoolean(ARG_USE_TOPIC_FLOW) == true
         permissionPolicy.ensurePermissionChecker(
             listOf(PermissionPolicy.CLAN_OWNER, PermissionPolicy.MANAGE_THREAD, PermissionPolicy.MANAGE_CHANNEL),
             parentChannelId,
@@ -315,7 +325,7 @@ class CreateThreadFragment : BaseFragment() {
 
         fragmentView = root
 
-        if (fromMessageFlow) {
+        if (fromTopicFlow) {
             nameBlock?.visibility = View.GONE
             privateRow?.visibility = View.GONE
             titleSub?.visibility = View.VISIBLE
@@ -323,18 +333,15 @@ class CreateThreadFragment : BaseFragment() {
             channelIconSlot?.visibility = View.VISIBLE
             updateHeaderTopicIcon()
             titleMain?.text = getString(R.string.topic_discussion)
-            fragmentScope.launch {
-                val msg = chatController.getMessageById(parentChannelId, seedMessageId)
-                withContext(mainDispatcher) {
-                    seedMessage = msg
-                    bindPreview(msg)
-                }
-            }
+            loadSeedMessageForPreview()
         } else {
             titleSub?.visibility = View.GONE
             channelIconSlot?.visibility = View.VISIBLE
             titleMain?.text = parentLabel
             updateHeaderChannelIcon()
+            if (hasSeedMessage) {
+                loadSeedMessageForPreview()
+            }
         }
 
         refreshNameError()
@@ -472,7 +479,7 @@ class CreateThreadFragment : BaseFragment() {
             }
         }
         val icon = ImageView(context).apply {
-            val iconType = if (fromMessageFlow) MezonIcon.notificationTabTopic else MezonIcon.threadIcon
+            val iconType = if (fromTopicFlow) MezonIcon.notificationTabTopic else MezonIcon.threadIcon
             setImageDrawable(iconType.getDrawable(context))
             scaleType = ImageView.ScaleType.FIT_CENTER
         }
@@ -596,11 +603,32 @@ class CreateThreadFragment : BaseFragment() {
         return box
     }
 
+    private fun loadSeedMessageForPreview() {
+        if (seedMessageId == 0L) return
+        val stashed = CreateThreadSeedStash.takeSeedMessage(seedMessageId)
+        if (stashed != null) {
+            seedMessage = stashed
+            bindPreview(stashed)
+            return
+        }
+        fragmentScope.launch {
+            var msg = chatController.getMessageById(parentChannelId, seedMessageId)
+            if (msg == null) {
+                chatController.reloadChannelMessageIfMissing(parentChannelId, clanId, seedMessageId)
+                msg = chatController.getMessageById(parentChannelId, seedMessageId)
+            }
+            withContext(mainDispatcher) {
+                seedMessage = msg
+                bindPreview(msg)
+            }
+        }
+    }
+
     private fun bindPreview(msg: MessageEntity?) {
         val box = previewBox ?: return
         val ctx = box.context
         box.removeAllViews()
-        if (msg == null || !fromMessageFlow) {
+        if (msg == null || !hasSeedMessage) {
             box.visibility = View.GONE
             return
         }
@@ -650,6 +678,38 @@ class CreateThreadFragment : BaseFragment() {
             visibility = if (previewText.isEmpty()) View.GONE else View.VISIBLE
         }
         textCol.addView(body, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 0f, Gravity.START, 0f, 4f, 0f, 0f))
+        val mediaAttachments = seedMediaAttachments(msg)
+        if (mediaAttachments.isNotEmpty()) {
+            val mediaRow = LinearLayout(ctx).apply {
+                orientation = LinearLayout.HORIZONTAL
+                gravity = Gravity.CENTER_VERTICAL
+            }
+            val thumbSize = LayoutHelper.dp(56)
+            val thumbHost = ForwardPreviewThumbHost(ctx)
+            mediaRow.addView(thumbHost, LayoutHelper.createLinear(thumbSize, thumbSize, 0f, Gravity.START, 0f, 4f, 8f, 0f))
+            val first = mediaAttachments[0]
+            thumbHost.bind(first.url, first.thumb.takeIf { it.isNotBlank() } ?: first.url)
+            val extra = mediaAttachments.size - 1
+            if (extra > 0) {
+                val plus = TextView(ctx).apply {
+                    text = getString(R.string.forward_thumb_more, extra)
+                    setTextColor(themeColors.onSurfaceVariant)
+                    setTextSize(TypedValue.COMPLEX_UNIT_SP, 13f)
+                }
+                mediaRow.addView(plus, LayoutHelper.createLinear(LayoutHelper.WRAP_CONTENT, LayoutHelper.WRAP_CONTENT))
+            }
+            textCol.addView(mediaRow, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 0f, Gravity.START, 0f, 4f, 0f, 0f))
+        } else {
+            val attachmentSummary = seedAttachmentSummary(msg)
+            if (attachmentSummary.isNotEmpty() && previewText.isEmpty()) {
+                val summary = TextView(ctx).apply {
+                    text = attachmentSummary
+                    setTextColor(themeColors.onSurface)
+                    setTextSize(TypedValue.COMPLEX_UNIT_SP, 15f)
+                }
+                textCol.addView(summary, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 0f, Gravity.START, 0f, 4f, 0f, 0f))
+            }
+        }
         inner.addView(textCol, LayoutHelper.createLinear(0, LayoutHelper.WRAP_CONTENT, 1f))
 
         box.addView(inner, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT))
@@ -662,19 +722,58 @@ class CreateThreadFragment : BaseFragment() {
     }
 
     private fun seedPreviewText(msg: MessageEntity): String {
-        val text = parseContentText(msg.content).trim()
+        val text = parseContentPreview(msg.content).trim()
         if (text.isNotEmpty()) return text
-        val attachment = msg.allAttachmentsInfo.firstOrNull()
-        val filename = attachment?.filename?.trim().orEmpty().ifBlank { msg.attachmentFilename.trim() }
-        if (filename.isNotEmpty()) return filename
-        val filetype = attachment?.filetype?.lowercase().orEmpty().ifBlank { msg.attachmentFiletype.lowercase() }
-        return when {
-            msg.messageType == MessageEntity.TYPE_GIF || filetype.contains("gif") -> getString(R.string.message_attachment_gif)
-            msg.messageType == MessageEntity.TYPE_VIDEO || filetype.startsWith("video/") -> getString(R.string.message_attachment_video)
-            msg.messageType == MessageEntity.TYPE_PHOTO || filetype.startsWith("image/") -> getString(R.string.message_attachment_photo)
-            msg.messageType == MessageEntity.TYPE_FILE || msg.hasFileAttachments -> getString(R.string.message_attachment_file)
-            else -> ""
+        if (seedMediaAttachments(msg).isNotEmpty()) return ""
+        return seedAttachmentSummary(msg)
+    }
+
+    private fun seedMediaAttachments(msg: MessageEntity): List<AttachmentInfo> {
+        if (!msg.hasAnyMedia) return emptyList()
+        val withUrl = msg.allAttachmentsInfo.filter { it.url.isNotEmpty() }
+        if (withUrl.isEmpty()) return emptyList()
+        val media = withUrl.filter { isMediaAttachment(it.filetype, it.url) }
+        return media.ifEmpty { withUrl.take(1) }
+    }
+
+    private fun seedAttachmentSummary(msg: MessageEntity): String {
+        val all = msg.allAttachmentsInfo.filter { it.url.isNotEmpty() }
+        if (all.isEmpty()) {
+            if (isEmbedOrComponentsPayload(msg.content)) return getString(R.string.message_attachment_file)
+            return ""
         }
+        var img = 0
+        var vid = 0
+        var fil = 0
+        for (a in all) {
+            when {
+                a.filetype.startsWith("image/", ignoreCase = true) ||
+                    a.filetype.contains("gif", ignoreCase = true) ||
+                    a.url.contains("tenor.com", ignoreCase = true) -> img++
+                a.filetype.startsWith("video/", ignoreCase = true) -> vid++
+                else -> fil++
+            }
+        }
+        val parts = ArrayList<String>(3)
+        if (img > 0) {
+            parts.add(
+                if (img == 1) getString(R.string.forward_meta_photo, img)
+                else getString(R.string.forward_meta_photos, img)
+            )
+        }
+        if (vid > 0) {
+            parts.add(
+                if (vid == 1) getString(R.string.forward_meta_video, vid)
+                else getString(R.string.forward_meta_videos, vid)
+            )
+        }
+        if (fil > 0) {
+            parts.add(
+                if (fil == 1) getString(R.string.forward_meta_file, fil)
+                else getString(R.string.forward_meta_files, fil)
+            )
+        }
+        return parts.joinToString(", ")
     }
 
     private fun parentChannelType(): Int =
@@ -1623,47 +1722,21 @@ class CreateThreadFragment : BaseFragment() {
         return markers.ifEmpty { null }
     }
 
-    private fun buildSeedRefs(seed: MessageEntity?): List<com.mezon.mezon.api.MessageRef>? {
-        val s = seed ?: return null
-        return listOf(
-            messageRef {
-                messageId = 0L
-                messageRefId = s.id
-                refType = 0
-                messageSenderId = s.senderId
-                messageSenderUsername = s.senderUsername.ifBlank { s.senderName }
-                messageSenderAvatar = s.senderAvatar
-                messageSenderClanNick = if (clanId != 0L) s.senderName else ""
-                messageSenderDisplayName = s.senderName
-                content = s.content
-                hasAttachment = s.hasAnyMedia || s.hasFileAttachments
-            }
-        )
-    }
-
     private fun sendComposerToThread(
         threadChannelId: Long,
-        threadPrivate: Boolean,
-        seed: MessageEntity?
+        threadPrivate: Boolean
     ) {
         val rawInput = composerField.text?.toString() ?: ""
         val text = rawInput.trim()
-        val refs = buildSeedRefs(seed)
         val ctx = getContext() ?: return
         if (text.isBlank() && pendingAttachments.isEmpty()) {
             pendingStickerSend?.let { st ->
                 chatController.sendDirectAttachment(
                     threadChannelId, clanId, CHANNEL_TYPE_THREAD, threadPrivate,
-                    st.url, st.filetype, st.filename, refs
+                    st.url, st.filetype, st.filename, null
                 )
                 pendingStickerSend = null
                 return
-            }
-            if (refs != null) {
-                chatController.sendMessage(
-                    threadChannelId, clanId, CHANNEL_TYPE_THREAD, threadPrivate,
-                    "", refs
-                )
             }
             return
         }
@@ -1695,7 +1768,7 @@ class CreateThreadFragment : BaseFragment() {
                 threadChannelId, clanId, CHANNEL_TYPE_THREAD, threadPrivate, cleanedText,
                 ArrayList(pendingAttachments),
                 ctx.contentResolver,
-                refs,
+                null,
                 mentions,
                 hashtags,
                 emojiMarkers
@@ -1705,7 +1778,7 @@ class CreateThreadFragment : BaseFragment() {
         } else {
             chatController.sendMessage(
                 threadChannelId, clanId, CHANNEL_TYPE_THREAD, threadPrivate, cleanedText,
-                refs, mentions, emojiMarkers, mdMarkers, hashtags
+                null, mentions, emojiMarkers, mdMarkers, null, hashtags
             )
         }
         composerField.text?.clear()
@@ -1716,7 +1789,7 @@ class CreateThreadFragment : BaseFragment() {
         pendingStickerSend?.let { st ->
             chatController.sendDirectAttachment(
                 threadChannelId, clanId, CHANNEL_TYPE_THREAD, threadPrivate,
-                st.url, st.filetype, st.filename, refs
+                st.url, st.filetype, st.filename, null
             )
             pendingStickerSend = null
         }
@@ -1797,6 +1870,7 @@ class CreateThreadFragment : BaseFragment() {
                 mentions,
                 emojiMarkers,
                 mdMarkers,
+                null,
                 hashtags,
                 topicId = topicId
             )
@@ -1846,7 +1920,7 @@ class CreateThreadFragment : BaseFragment() {
     }
 
     private fun canCreateThreadForCurrentFlow(): Boolean {
-        return if (fromMessageFlow) {
+        return if (fromTopicFlow) {
             permissionPolicy.canCreateThreadFromMessage(parentChannelId, clanId)
         } else {
             permissionPolicy.canCreateThreadFromThreadList(parentChannelId, clanId)
@@ -1860,7 +1934,7 @@ class CreateThreadFragment : BaseFragment() {
             return
         }
         submitAttempted = true
-        if (!fromMessageFlow) {
+        if (!fromTopicFlow) {
             val nameErr = validateThreadName(nameField?.text?.toString().orEmpty())
             if (nameErr.isNotEmpty()) {
                 errorText?.text = nameErr
@@ -1877,12 +1951,16 @@ class CreateThreadFragment : BaseFragment() {
 
         fragmentScope.launch {
             try {
-                if (fromMessageFlow && seedMessageId != 0L && seedMessage == null) {
-                    val loaded = chatController.getMessageById(parentChannelId, seedMessageId)
+                if (hasSeedMessage && seedMessage == null) {
+                    var loaded = chatController.getMessageById(parentChannelId, seedMessageId)
+                    if (loaded == null) {
+                        chatController.reloadChannelMessageIfMissing(parentChannelId, clanId, seedMessageId)
+                        loaded = chatController.getMessageById(parentChannelId, seedMessageId)
+                    }
                     seedMessage = loaded
                     withContext(mainDispatcher) { bindPreview(loaded) }
                 }
-                if (fromMessageFlow) {
+                if (fromTopicFlow) {
                     val createdTopic = withContext(ioDispatcher) {
                         topicController.createTopic(
                             clanId = clanId,
@@ -1946,20 +2024,20 @@ class CreateThreadFragment : BaseFragment() {
                 val threadPrivate = entity.isPrivate
                 val seed = seedMessage
                 if (seed != null) {
-                    val seedPlain = parseContentText(seed.content).trim()
-                    if (seedPlain.isNotEmpty()) {
-                        chatController.sendMessage(
+                    val seedOk = withContext(ioDispatcher) {
+                        chatController.sendThreadSeedMessage(
                             desc.channelId,
                             clanId,
                             CHANNEL_TYPE_THREAD,
                             threadPrivate,
-                            seedPlain
+                            seed
                         )
-                        delay(80)
                     }
+                    if (!seedOk) throw IllegalStateException("seed message send failed")
+                    delay(80)
                 }
                 withContext(mainDispatcher) {
-                    sendComposerToThread(desc.channelId, threadPrivate, seed)
+                    sendComposerToThread(desc.channelId, threadPrivate)
                 }
                 delay(80)
                 withContext(mainDispatcher) {

--- a/app/src/main/java/com/mezon/mobile/home/chat/thread/ThreadListAdapter.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/thread/ThreadListAdapter.kt
@@ -13,11 +13,13 @@ import kotlinx.coroutines.withContext
 
 class ThreadListAdapter(
     private val theme: ThemeColors,
+    private val creatorNameResolver: (Long, String) -> String,
     private val senderNameResolver: (Long) -> String,
     private val onThreadClick: (ThreadInfo) -> Unit
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private var items = ArrayList<Any>()
+    private var displayNames = HashMap<Long, String>()
     private var adapterScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var diffJob: kotlinx.coroutines.Job? = null
 
@@ -27,29 +29,56 @@ class ThreadListAdapter(
 
     fun setData(sections: List<ThreadSection>, animateChanges: Boolean = true) {
         val newItems = ArrayList<Any>()
+        val threads = ArrayList<ThreadInfo>()
         for (section in sections) {
             newItems.add(section.title)
-            newItems.addAll(section.threads)
+            for (thread in section.threads) {
+                newItems.add(thread)
+                threads.add(thread)
+            }
         }
         diffJob?.cancel()
         if (!animateChanges) {
             items.clear()
             items.addAll(newItems)
+            displayNames = resolveNames(threads)
             notifyDataSetChanged()
             return
         }
         if (items.size > 50 || newItems.size > 50) {
+            val old = items
             diffJob = adapterScope.launch {
                 val result = withContext(Dispatchers.Default) {
-                    DiffUtil.calculateDiff(ThreadDiffCallback(items, newItems))
+                    DiffUtil.calculateDiff(ThreadDiffCallback(old, newItems))
                 }
+                val newNames = withContext(Dispatchers.Default) { resolveNames(threads) }
                 items = newItems
+                displayNames = newNames
                 result.dispatchUpdatesTo(this@ThreadListAdapter)
             }
         } else {
+            val newNames = resolveNames(threads)
             val result = DiffUtil.calculateDiff(ThreadDiffCallback(items, newItems))
             items = newItems
+            displayNames = newNames
             result.dispatchUpdatesTo(this)
+        }
+    }
+
+    private fun resolveNames(threads: List<ThreadInfo>): HashMap<Long, String> {
+        val names = HashMap<Long, String>(threads.size)
+        for (thread in threads) {
+            names[thread.channelId] = resolveDisplayName(thread)
+        }
+        return names
+    }
+
+    private fun resolveDisplayName(thread: ThreadInfo): String {
+        val creatorName = creatorNameResolver(thread.creatorId, thread.creatorName)
+        return if (thread.lastSenderId != 0L) {
+            senderNameResolver(thread.lastSenderId).ifBlank { creatorName }
+        } else {
+            creatorName
         }
     }
 
@@ -87,12 +116,7 @@ class ThreadListAdapter(
                 (holder.itemView as ThreadSectionCell).setTitle(item)
             }
             is ThreadInfo -> {
-                val creatorName = item.creatorName.ifBlank { senderNameResolver(item.creatorId) }
-                val senderName = if (item.lastSenderId != 0L) {
-                    senderNameResolver(item.lastSenderId).ifBlank { creatorName }
-                } else {
-                    creatorName
-                }
+                val senderName = displayNames[item.channelId] ?: item.creatorName
                 (holder.itemView as ThreadCell).setData(item, senderName)
             }
         }

--- a/app/src/main/java/com/mezon/mobile/home/chat/thread/ThreadListFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/thread/ThreadListFragment.kt
@@ -28,6 +28,7 @@ import com.mezon.mobile.core.NotificationCenter
 import com.mezon.mobile.core.RecyclerListView
 import com.mezon.mobile.di.FragmentEntryPoint
 import com.mezon.mobile.home.MemberResolver
+import com.mezon.mobile.home.UserClanController
 import com.mezon.mobile.home.clans.ChannelController
 import com.mezon.mobile.home.clans.ClanChannelEntity
 import com.mezon.mobile.home.clans.PermissionPolicy
@@ -75,6 +76,7 @@ class ThreadListFragment : BaseFragment() {
     private lateinit var api: MezonApi
     private lateinit var sessionManager: SessionManager
     private lateinit var memberResolver: MemberResolver
+    private lateinit var userClanController: UserClanController
     private lateinit var channelController: ChannelController
     private lateinit var permissionPolicy: PermissionPolicy
     private lateinit var ioDispatcher: CoroutineDispatcher
@@ -125,6 +127,10 @@ class ThreadListFragment : BaseFragment() {
             val changedClanId = args.firstOrNull() as? Long ?: return@observe
             if (changedClanId == clanId) refreshCachedThreadList()
         }
+        observe(NotificationCenter.clanMembersDidLoad) { _, _, args ->
+            val changedClanId = args.firstOrNull() as? Long ?: return@observe
+            if (changedClanId == clanId) refreshCachedThreadList(animateChanges = false)
+        }
         observe(NotificationCenter.updateInterfaces) { _, _, args ->
             val mask = args.firstOrNull() as? Int ?: return@observe
             val interestedMask = NotificationCenter.UPDATE_MASK_NEW_MESSAGE or
@@ -143,6 +149,7 @@ class ThreadListFragment : BaseFragment() {
         api = entryPoint.mezonApi()
         sessionManager = entryPoint.sessionManager()
         memberResolver = entryPoint.memberResolver()
+        userClanController = entryPoint.userClanController()
         channelController = entryPoint.channelController()
         permissionPolicy = entryPoint.permissionPolicy()
         ioDispatcher = entryPoint.ioDispatcher()
@@ -195,6 +202,7 @@ class ThreadListFragment : BaseFragment() {
 
         adapter = ThreadListAdapter(
             theme = themeColors,
+            creatorNameResolver = { creatorId, apiCreatorName -> resolveCreatorName(creatorId, apiCreatorName) },
             senderNameResolver = { senderId -> resolveSenderName(senderId) },
             onThreadClick = { thread -> navigateToThread(thread) }
         )
@@ -225,6 +233,9 @@ class ThreadListFragment : BaseFragment() {
 
         fragmentView = root
         updateCreateThreadActions()
+        if (clanId != 0L) {
+            userClanController.loadClanMembers(clanId)
+        }
         fetchThreads(1)
         return root
     }
@@ -645,10 +656,34 @@ class ThreadListFragment : BaseFragment() {
 
     private fun resolveSenderName(senderId: Long): String {
         if (senderId == 0L) return ""
-        val member = memberResolver.resolveMember(senderId, clanId, channelId, CHANNEL_TYPE_THREAD)
+        val member = memberResolver.resolveClanScopedMember(senderId, clanId, channelId, CHANNEL_TYPE_THREAD)
+            ?: memberResolver.resolveMember(senderId, clanId, channelId, CHANNEL_TYPE_THREAD)
         return member?.let {
             it.clanNick.ifBlank { it.displayName.ifBlank { it.username } }
         } ?: ""
+    }
+
+    private fun resolveCreatorName(creatorId: Long, apiCreatorName: String): String {
+        val apiName = apiCreatorName.trim()
+        if (clanId == 0L) {
+            return if (isSystemCreatorName(apiName)) "" else apiName
+        }
+        if (creatorId == 0L) {
+            return if (isSystemCreatorName(apiName)) "" else apiName
+        }
+        val member = memberResolver.resolveClanScopedMember(creatorId, clanId, channelId, CHANNEL_TYPE_THREAD)
+            ?: memberResolver.resolveMember(creatorId, clanId, channelId, CHANNEL_TYPE_THREAD)
+        val clanPreferred = member?.clanNick?.trim().orEmpty().ifBlank {
+            member?.displayName?.trim().orEmpty()
+        }
+        if (clanPreferred.isNotBlank()) return clanPreferred
+        if (!isSystemCreatorName(apiName) && apiName.isNotBlank()) return apiName
+        return member?.username.orEmpty()
+    }
+
+    private fun isSystemCreatorName(name: String): Boolean {
+        if (name.isBlank()) return false
+        return name.equals("system", ignoreCase = true)
     }
 
     private fun navigateToThread(thread: ThreadInfo) {

--- a/app/src/main/java/com/mezon/mobile/home/clans/ClansFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ClansFragment.kt
@@ -158,7 +158,10 @@ class ClansFragment : BaseFragment() {
         observe(NotificationCenter.clanMembersDidLoad) { _, _, args ->
             if (fragmentView == null || isPaused) return@observe
             val clanId = args.firstOrNull() as? Long ?: return@observe
-            if (clanId == clansController.selectedClanId.value) updateMemberCount()
+            if (clanId == clansController.selectedClanId.value) {
+                updateMemberCount()
+                syncVoiceMembersUi()
+            }
         }
         observe(NotificationCenter.dialogsNeedReload) { _, _, _ ->
             if (fragmentView == null || isPaused || listFrozen) return@observe
@@ -174,11 +177,18 @@ class ClansFragment : BaseFragment() {
             updateVisibleRows(mask)
         }
         observe(NotificationCenter.voiceChannelMembersChanged) { _, _, args ->
-            if (fragmentView == null || isPaused || listFrozen) return@observe
+            if (fragmentView == null || listFrozen) return@observe
             val clanId = args.firstOrNull() as? Long ?: return@observe
             if (clanId == clansController.selectedClanId.value) {
-                updateVoiceMembers(clanId)
+                syncVoiceMembersUi()
             }
+        }
+        observe(NotificationCenter.appDidReconnect) { _, _, _ ->
+            if (fragmentView == null || listFrozen) return@observe
+            val clanId = clansController.selectedClanId.value
+            if (clanId == 0L) return@observe
+            voiceController.fetchVoiceChannelMembers(clanId, noCache = true)
+            syncVoiceMembersUi()
         }
         observe(NotificationCenter.themeChanged) { _, _, _ ->
             if (fragmentView == null) return@observe
@@ -605,12 +615,18 @@ class ClansFragment : BaseFragment() {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        ensureVoiceMembersLoaded()
+    }
+
     override fun onBecomeFullyVisible() {
         super.onBecomeFullyVisible()
         if (::discoverListSection.isInitialized &&
             discoverListSection.rootView.visibility == View.VISIBLE) {
             discoverListSection.onEmbeddedVisibilityChanged(true)
         }
+        ensureVoiceMembersLoaded()
         if (viewJustCreated) {
             viewJustCreated = false
             return
@@ -913,6 +929,21 @@ class ClansFragment : BaseFragment() {
         val clanId = clansController.selectedClanId.value
         if (clanId == 0L) return
         presentFragment(ChannelAppShowAllFragment.newInstance(clanId))
+    }
+
+    private fun ensureVoiceMembersLoaded() {
+        if (fragmentView == null || listFrozen || !::channelListView.isInitialized) return
+        val clanId = clansController.selectedClanId.value
+        if (clanId == 0L) return
+        voiceController.fetchVoiceChannelMembers(clanId)
+        updateVoiceMembers(clanId)
+    }
+
+    private fun syncVoiceMembersUi() {
+        if (fragmentView == null || listFrozen || !::channelListView.isInitialized) return
+        val clanId = clansController.selectedClanId.value
+        if (clanId == 0L) return
+        updateVoiceMembers(clanId)
     }
 
     private fun updateVoiceMembers(clanId: Long) {

--- a/app/src/main/java/com/mezon/mobile/home/messages/DmPickerNavigation.kt
+++ b/app/src/main/java/com/mezon/mobile/home/messages/DmPickerNavigation.kt
@@ -1,6 +1,7 @@
 package com.mezon.mobile.home.messages
 
 import com.mezon.mobile.MainActivity
+import com.mezon.mobile.core.AndroidUtilities
 import com.mezon.mobile.core.BaseFragment
 
 internal fun BaseFragment.openChatFromPicker(
@@ -11,17 +12,31 @@ internal fun BaseFragment.openChatFromPicker(
     popSelfBeforeOpen: Boolean = false,
     onOpenChat: ((channelId: Long, channelName: String, clanId: Long, channelType: Int) -> Unit)? = null
 ) {
-    if (popSelfBeforeOpen) finishFragment()
     val main = getParentActivity() as? MainActivity
     if (main != null) {
-        main.openChat(
-            channelId,
-            channelName,
-            clanId,
-            channelType,
-            replaceLastFragment = true
-        )
+        if (popSelfBeforeOpen) {
+            finishFragment()
+            AndroidUtilities.runOnUIThread(Runnable {
+                if (main.isFinishing || main.isDestroyed) return@Runnable
+                main.openChat(
+                    channelId,
+                    channelName,
+                    clanId,
+                    channelType,
+                    replaceLastFragment = true
+                )
+            }, 180L)
+        } else {
+            main.openChat(
+                channelId,
+                channelName,
+                clanId,
+                channelType,
+                replaceLastFragment = true
+            )
+        }
     } else {
+        if (popSelfBeforeOpen) finishFragment()
         onOpenChat?.invoke(channelId, channelName, clanId, channelType)
     }
 }

--- a/app/src/main/java/com/mezon/mobile/home/sharing/ForwardPreviewThumbHost.kt
+++ b/app/src/main/java/com/mezon/mobile/home/sharing/ForwardPreviewThumbHost.kt
@@ -19,6 +19,16 @@ internal class ForwardPreviewThumbHost(context: Context) : View(context) {
         receiver.setRequestedSize(w, h)
     }
 
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        receiver.onAttachedToWindow()
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        receiver.onDetachedFromWindow()
+    }
+
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
         receiver.draw(canvas)

--- a/app/src/main/java/com/mezon/mobile/home/voice/VoiceController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/voice/VoiceController.kt
@@ -133,6 +133,7 @@ class VoiceController @Inject constructor(
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "fetchVoiceChannelMembers failed", e)
+                cacheTracker.invalidate(key)
             } finally {
                 if (!noCache) voiceMemberListFetchInflight.remove(clanId)
             }

--- a/app/src/main/java/com/mezon/mobile/ui/cells/ActionBarView.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/cells/ActionBarView.kt
@@ -141,7 +141,12 @@ class ActionBarView(context: Context, private val theme: ThemeColors) : FrameLay
     fun setTitle(title: CharSequence?) {
         if (title != null && titleTextView == null) createTitleTextView()
         titleTextView?.visibility = if (title != null && !isSearchFieldVisible) VISIBLE else INVISIBLE
+        val changed = titleTextView?.text?.toString() != title?.toString()
         titleTextView?.text = title
+        if (changed) {
+            titleTextView?.requestLayout()
+            requestLayout()
+        }
     }
 
     fun getTitle(): CharSequence? = titleTextView?.text
@@ -166,7 +171,12 @@ class ActionBarView(context: Context, private val theme: ThemeColors) : FrameLay
     fun setSubtitle(subtitle: CharSequence?) {
         if (subtitle != null && subtitleTextView == null) createSubtitleTextView()
         subtitleTextView?.visibility = if (!subtitle.isNullOrEmpty() && !isSearchFieldVisible) VISIBLE else GONE
+        val changed = subtitleTextView?.text?.toString() != subtitle?.toString()
         subtitleTextView?.text = subtitle
+        if (changed) {
+            subtitleTextView?.requestLayout()
+            requestLayout()
+        }
     }
 
     fun getSubtitle(): CharSequence? = subtitleTextView?.text
@@ -606,7 +616,8 @@ class ActionBarView(context: Context, private val theme: ThemeColors) : FrameLay
 
         val backWidth = if (backButtonImageView != null && backButtonImageView!!.visibility != GONE) BACK_BUTTON_SIZE else 0
         val lead = titleStartLeadWidth()
-        val titleAvailableWidth = (widthSize - backWidth - menuWidth - LayoutHelper.dp(16) - lead).coerceAtLeast(0)
+        val horizontalPadding = LayoutHelper.dp(16)
+        val titleAvailableWidth = (widthSize - backWidth - menuWidth - horizontalPadding - lead).coerceAtLeast(0)
 
         titleStartImageView?.let { iv ->
             if (iv.visibility != GONE && titleStartIconSize > 0) {
@@ -623,6 +634,13 @@ class ActionBarView(context: Context, private val theme: ThemeColors) : FrameLay
                     MeasureSpec.makeMeasureSpec(titleAvailableWidth, MeasureSpec.AT_MOST),
                     MeasureSpec.makeMeasureSpec(actionBarHeight, MeasureSpec.AT_MOST)
                 )
+                if (centerTitle && tv.measuredWidth < titleAvailableWidth) {
+                    val slackWidth = (tv.measuredWidth + LayoutHelper.dp(4)).coerceAtMost(titleAvailableWidth)
+                    tv.measure(
+                        MeasureSpec.makeMeasureSpec(slackWidth, MeasureSpec.EXACTLY),
+                        MeasureSpec.makeMeasureSpec(actionBarHeight, MeasureSpec.AT_MOST)
+                    )
+                }
             }
         }
 
@@ -632,6 +650,13 @@ class ActionBarView(context: Context, private val theme: ThemeColors) : FrameLay
                     MeasureSpec.makeMeasureSpec(titleAvailableWidth, MeasureSpec.AT_MOST),
                     MeasureSpec.makeMeasureSpec(actionBarHeight, MeasureSpec.AT_MOST)
                 )
+                if (centerTitle && sv.measuredWidth < titleAvailableWidth) {
+                    val slackWidth = (sv.measuredWidth + LayoutHelper.dp(4)).coerceAtMost(titleAvailableWidth)
+                    sv.measure(
+                        MeasureSpec.makeMeasureSpec(slackWidth, MeasureSpec.EXACTLY),
+                        MeasureSpec.makeMeasureSpec(actionBarHeight, MeasureSpec.AT_MOST)
+                    )
+                }
             }
         }
 
@@ -676,16 +701,32 @@ class ActionBarView(context: Context, private val theme: ThemeColors) : FrameLay
             val subH = if (hasSubtitle) subtitleTextView?.measuredHeight ?: 0 else 0
             val totalH = titleH + subH
             val topMargin = statusBarOffset + (actionBarHeight - totalH) / 2
+            val titleW = titleTextView?.measuredWidth ?: 0
+            val subW = if (hasSubtitle) subtitleTextView?.measuredWidth ?: 0 else 0
+            val textW = if (hasSubtitle) maxOf(titleW, subW) else titleW
+            val blockWidth = lead + textW
+            val minBlockLeft = backWidth
+            val maxBlockLeft = (w - menuWidth - LayoutHelper.dp(8) - blockWidth).coerceAtLeast(minBlockLeft)
+            val blockLeft = ((w - blockWidth) / 2).coerceIn(minBlockLeft, maxBlockLeft)
+
+            titleStartImageView?.let { iv ->
+                if (iv.visibility != GONE && titleStartIconSize > 0) {
+                    val iconTop = topMargin + (totalH - titleStartIconSize) / 2
+                    iv.layout(blockLeft, iconTop, blockLeft + titleStartIconSize, iconTop + titleStartIconSize)
+                }
+            }
+
+            val textStart = blockLeft + lead
+
             titleTextView?.let { tv ->
                 if (tv.visibility != GONE) {
-                    val tLeft = (w - tv.measuredWidth) / 2
-                    tv.layout(tLeft, topMargin, tLeft + tv.measuredWidth, topMargin + titleH)
+                    tv.layout(textStart, topMargin, textStart + titleW, topMargin + titleH)
                 }
             }
             if (hasSubtitle) {
                 subtitleTextView?.let { sv ->
-                    val sLeft = (w - sv.measuredWidth) / 2
-                    sv.layout(sLeft, topMargin + titleH, sLeft + sv.measuredWidth, topMargin + totalH)
+                    val sLeft = textStart + (titleW - subW) / 2
+                    sv.layout(sLeft, topMargin + titleH, sLeft + subW, topMargin + totalH)
                 }
             }
         } else if (hasSubtitle) {

--- a/app/src/main/java/com/mezon/mobile/ui/cells/AvatarView.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/cells/AvatarView.kt
@@ -65,6 +65,8 @@ class AvatarView(context: Context) : View(context) {
     }
 
     fun setPhoto(bitmap: android.graphics.Bitmap?) {
+        cancellable?.cancel()
+        cancellable = null
         avatarDrawable.setPhoto(bitmap)
         invalidate()
     }

--- a/app/src/main/java/com/mezon/mobile/util/MessageContentParser.kt
+++ b/app/src/main/java/com/mezon/mobile/util/MessageContentParser.kt
@@ -880,7 +880,9 @@ data class EmbedData(
     val timestamp: String
 )
 
-private const val MESSAGE_COMPONENT_TYPE_BUTTON = 1
+private const val MESSAGE_COMPONENT_TYPE_ACTION_ROW = 1
+private const val MESSAGE_COMPONENT_TYPE_BUTTON_LEGACY = 1
+private const val MESSAGE_COMPONENT_TYPE_BUTTON_V2 = 2
 
 enum class EmbedButtonStyle(val value: Int) {
     PRIMARY(1),
@@ -929,21 +931,45 @@ private fun parseEmbedActionRowsFromObject(obj: JSONObject): List<EmbedActionRow
     val out = ArrayList<EmbedActionRow>(rows.length())
     for (r in 0 until rows.length()) {
         val rowObj = rows.optJSONObject(r) ?: continue
+        val rowType = rowObj.optInt("type", -1)
+        if (rowType > 0 && rowType != MESSAGE_COMPONENT_TYPE_ACTION_ROW) continue
         val comps = rowObj.optJSONArray("components") ?: continue
         val buttons = ArrayList<EmbedComponentButton>(comps.length())
         for (c in 0 until comps.length()) {
             val comp = comps.optJSONObject(c) ?: continue
-            if (comp.optInt("type", -1) != MESSAGE_COMPONENT_TYPE_BUTTON) continue
+            val compType = comp.optInt("type", -1)
+            val isButton = compType == MESSAGE_COMPONENT_TYPE_BUTTON_LEGACY ||
+                compType == MESSAGE_COMPONENT_TYPE_BUTTON_V2
+            if (!isButton) continue
+            val inner = comp.optJSONObject("component")
             val id = comp.optString("id", "")
+                .ifEmpty { comp.optString("custom_id", "") }
+                .ifEmpty { comp.optString("component_id", "") }
+                .ifEmpty {
+                    inner?.optString("id", "")
+                        ?.ifEmpty { inner.optString("custom_id", "") }
+                        ?.ifEmpty { inner.optString("component_id", "") }
+                        .orEmpty()
+                }
             if (id.isEmpty()) continue
-            val inner = comp.optJSONObject("component") ?: continue
-            val label = inner.optString("label", "")
+            val label = inner?.optString("label", "")?.ifEmpty { comp.optString("label", "") }
+                ?: comp.optString("label", "")
             if (label.isEmpty()) continue
-            val url = inner.optString("url", "").takeIf { it.isNotEmpty() }
-            val style = EmbedButtonStyle.fromInt(inner.optInt("style", EmbedButtonStyle.PRIMARY.value))
-            val disabled = inner.optBoolean("disable", false) ||
-                inner.optBoolean("disabled", false) ||
-                inner.optBoolean("isDisabled", false)
+            val url = inner?.optString("url", "")?.takeIf { it.isNotEmpty() }
+                ?: comp.optString("url", "").takeIf { it.isNotEmpty() }
+            val style = EmbedButtonStyle.fromInt(
+                if (inner != null && inner.has("style")) {
+                    inner.optInt("style", EmbedButtonStyle.PRIMARY.value)
+                } else {
+                    comp.optInt("style", EmbedButtonStyle.PRIMARY.value)
+                }
+            )
+            val disabled = comp.optBoolean("disable", false) ||
+                comp.optBoolean("disabled", false) ||
+                comp.optBoolean("isDisabled", false) ||
+                inner?.optBoolean("disable", false) == true ||
+                inner?.optBoolean("disabled", false) == true ||
+                inner?.optBoolean("isDisabled", false) == true
             buttons.add(EmbedComponentButton(id, label, url, style, disabled))
         }
         if (buttons.isNotEmpty()) out.add(EmbedActionRow(buttons))


### PR DESCRIPTION
## Summary
- Fix centered action bar title measure so short thread/channel names no longer ellipsize prematurely after rename.
- Refresh clan/thread headers on resume, visibility, and `channelsDidLoad` so titles stay in sync after edit.
- Restore create-thread seed send, composer OGP preview/carry-through, group avatar UI, and related thread list polish.

## Test plan
- [ ] Edit a thread to a short name → back to chat and channel info: title centered, no false `...`
- [ ] Edit thread name → re-enter from channel list: same title display as after edit
- [ ] Create thread with seed message (text + attachment): seed posts into new thread
- [ ] Paste URL in composer: OGP preview shows; send message renders OGP card in bubble
- [ ] DM group: edit name/avatar in channel info; avatar and name counter (x/64) behave correctly
- [ ] Thread list: creator name resolves after clan members load
- [ ] Voice tab cold start: no regression on clan list


Made with [Cursor](https://cursor.com)