### PR TITLE
fix(chat): jump to present from FAB after pin navigation

### DIFF
--- a/app/src/main/java/com/mezon/mobile/MezonApplication.kt
+++ b/app/src/main/java/com/mezon/mobile/MezonApplication.kt
@@ -38,7 +38,7 @@ class MezonApplication : Application() {
         sentryReporter.init(this)
         StartupCache.init(this)
 
-        runBlocking(Dispatchers.IO) {
+        val seedStartupCacheFromDataStore: suspend () -> Unit = {
             runCatching {
                 val prefs = dataStore.data.first()
                 StartupCache.seed(
@@ -47,6 +47,13 @@ class MezonApplication : Application() {
                     locale = prefs[stringPreferencesKey("app_language")] ?: "en"
                 )
             }
+            Unit
+        }
+
+        if (StartupCache.isSeeded) {
+            appStartScope.launch { seedStartupCacheFromDataStore() }
+        } else {
+            runBlocking(Dispatchers.IO) { seedStartupCacheFromDataStore() }
         }
 
         val systemDark =

--- a/app/src/main/java/com/mezon/mobile/core/StartupCache.kt
+++ b/app/src/main/java/com/mezon/mobile/core/StartupCache.kt
@@ -11,6 +11,7 @@ object StartupCache {
     var suppressHomeListApiForIncomingCallWake: Boolean = false
 
     private const val PREFS_NAME = "mezon_startup_cache"
+    private const val KEY_SEEDED = "seeded"
     private const val KEY_HAS_SESSION = "has_session"
     private const val KEY_THEME = "theme"
     private const val KEY_LOCALE = "locale"
@@ -21,6 +22,9 @@ object StartupCache {
     private const val KEY_CACHED_USER_AVATAR_URL = "cached_user_avatar_url"
 
     private lateinit var prefs: SharedPreferences
+
+    val isSeeded: Boolean
+        get() = prefs.getBoolean(KEY_SEEDED, false)
 
     var hasSession: Boolean
         get() = prefs.getBoolean(KEY_HAS_SESSION, false)
@@ -86,6 +90,7 @@ object StartupCache {
 
     fun seed(hasSession: Boolean, themeMode: String, locale: String) {
         prefs.edit()
+            .putBoolean(KEY_SEEDED, true)
             .putBoolean(KEY_HAS_SESSION, hasSession)
             .putString(KEY_THEME, themeMode)
             .putString(KEY_LOCALE, locale)

--- a/app/src/main/java/com/mezon/mobile/home/ChatController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChatController.kt
@@ -99,6 +99,7 @@ const val LOAD_TYPE_MORE_BOTTOM = 2
 private const val DIRECTION_BEFORE = 3
 /** Wait for poll message over websocket after CreatePoll REST. */
 private const val POLL_MESSAGE_WAIT_MS = 8_000L
+private val FILENAME_SANITIZE_REGEX = Regex("[^a-zA-Z0-9._-]")
 
 private fun computeHasMoreTop(
     topicId: Long,
@@ -1349,7 +1350,7 @@ class ChatController @Inject constructor(
                                 continue
                             }
                             val timestamp = System.currentTimeMillis() / 1000
-                            val sanitizedName = item.filename.replace(Regex("[^a-zA-Z0-9._-]"), "_")
+                            val sanitizedName = item.filename.replace(FILENAME_SANITIZE_REGEX, "_")
                             val uploadFilename = "${timestamp}_$sanitizedName"
 
                             val presignResult = api.uploadAttachmentFile(
@@ -1500,7 +1501,7 @@ class ChatController @Inject constructor(
                         for (attempt in 1..SHARE_MAX_RETRIES) {
                             try {
                                 val timestamp = System.currentTimeMillis() / 1000
-                                val sanitizedName = item.filename.replace(Regex("[^a-zA-Z0-9._-]"), "_")
+                                val sanitizedName = item.filename.replace(FILENAME_SANITIZE_REGEX, "_")
                                 val uploadFilename = "${timestamp}_$sanitizedName"
 
                                 val presignResult = api.uploadAttachmentFile(

--- a/app/src/main/java/com/mezon/mobile/home/chat/AdvancedAttachAlert.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/AdvancedAttachAlert.kt
@@ -115,13 +115,17 @@ class AdvancedAttachAlert(
             cell.layoutParams = RecyclerView.LayoutParams(
                 RecyclerView.LayoutParams.MATCH_PARENT, LayoutHelper.dp(100f)
             )
-            return Holder(cell)
+            val holder = Holder(cell)
+            cell.setOnClickListener {
+                val pos = holder.bindingAdapterPosition
+                if (pos != RecyclerView.NO_POSITION) onFunctionClicked(functions[pos])
+            }
+            return holder
         }
 
         override fun onBindViewHolder(holder: Holder, position: Int) {
             val item = functions[position]
             holder.cell.setData(item.labelResId, item.icon)
-            holder.cell.setOnClickListener { onFunctionClicked(item) }
         }
 
         override fun getItemCount() = functions.size

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -165,6 +165,7 @@ private const val POLL_TALLY_TICK_MS = 15_000L
 private const val POLL_TALLY_MIN_GAP_MS = 12_000L
 private const val POLL_TALLY_MAX_PER_TICK = 8
 private const val TOPIC_BADGE_HYDRATE_DEBOUNCE_MS = 500L
+private val AT_HERE_INPUT_REGEX = Regex("(?<!\\w)@here(?!\\w)")
 
 open class ChatFragment : BaseFragment() {
 
@@ -2894,17 +2895,10 @@ open class ChatFragment : BaseFragment() {
     }
 
     private fun onPageDownClicked() {
-        if (returnToMessageId != 0L) {
-            val retId = returnToMessageId
-            returnToMessageId = 0L
-            scrollToReplyMessage(retId)
-        } else {
-            jumpToPresent()
-        }
+        jumpToPresent()
     }
 
     private fun jumpToPresent() {
-        returnToMessageId = 0L
         newUnreadCount = 0
         isViewingOlder = false
         hasMoreBottom = false
@@ -2926,13 +2920,8 @@ open class ChatFragment : BaseFragment() {
             markAsRead()
         } else {
             jumpingToPresent = true
-            messages.clear()
-            messagesDict.clear()
-            EmbedFormUtil.clearAll()
-            adapter.notifyMessagesUpdated()
-            recyclerView.visibility = View.INVISIBLE
             firstLoad = true
-            Log.d(TAG, "jumpToPresent: cleared list, calling loadMessages forceRefresh=true")
+            Log.d(TAG, "jumpToPresent: keeping current list until reload completes, loadMessages forceRefresh=true")
             chatController.loadMessages(channelId, clanId, forceRefresh = true, preferHttp = false, topicId = topicId)
         }
     }
@@ -6333,7 +6322,10 @@ open class ChatFragment : BaseFragment() {
             Log.d(TAG, "applyRealId tempId=$tempId realId=$realId already present, dropping optimistic")
             messagesDict.delete(tempId)
             messages.removeAt(idx)
-            if (fragmentView != null) adapter.notifyMessagesUpdated()
+            if (fragmentView != null) {
+                adapter.notifyMessageRemovedAt(idx)
+                updateUnreadDividerPosition()
+            }
             return
         }
 
@@ -6389,10 +6381,8 @@ open class ChatFragment : BaseFragment() {
 
     private var pendingHighlightMessageId = 0L
     private var pendingJumpMessageId = 0L
-    private var returnToMessageId = 0L
 
     private fun scrollToReplyMessage(messageId: Long) {
-        saveReturnPosition()
         val idx = messages.indexOfFirst { it.id == messageId }
         if (idx >= 0) {
             scrollToAndHighlight(idx)
@@ -6407,22 +6397,6 @@ open class ChatFragment : BaseFragment() {
                 preferHttp = openedFromNotification,
                 topicId = topicId
             )
-        }
-    }
-
-    private fun saveReturnPosition() {
-        if (messages.isEmpty()) return
-        val lm = recyclerView.layoutManager as? LinearLayoutManager ?: return
-        val firstPos = lm.findFirstVisibleItemPosition()
-        if (firstPos == RecyclerView.NO_POSITION) return
-        val v = recyclerView.findViewHolderForAdapterPosition(firstPos)?.itemView
-        val msgId = when (v) {
-            is ChatMessageCell -> v.messageEntity?.id
-            is SystemMessageCell -> v.messageEntity?.id
-            else -> null
-        }
-        if (msgId != null && msgId != 0L) {
-            returnToMessageId = msgId
         }
     }
 
@@ -6511,8 +6485,7 @@ open class ChatFragment : BaseFragment() {
     private fun mergeAtHereMentionsFromText(cleanedText: String, existing: List<MentionData>): List<MentionData> {
         val result = existing.toMutableList()
         if (cleanedText.isEmpty()) return result
-        val atHere = "(?<!\\w)@here(?!\\w)".toRegex()
-        for (match in atHere.findAll(cleanedText)) {
+        for (match in AT_HERE_INPUT_REGEX.findAll(cleanedText)) {
             val s = match.range.first
             val e = match.range.last + 1
             if (result.any { mentionIntervalsOverlap(it.startOffset, it.endOffset, s, e) }) continue

--- a/app/src/main/java/com/mezon/mobile/home/chat/thread/CreateThreadFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/thread/CreateThreadFragment.kt
@@ -102,6 +102,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
+private val AT_HERE_INPUT_REGEX = Regex("(?<!\\w)@here(?!\\w)")
+
 class CreateThreadFragment : BaseFragment() {
 
     companion object {
@@ -1515,8 +1517,7 @@ class CreateThreadFragment : BaseFragment() {
     private fun mergeAtHereMentionsFromText(cleanedText: String, existing: List<MentionData>): List<MentionData> {
         val result = existing.toMutableList()
         if (cleanedText.isEmpty()) return result
-        val atHere = "(?<!\\w)@here(?!\\w)".toRegex()
-        for (match in atHere.findAll(cleanedText)) {
+        for (match in AT_HERE_INPUT_REGEX.findAll(cleanedText)) {
             val s = match.range.first
             val e = match.range.last + 1
             if (result.any { mentionIntervalsOverlap(it.startOffset, it.endOffset, s, e) }) continue

--- a/app/src/main/java/com/mezon/mobile/home/clans/ClansFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ClansFragment.kt
@@ -26,6 +26,7 @@ import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
+import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -238,7 +239,12 @@ class ClansFragment : BaseFragment() {
             layoutManager = LinearLayoutManager(context)
             setBackgroundColor(themeColors.serverRailBg)
             isVerticalScrollBarEnabled = false
-            itemAnimator = null
+            itemAnimator = DefaultItemAnimator().apply {
+                supportsChangeAnimations = false
+                addDuration = 180L
+                removeDuration = 180L
+                moveDuration = 220L
+            }
             setSelectorType(RecyclerListView.SELECTOR_CIRCLE_TO_BOUND)
         }
         serverAdapter = ServerRailAdapter()
@@ -1098,6 +1104,8 @@ class ClansFragment : BaseFragment() {
         sheet.show()
     }
 
+    private data class RailRow(val id: Long, val type: Int, val content: Any?)
+
     inner class ServerRailAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
         init { setHasStableIds(true) }
@@ -1130,15 +1138,10 @@ class ClansFragment : BaseFragment() {
             newLogoUrl: String = "",
             embeddedDiscoverRail: Boolean = false
         ) {
-            val oldUnreadDms = ArrayList(unreadDms)
-            val oldUnreadIds = oldUnreadDms.map { it.channelId }
-            val oldClans = ArrayList(clans)
-            val oldClanIds = oldClans.map { it.clanId }
-            val oldSelectedId = selectedClanId
-            val oldPendingFriendCount = pendingFriendCount
-            val oldLogoUrl = logoUrl
-            val oldEmbeddedDiscoverRail = embeddedRailDiscoverHighlight
-            val oldSize = itemCount
+            val oldRows = buildRows(
+                unreadDms, clans, selectedClanId,
+                pendingFriendCount, logoUrl, embeddedRailDiscoverHighlight
+            )
 
             unreadDms.clear()
             unreadDms.addAll(newUnreadDms)
@@ -1149,55 +1152,50 @@ class ClansFragment : BaseFragment() {
             logoUrl = newLogoUrl
             embeddedRailDiscoverHighlight = embeddedDiscoverRail
 
-            val newUnreadIds = newUnreadDms.map { it.channelId }
-            val newClanIds = newClans.map { it.clanId }
-            val newSize = itemCount
+            val newRows = buildRows(
+                unreadDms, clans, selectedClanId,
+                pendingFriendCount, logoUrl, embeddedRailDiscoverHighlight
+            )
 
-            val structureChanged = oldSize != newSize ||
-                oldUnreadIds != newUnreadIds ||
-                oldClanIds != newClanIds
-            if (structureChanged) {
-                notifyDataSetChanged()
-                return
+            DiffUtil.calculateDiff(object : DiffUtil.Callback() {
+                override fun getOldListSize() = oldRows.size
+                override fun getNewListSize() = newRows.size
+                override fun areItemsTheSame(oldPos: Int, newPos: Int) =
+                    oldRows[oldPos].id == newRows[newPos].id
+                override fun areContentsTheSame(oldPos: Int, newPos: Int) =
+                    oldRows[oldPos] == newRows[newPos]
+            }).dispatchUpdatesTo(this)
+        }
+
+        private fun buildRows(
+            unreadList: List<DirectMessage>,
+            clanList: List<ClanEntity>,
+            selectedId: Long,
+            pendingCount: Int,
+            logo: String,
+            discoverHighlight: Boolean
+        ): List<RailRow> {
+            val rows = ArrayList<RailRow>(unreadList.size + clanList.size + 4)
+            rows.add(RailRow(Long.MIN_VALUE, VIEW_TYPE_DM_HEADER, listOf(logo, pendingCount)))
+            for (dm in unreadList) {
+                rows.add(RailRow(dm.channelId, VIEW_TYPE_UNREAD_DM, listOf(dm.unreadCount, dm.lastMessageContent)))
             }
-
-            if (oldLogoUrl != newLogoUrl || oldPendingFriendCount != newPendingFriendCount) {
-                notifyItemChanged(0)
+            if (clanList.isNotEmpty()) {
+                rows.add(RailRow(Long.MIN_VALUE + 1, VIEW_TYPE_SEPARATOR, Unit))
             }
-
-            for (i in newUnreadDms.indices) {
-                val old = oldUnreadDms.getOrNull(i)
-                val new = newUnreadDms[i]
-                if (old == null || old.unreadCount != new.unreadCount ||
-                    old.lastMessageContent != new.lastMessageContent) {
-                    notifyItemChanged(dmHeaderCount + i)
-                }
+            for (clan in clanList) {
+                rows.add(
+                    RailRow(
+                        clan.clanId, VIEW_TYPE_CLAN,
+                        listOf(clan.badgeCount, clan.hasUnread, clan.logo, clan.clanName, clan.clanId == selectedId)
+                    )
+                )
             }
-
-            val sep = if (hasSeparator) 1 else 0
-            val clanStart = dmHeaderCount + unreadDms.size + sep
-            val oldClanMap = HashMap<Long, ClanEntity>(oldClans.size)
-            for (c in oldClans) oldClanMap[c.clanId] = c
-
-            for (i in newClans.indices) {
-                val new = newClans[i]
-                val old = oldClanMap[new.clanId]
-                val selected = new.clanId == newSelectedId
-                val wasSelected = new.clanId == oldSelectedId
-                if (old == null ||
-                    old.badgeCount != new.badgeCount ||
-                    old.hasUnread != new.hasUnread ||
-                    old.logo != new.logo ||
-                    old.clanName != new.clanName ||
-                    selected != wasSelected) {
-                    notifyItemChanged(clanStart + i)
-                }
+            if (discoverRailCellEnabled) {
+                rows.add(RailRow(Long.MIN_VALUE + 3, VIEW_TYPE_DISCOVER, discoverHighlight))
             }
-
-            if (discoverRailCellEnabled &&
-                oldEmbeddedDiscoverRail != embeddedRailDiscoverHighlight) {
-                notifyItemChanged(itemCount - 2)
-            }
+            rows.add(RailRow(Long.MIN_VALUE + 4, VIEW_TYPE_ADD_CLAN, Unit))
+            return rows
         }
 
         fun updatePendingFriendCount(count: Int) {

--- a/app/src/main/java/com/mezon/mobile/home/clans/DmLogoCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/DmLogoCell.kt
@@ -33,6 +33,7 @@ class DmLogoCell(
     private var logoCancellable: MezonImageLoader.Cancellable? = null
     private val clipPath = Path()
     private val clipRect = RectF()
+    private val bitmapDestRect = android.graphics.Rect()
 
     private val badgeBgPaint = Paint(Paint.ANTI_ALIAS_FLAG)
     private val badgeTextPaint = TextPaint(Paint.ANTI_ALIAS_FLAG).apply {
@@ -113,7 +114,8 @@ class DmLogoCell(
 
         val bmp = logoBitmap
         if (bmp != null && !bmp.isRecycled) {
-            canvas.drawBitmap(bmp, null, android.graphics.Rect(left, top, right, bottom), null)
+            bitmapDestRect.set(left, top, right, bottom)
+            canvas.drawBitmap(bmp, null, bitmapDestRect, null)
         } else {
             fallbackDrawable.setBounds(left, top, right, bottom)
             fallbackDrawable.draw(canvas)

--- a/app/src/main/java/com/mezon/mobile/home/clans/channelapp/ChannelAppShowAllFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/channelapp/ChannelAppShowAllFragment.kt
@@ -216,13 +216,17 @@ class ChannelAppShowAllFragment : BaseFragment() {
         }
 
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AppHolder {
-            return AppHolder(AppRowView(parent.context, themeColors))
+            val holder = AppHolder(AppRowView(parent.context, themeColors))
+            holder.itemView.setOnClickListener {
+                val pos = holder.bindingAdapterPosition
+                if (pos != RecyclerView.NO_POSITION) onClick(items[pos])
+            }
+            return holder
         }
 
         override fun onBindViewHolder(holder: AppHolder, position: Int) {
             val item = items[position]
             (holder.itemView as AppRowView).bind(item)
-            holder.itemView.setOnClickListener { onClick(item) }
         }
 
         override fun getItemCount(): Int = items.size

--- a/app/src/main/java/com/mezon/mobile/home/clans/settings/AuditLogSettingFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/settings/AuditLogSettingFragment.kt
@@ -618,7 +618,12 @@ private class AuditLogPickerListAdapter(
             setPadding(0, LayoutHelper.dp(1), 0, LayoutHelper.dp(1))
             addView(tv, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT))
         }
-        return VH(row, tv)
+        val vh = VH(row, tv)
+        row.setOnClickListener {
+            val pos = vh.bindingAdapterPosition
+            if (pos != RecyclerView.NO_POSITION) onRow(filtered[pos])
+        }
+        return vh
     }
 
     override fun getItemCount(): Int = filtered.size
@@ -638,7 +643,6 @@ private class AuditLogPickerListAdapter(
         } else {
             null
         }
-        holder.itemView.setOnClickListener { onRow(row) }
     }
 
     class VH(val wrap: FrameLayout, val text: TextView) : RecyclerView.ViewHolder(wrap)

--- a/app/src/main/java/com/mezon/mobile/home/clans/settings/EmojiSettingFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/settings/EmojiSettingFragment.kt
@@ -959,7 +959,11 @@ class EmojiSettingFragment : BaseFragment() {
                 LayoutHelper.createLinear(40, LayoutHelper.WRAP_CONTENT, 0f, Gravity.CENTER_VERTICAL),
             )
 
-            return RowVH(row, emojiIv, edit, av, deleteBtn)
+            val vh = RowVH(row, emojiIv, edit, av, deleteBtn)
+            deleteBtn.setOnClickListener {
+                vh.item?.let { confirmDelete(it) }
+            }
+            return vh
         }
 
         override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
@@ -1004,9 +1008,6 @@ class EmojiSettingFragment : BaseFragment() {
             val del = MezonIcon.closeSmallBold.getDrawable(holder.deleteBtn.context, themeColors.error)
             holder.deleteBtn.setImageDrawable(del)
             holder.deleteBtn.visibility = if (allow) View.VISIBLE else View.INVISIBLE
-            holder.deleteBtn.setOnClickListener {
-                confirmDelete(item)
-            }
         }
 
         private inner class RowVH(

--- a/app/src/main/java/com/mezon/mobile/home/clans/settings/RoleSetupPermissionsFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/settings/RoleSetupPermissionsFragment.kt
@@ -386,7 +386,18 @@ class RoleSetupPermissionsFragment : BaseFragment() {
                 RecyclerView.LayoutParams.MATCH_PARENT,
                 RecyclerView.LayoutParams.WRAP_CONTENT
             )
-            return Holder(cell, cell)
+            val holder = Holder(cell, cell)
+            cell.setOnClickListener {
+                val pos = holder.bindingAdapterPosition
+                if (pos == RecyclerView.NO_POSITION || pos !in rows.indices) return@setOnClickListener
+                val item = rows[pos]
+                if (disabledForSlug(item.slug, roleSnapshot, permState())) return@setOnClickListener
+                val next = !cell.isChecked()
+                cell.setChecked(next)
+                if (next) selectedIds.add(item.permissionId) else selectedIds.remove(item.permissionId)
+                updateActionState()
+            }
+            return holder
         }
 
         override fun onBindViewHolder(holder: Holder, position: Int) {
@@ -416,12 +427,6 @@ class RoleSetupPermissionsFragment : BaseFragment() {
                 } else {
                     applyChecked(next)
                 }
-            }
-            cell.setOnClickListener {
-                if (disabled) return@setOnClickListener
-                val next = !cell.isChecked()
-                cell.setChecked(next)
-                applyChecked(next)
             }
         }
 

--- a/app/src/main/java/com/mezon/mobile/home/profile/AppearanceThemeFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/profile/AppearanceThemeFragment.kt
@@ -467,7 +467,12 @@ class AppearanceThemeFragment : BaseFragment() {
                 }
             )
             cell.addView(swatch)
-            return ThemeViewHolder(cell, swatch, icon)
+            val holder = ThemeViewHolder(cell, swatch, icon)
+            cell.setOnClickListener {
+                val pos = holder.bindingAdapterPosition
+                if (pos != RecyclerView.NO_POSITION) onItemClick(pos)
+            }
+            return holder
         }
 
         override fun getItemCount(): Int = options.size
@@ -499,7 +504,6 @@ class AppearanceThemeFragment : BaseFragment() {
                 holder.icon.setImageDrawable(null)
                 holder.icon.colorFilter = null
             }
-            holder.itemView.setOnClickListener { onItemClick(position) }
         }
 
         class ThemeViewHolder(

--- a/app/src/main/java/com/mezon/mobile/home/voice/VoiceParticipantAdapter.kt
+++ b/app/src/main/java/com/mezon/mobile/home/voice/VoiceParticipantAdapter.kt
@@ -47,11 +47,27 @@ class VoiceParticipantAdapter(
         val cell = ParticipantCell(parent.context, themeColors).apply {
             layoutParams = createLayoutParams(isCompactMode())
         }
-        return ParticipantVH(cell)
+        val holder = ParticipantVH(cell)
+        cell.setOnClickListener {
+            val participant = holder.participant ?: return@setOnClickListener
+            if (participant.isScreenShare && participant.videoTrack != null) {
+                onScreenShareClick(participant)
+            }
+        }
+        cell.setOnLongClickListener {
+            val participant = holder.participant ?: return@setOnLongClickListener false
+            if (participant.isScreenShare) {
+                return@setOnLongClickListener false
+            }
+            onParticipantLongPress(participant)
+            true
+        }
+        return holder
     }
 
     override fun onBindViewHolder(holder: ParticipantVH, position: Int) {
         val participant = getParticipants()[position]
+        holder.participant = participant
         holder.cell.layoutParams = createLayoutParams(isCompactMode())
         holder.cell.setParticipant(
             participant.identity.toLongOrNull() ?: 0L,
@@ -71,19 +87,6 @@ class VoiceParticipantAdapter(
         } else {
             holder.cell.detachVideoTrack()
         }
-
-        holder.cell.setOnClickListener {
-            if (participant.isScreenShare && participant.videoTrack != null) {
-                onScreenShareClick(participant)
-            }
-        }
-        holder.cell.setOnLongClickListener {
-            if (participant.isScreenShare) {
-                return@setOnLongClickListener false
-            }
-            onParticipantLongPress(participant)
-            true
-        }
     }
 
     override fun onViewRecycled(holder: ParticipantVH) {
@@ -101,5 +104,7 @@ class VoiceParticipantAdapter(
         }
     }
 
-    class ParticipantVH(val cell: ParticipantCell) : RecyclerView.ViewHolder(cell)
+    class ParticipantVH(val cell: ParticipantCell) : RecyclerView.ViewHolder(cell) {
+        var participant: ParticipantInfo? = null
+    }
 }


### PR DESCRIPTION
Always call jumpToPresent on page-down so pinned-message jumps reload latest history instead of scrolling to a stale return anchor. Also hoists adapter click listeners, DiffUtil-updates the clan server rail, async-warms StartupCache on relaunch, and caches hot-path regex/rect reuse.