### PR TITLE
fix(chat): polish attachment upload concurrency and loading UX

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/ChatController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChatController.kt
@@ -152,8 +152,10 @@ class ChatController @Inject constructor(
     private val attachmentJobsByTempId = LongSparseArray<IncrementalAttachmentJob>()
     private val attachmentJobsByRealId = LongSparseArray<IncrementalAttachmentJob>()
     private val pendingAttachmentEntityByTempId = LongSparseArray<MessageEntity>()
+    private val imageCompressionSlots = Semaphore(IMAGE_COMPRESSION_PARALLELISM)
+    private val largeUploadSlots = Semaphore(LARGE_ATTACHMENT_PARALLELISM)
 
-    private data class CachedAttachment(
+    private class CachedAttachment(
         val item: AttachmentPickerItem,
         val bytes: ByteArray,
     )
@@ -307,6 +309,7 @@ class ChatController @Inject constructor(
         }
         pendingApiReactions.clear()
         lastApiReactionDedup = null
+        com.mezon.mobile.util.AttachmentUploader.resetMultipartAvailabilityForSession()
     }
 
     suspend fun getMessageById(channelId: Long, messageId: Long): MessageEntity? =
@@ -1282,6 +1285,9 @@ class ChatController @Inject constructor(
         private const val SHARE_MAX_RETRIES = 5
         private const val SHARE_RETRY_DELAY_MS = 4000L
         private const val ATTACHMENT_UPLOAD_PARALLELISM = 4
+        private const val IMAGE_COMPRESSION_PARALLELISM = 2
+        private const val LARGE_ATTACHMENT_BYTES = 50L * 1024 * 1024
+        private const val LARGE_ATTACHMENT_PARALLELISM = 2
         private const val PENDING_API_REACTION_DEDUP_MS = 5000L
     }
 
@@ -1627,40 +1633,55 @@ class ChatController @Inject constructor(
         val uploadedByIndex = arrayOfNulls<MessageAttachment>(items.size)
         val failedIndices = HashSet<Int>()
         var messageSent = false
+        var firstSendStarted = false
         var realMessageId = 0L
         var lastSyncedUploadCount = 0
+        val resultMutex = Mutex()
+        val sendMutex = Mutex()
 
         suspend fun flushAttachmentUpdate(updateError: Boolean = false) {
-            if (!messageSent || realMessageId == 0L) return
-            val uploadedList = uploadedByIndex.filterNotNull()
-            val uploadedCount = uploadedList.size
-            val hasFailure = failedIndices.isNotEmpty()
-            if (!updateError && uploadedCount == lastSyncedUploadCount && !hasFailure) return
+            var proceed = false
+            var uploadedSnapshot: List<MessageAttachment?> = emptyList()
+            var failedSnapshot: Set<Int> = emptySet()
+            var uploadedCount = 0
+            var targetMessageId = 0L
+            resultMutex.withLock {
+                if (messageSent && realMessageId != 0L) {
+                    uploadedSnapshot = uploadedByIndex.toList()
+                    failedSnapshot = failedIndices.toSet()
+                    uploadedCount = uploadedSnapshot.count { it != null }
+                    targetMessageId = realMessageId
+                    proceed = updateError || uploadedCount != lastSyncedUploadCount || failedSnapshot.isNotEmpty()
+                }
+            }
+            if (!proceed) return
             if (uploadedCount > 1) {
                 try {
                     channelUpdate(
                         apiUrl, token,
                         params.clanId, params.channelId, params.mode, params.isPublic,
-                        realMessageId, params.wireContent, params.protoMentions, uploadedList,
+                        targetMessageId, params.wireContent, params.protoMentions, uploadedSnapshot.filterNotNull(),
                         topicId = params.topicId,
                     )
-                    lastSyncedUploadCount = uploadedCount
+                    resultMutex.withLock {
+                        if (uploadedCount > lastSyncedUploadCount) lastSyncedUploadCount = uploadedCount
+                    }
                 } catch (e: Exception) {
-                    Log.e(TAG, "Incremental send: attachment batch update failed messageId=$realMessageId", e)
+                    Log.e(TAG, "Incremental send: attachment batch update failed messageId=$targetMessageId", e)
                     applyLocalOrderedAttachmentUpdate(
-                        params.cacheKey, realMessageId, params.allItems,
-                        uploadedByIndex.toList(), failedIndices, updateError = true,
+                        params.cacheKey, targetMessageId, params.allItems,
+                        uploadedSnapshot, failedSnapshot, updateError = true,
                     )
                     return
                 }
             }
             applyLocalOrderedAttachmentUpdate(
-                params.cacheKey, realMessageId, params.allItems,
-                uploadedByIndex.toList(), failedIndices, updateError = updateError,
+                params.cacheKey, targetMessageId, params.allItems,
+                uploadedSnapshot, failedSnapshot, updateError = updateError,
             )
         }
 
-        suspend fun dispatchFirstMessage(attachment: MessageAttachment, index: Int) {
+        suspend fun dispatchFirstMessage(attachment: MessageAttachment) {
             val request = channelMessageSend {
                 this.clanId = params.clanId
                 this.channelId = params.channelId
@@ -1675,20 +1696,27 @@ class ChatController @Inject constructor(
                 if (params.topicId != 0L) this.topicId = params.topicId
             }
             val ack = channelSend(apiUrl, token, request)
-            realMessageId = ack.messageId
-            messageSent = true
-            job.realMessageId = realMessageId
-            lastSyncedUploadCount = 1
+            val newMessageId = ack.messageId
+            val uploadedSnapshot: List<MessageAttachment?>
+            val failedSnapshot: Set<Int>
+            resultMutex.withLock {
+                realMessageId = newMessageId
+                messageSent = true
+                job.realMessageId = newMessageId
+                lastSyncedUploadCount = 1
+                uploadedSnapshot = uploadedByIndex.toList()
+                failedSnapshot = failedIndices.toSet()
+            }
             synchronized(this) {
-                attachmentJobsByRealId.put(realMessageId, job)
+                attachmentJobsByRealId.put(newMessageId, job)
             }
             markForwardTargetUsed(params.channelId, params.channelType)
             val updatedEntity = applyLocalAfterFirstSendOrdered(
-                params.cacheKey, params.tempId, realMessageId,
-                params.allItems, uploadedByIndex.toList(), failedIndices,
+                params.cacheKey, params.tempId, newMessageId,
+                params.allItems, uploadedSnapshot, failedSnapshot,
             )
             notificationCenter.postNotificationOnMainThread(
-                NotificationCenter.pendingMessageSent, params.cacheKey, params.tempId, realMessageId
+                NotificationCenter.pendingMessageSent, params.cacheKey, params.tempId, newMessageId
             )
             notificationCenter.postNotificationOnMainThread(
                 NotificationCenter.messageDidUpdate, params.cacheKey, updatedEntity,
@@ -1697,9 +1725,10 @@ class ChatController @Inject constructor(
         }
 
         val uploadSlots = Semaphore(ATTACHMENT_UPLOAD_PARALLELISM)
-        val resultMutex = Mutex()
 
         suspend fun recordResult(index: Int, attachment: MessageAttachment?) {
+            var firstToSend: MessageAttachment? = null
+            var shouldFlush = false
             resultMutex.withLock {
                 if (attachment == null) {
                     failedIndices.add(index)
@@ -1707,13 +1736,22 @@ class ChatController @Inject constructor(
                 } else {
                     uploadedByIndex[index] = attachment
                     job.uploadedCount = uploadedByIndex.count { it != null }
-                    if (!messageSent) dispatchFirstMessage(attachment, index)
+                    if (!messageSent && !firstSendStarted) {
+                        firstSendStarted = true
+                        firstToSend = attachment
+                    }
                 }
-                if (messageSent &&
+                if (firstToSend == null && messageSent &&
                     uploadedByIndex.count { it != null } - lastSyncedUploadCount >= ATTACHMENT_UPLOAD_PARALLELISM
                 ) {
-                    flushAttachmentUpdate()
+                    shouldFlush = true
                 }
+            }
+            val toSend = firstToSend
+            if (toSend != null) {
+                sendMutex.withLock { dispatchFirstMessage(toSend) }
+            } else if (shouldFlush) {
+                sendMutex.withLock { flushAttachmentUpdate() }
             }
         }
 
@@ -1721,10 +1759,14 @@ class ChatController @Inject constructor(
             coroutineScope {
                 items.forEachIndexed { index, item ->
                     launch(ioDispatcher) {
-                        val attachment = if (item == null) {
-                            null
-                        } else {
-                            uploadSlots.withPermit {
+                        val attachment = when {
+                            item == null -> null
+                            item.size > LARGE_ATTACHMENT_BYTES -> largeUploadSlots.withPermit {
+                                loadAndUploadAttachment(
+                                    item, contentResolver, apiUrl, token, cdnBaseUrl, params.maxRetriesPerFile,
+                                )
+                            }
+                            else -> uploadSlots.withPermit {
                                 loadAndUploadAttachment(
                                     item, contentResolver, apiUrl, token, cdnBaseUrl, params.maxRetriesPerFile,
                                 )
@@ -1734,7 +1776,7 @@ class ChatController @Inject constructor(
                     }
                 }
             }
-            if (messageSent) flushAttachmentUpdate()
+            if (messageSent) sendMutex.withLock { flushAttachmentUpdate() }
 
             if (!messageSent) {
                 notificationCenter.postNotificationOnMainThread(
@@ -1745,6 +1787,7 @@ class ChatController @Inject constructor(
             synchronized(this) {
                 attachmentJobsByTempId.remove(params.tempId)
                 if (realMessageId != 0L) attachmentJobsByRealId.remove(realMessageId)
+                pendingAttachmentEntityByTempId.remove(params.tempId)
             }
         }
     }
@@ -1760,9 +1803,11 @@ class ChatController @Inject constructor(
         val uploader = com.mezon.mobile.util.AttachmentUploader
 
         if (!item.isVideo && uploader.isCompressibleImage(item.mimeType)) {
-            val compressed = uploader.compressImageFromUri(
-                contentResolver, item.uri, item.mimeType, item.filename, item.size,
-            )
+            val compressed = imageCompressionSlots.withPermit {
+                uploader.compressImageFromUri(
+                    contentResolver, item.uri, item.mimeType, item.filename, item.size,
+                )
+            }
             if (compressed != null) {
                 val uploadItem = item.copy(
                     filename = compressed.filename,
@@ -1791,6 +1836,34 @@ class ChatController @Inject constructor(
         }
     }
 
+    private suspend fun uploadVideoThumbnailIfNeeded(
+        item: AttachmentPickerItem,
+        file: java.io.File,
+        apiUrl: String,
+        token: String,
+        cdnBaseUrl: String,
+        timestamp: Long,
+        sanitizedName: String,
+    ): String {
+        if (!item.isVideo && !com.mezon.mobile.util.AttachmentUploader.isVideoMimeType(item.mimeType)) {
+            return ""
+        }
+        val thumb = com.mezon.mobile.util.AttachmentUploader.extractVideoThumbnailJpeg(file) ?: return ""
+        val dot = sanitizedName.lastIndexOf('.')
+        val base = if (dot > 0) sanitizedName.substring(0, dot) else sanitizedName
+        val thumbFilename = "${timestamp}_${base}_thumb.jpg"
+        return try {
+            val thumbUpload = com.mezon.mobile.util.AttachmentUploader.uploadAttachmentBytes(
+                api, apiUrl, token, thumbFilename, thumb.mimeType, thumb.bytes,
+                thumb.width, thumb.height, cdnBaseUrl,
+            )
+            thumbUpload.cdnUrl
+        } catch (e: Exception) {
+            Log.w(TAG, "Video thumbnail upload failed for ${item.filename}", e)
+            ""
+        }
+    }
+
     private suspend fun uploadStreamedAttachment(
         item: AttachmentPickerItem,
         file: java.io.File,
@@ -1809,6 +1882,9 @@ class ChatController @Inject constructor(
                     api, apiUrl, token, uploadFilename, item.mimeType, file, fileSize,
                     item.width, item.height, cdnBaseUrl,
                 )
+                val thumbUrl = uploadVideoThumbnailIfNeeded(
+                    item, file, apiUrl, token, cdnBaseUrl, timestamp, sanitizedName,
+                )
                 Log.d(TAG, "Uploaded: ${item.filename} → ${uploadResult.cdnUrl}")
                 return messageAttachment {
                     this.filename = item.filename
@@ -1818,6 +1894,7 @@ class ChatController @Inject constructor(
                     this.width = item.width
                     this.height = item.height
                     if (item.duration > 0) this.duration = item.duration
+                    if (thumbUrl.isNotEmpty()) thumbnail = thumbUrl
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to upload attachment: ${item.filename}", e)

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
@@ -826,6 +826,8 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
 
         if (mediaGridCount == 0) return
 
+        val uploadPendingFlags = msg.mediaUploadPendingFlags()
+
         if (mediaGridCount > 1 && mediaGroupSlots.size != mediaGridCount) {
             val parentW = currentWidth()
             val maxW = albumMaxWidthPx(parentW)
@@ -850,7 +852,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             val isLocalUri = att.url.startsWith("content://") || att.url.startsWith("file://")
             val isVideo = att.filetype.startsWith("video/", true)
             slotIsVideo[i] = isVideo
-            slotUploadPending[i] = msg.isMediaAttachmentUploadPending(i)
+            slotUploadPending[i] = uploadPendingFlags.getOrElse(i) { false }
             if (isLocalUri && isVideo) {
                 receiver.recycle()
                 loadLocalVideoThumbnail(att.url, i)

--- a/app/src/main/java/com/mezon/mobile/home/chat/MediaGroupLayout.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/MediaGroupLayout.kt
@@ -12,10 +12,8 @@ object MediaGroupLayout {
     private const val MAX_SIZE_HEIGHT = 814f
     private const val LAYOUT_TO_PIXEL = 1000f
 
-    // Single album shows up to 12 photos (Telegram's line algorithm resolves <= 12).
     private const val SINGLE_ALBUM_MAX = 12
 
-    // When split, each sub-album caps at 10 like Telegram, distributed evenly.
     private const val SPLIT_CHUNK_MAX = 10
 
     private const val FLAG_LEFT = 1

--- a/app/src/main/java/com/mezon/mobile/home/chat/MessageEntity.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/MessageEntity.kt
@@ -316,32 +316,49 @@ data class MessageEntity(
         return url.startsWith("content://") || url.startsWith("file://")
     }
 
-    fun attachmentUploadFailed(url: String): Boolean {
-        if (extraAttachmentsJson.isEmpty()) return false
+    private fun parseUploadErrorUrls(): Set<String> {
+        if (extraAttachmentsJson.isEmpty()) return emptySet()
         return try {
             val arr = JSONArray(extraAttachmentsJson)
+            val urls = HashSet<String>()
             for (i in 0 until arr.length()) {
                 val obj = arr.getJSONObject(i)
-                if (obj.optString("url") == url) return obj.optBoolean("upload_error", false)
+                if (obj.optBoolean("upload_error", false)) urls.add(obj.optString("url"))
             }
-            false
+            urls
         } catch (_: Exception) {
-            false
+            emptySet()
         }
+    }
+
+    fun attachmentUploadFailed(url: String): Boolean = url in parseUploadErrorUrls()
+
+    private fun isMediaUploadPending(att: AttachmentInfo, index: Int, errorUrls: Set<String>): Boolean {
+        val url = att.url
+        if (!isLocalAttachmentUrl(url)) return false
+        if (url in errorUrls) return false
+        if (index == 0 && attachmentUrl == url && isError) return false
+        return true
     }
 
     fun isMediaAttachmentUploadPending(mediaIndex: Int): Boolean {
         val media = allImageAttachments
         if (mediaIndex !in media.indices) return false
-        val url = media[mediaIndex].url
-        if (!isLocalAttachmentUrl(url)) return false
-        if (attachmentUploadFailed(url)) return false
-        if (mediaIndex == 0 && attachmentUrl == url && isError) return false
-        return true
+        return isMediaUploadPending(media[mediaIndex], mediaIndex, parseUploadErrorUrls())
+    }
+
+    fun mediaUploadPendingFlags(): List<Boolean> {
+        val media = allImageAttachments
+        if (media.isEmpty()) return emptyList()
+        val errorUrls = parseUploadErrorUrls()
+        return media.indices.map { isMediaUploadPending(media[it], it, errorUrls) }
     }
 
     fun hasPendingMediaAttachmentUploads(): Boolean {
-        return allImageAttachments.indices.any { isMediaAttachmentUploadPending(it) }
+        val media = allImageAttachments
+        if (media.isEmpty()) return false
+        val errorUrls = parseUploadErrorUrls()
+        return media.indices.any { isMediaUploadPending(media[it], it, errorUrls) }
     }
 
     fun buildAttachmentJson(): String {

--- a/app/src/main/java/com/mezon/mobile/home/chat/PhotoViewer.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/PhotoViewer.kt
@@ -43,6 +43,9 @@ import kotlinx.coroutines.withContext
 import java.util.Locale
 
 private const val TAG = "PhotoViewer"
+private const val LOADING_SHOW_DELAY_MS = 300L
+private const val MIN_LOADING_VISIBLE_MS = 300L
+private const val LOADING_FADE_MS = 150L
 
 class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Black_NoTitleBar_Fullscreen) {
 
@@ -269,6 +272,10 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
         ) : RecyclerView.ViewHolder(container) {
             var pendingLoad: MezonImageLoader.Cancellable? = null
             var bindGeneration: Long = 0L
+            var progressShown = false
+            var progressShownAt = 0L
+            var showProgressRunnable: Runnable? = null
+            var hideProgressRunnable: Runnable? = null
         }
 
         private fun stopAndClearPhotoView(photoView: PhotoView) {
@@ -340,11 +347,68 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
             return ViewHolder(container, photoView, progress)
         }
 
+        private fun cancelProgressAnim(holder: ViewHolder) {
+            holder.showProgressRunnable?.let { holder.progressBar.removeCallbacks(it) }
+            holder.showProgressRunnable = null
+            holder.hideProgressRunnable?.let { holder.progressBar.removeCallbacks(it) }
+            holder.hideProgressRunnable = null
+            holder.progressBar.animate().cancel()
+        }
+
+        private fun scheduleShowProgress(holder: ViewHolder, bindGen: Long) {
+            cancelProgressAnim(holder)
+            holder.progressShown = false
+            holder.progressBar.visibility = View.GONE
+            holder.progressBar.alpha = 1f
+            val runnable = Runnable {
+                if (holder.bindGeneration != bindGen) return@Runnable
+                holder.progressShown = true
+                holder.progressShownAt = android.os.SystemClock.elapsedRealtime()
+                holder.progressBar.visibility = View.VISIBLE
+                holder.progressBar.alpha = 0f
+                holder.progressBar.animate().alpha(1f).setDuration(LOADING_FADE_MS).start()
+            }
+            holder.showProgressRunnable = runnable
+            holder.progressBar.postDelayed(runnable, LOADING_SHOW_DELAY_MS)
+        }
+
+        private fun hideProgressBar(holder: ViewHolder, bindGen: Long) {
+            holder.showProgressRunnable?.let { holder.progressBar.removeCallbacks(it) }
+            holder.showProgressRunnable = null
+            if (!holder.progressShown) {
+                holder.progressBar.visibility = View.GONE
+                return
+            }
+            val elapsedVisible = android.os.SystemClock.elapsedRealtime() - holder.progressShownAt
+            val delay = (MIN_LOADING_VISIBLE_MS - elapsedVisible).coerceAtLeast(0L)
+            holder.hideProgressRunnable?.let { holder.progressBar.removeCallbacks(it) }
+            val runnable = Runnable {
+                if (holder.bindGeneration != bindGen) return@Runnable
+                holder.hideProgressRunnable = null
+                holder.progressBar.animate().cancel()
+                holder.progressBar.animate()
+                    .alpha(0f)
+                    .setDuration(LOADING_FADE_MS)
+                    .withEndAction {
+                        if (holder.bindGeneration == bindGen) {
+                            holder.progressBar.visibility = View.GONE
+                            holder.progressBar.alpha = 1f
+                            holder.progressShown = false
+                        }
+                    }
+                    .start()
+            }
+            holder.hideProgressRunnable = runnable
+            if (delay > 0) holder.progressBar.postDelayed(runnable, delay) else runnable.run()
+        }
+
         override fun onViewRecycled(holder: ViewHolder) {
             super.onViewRecycled(holder)
             holder.pendingLoad?.cancel()
             holder.pendingLoad = null
             holder.bindGeneration++
+            cancelProgressAnim(holder)
+            holder.progressShown = false
             holder.progressBar.visibility = View.GONE
             stopAndClearPhotoView(holder.photoView)
         }
@@ -357,6 +421,7 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
             holder.pendingLoad = null
             holder.bindGeneration++
             val bindGen = holder.bindGeneration
+            cancelProgressAnim(holder)
             stopAndClearPhotoView(photoView)
 
             val hasThumb = position == currentIndex && initialThumb != null
@@ -364,8 +429,9 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
                 photoView.setImageBitmap(initialThumb)
                 photoView.getAttacher().update()
                 photoView.setScale(1f, false)
+            } else {
+                scheduleShowProgress(holder, bindGen)
             }
-            holder.progressBar.visibility = if (hasThumb) View.GONE else View.VISIBLE
 
             startLoad(holder, url, bindGen, allowRetry = true)
         }
@@ -377,7 +443,7 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
                     if (allowRetry) {
                         startLoad(holder, url, bindGen, allowRetry = false)
                     } else {
-                        holder.progressBar.visibility = View.GONE
+                        hideProgressBar(holder, bindGen)
                     }
                 }
             }
@@ -388,7 +454,7 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
                     holder.pendingLoad = loader.loadDrawable(url, 0, 0,
                         onSuccess = { drawable ->
                             if (holder.bindGeneration != bindGen) return@loadDrawable
-                            holder.progressBar.visibility = View.GONE
+                            hideProgressBar(holder, bindGen)
                             applyLoadedDrawable(holder, drawable)
                         },
                         onError = { onErr() }
@@ -397,7 +463,7 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
                     holder.pendingLoad = loader.load(url, 0, 0,
                         onSuccess = { bmp ->
                             if (holder.bindGeneration != bindGen) return@load
-                            holder.progressBar.visibility = View.GONE
+                            hideProgressBar(holder, bindGen)
                             applyLoadedBitmap(holder, bmp)
                         },
                         onError = { onErr() }
@@ -411,7 +477,7 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
                 holder.pendingLoad = loader.load(loadUrl, screenW, screenH,
                     onSuccess = { bmp ->
                         if (holder.bindGeneration != bindGen) return@load
-                        holder.progressBar.visibility = View.GONE
+                        hideProgressBar(holder, bindGen)
                         applyLoadedBitmap(holder, bmp)
                     },
                     onError = { onErr() },

--- a/app/src/main/java/com/mezon/mobile/util/AttachmentUploader.kt
+++ b/app/src/main/java/com/mezon/mobile/util/AttachmentUploader.kt
@@ -5,6 +5,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Matrix
 import android.media.ExifInterface
+import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.os.Build
 import android.util.Log
@@ -51,8 +52,48 @@ object AttachmentUploader {
     private const val IMAGE_MAX_DIMENSION = 2560
     private const val IMAGE_WEBP_QUALITY = 85
     private const val IMAGE_RECOMPRESS_MIN_BYTES = 512L * 1024
+    private const val VIDEO_THUMB_MAX_DIMENSION = 640
+    private const val VIDEO_THUMB_JPEG_QUALITY = 85
+    private const val VIDEO_THUMB_FRAME_US = 100_000L
 
-    data class CompressedImage(
+    fun isVideoMimeType(mimeType: String): Boolean =
+        mimeType.startsWith("video/", ignoreCase = true)
+
+    fun extractVideoThumbnailJpeg(file: File): CompressedImage? {
+        val retriever = MediaMetadataRetriever()
+        var frame: Bitmap? = null
+        return try {
+            retriever.setDataSource(file.absolutePath)
+            frame = retriever.getFrameAtTime(
+                VIDEO_THUMB_FRAME_US,
+                MediaMetadataRetriever.OPTION_CLOSEST_SYNC,
+            ) ?: return null
+            var bitmap = scaleToMaxDimension(frame, VIDEO_THUMB_MAX_DIMENSION)
+            if (bitmap !== frame) frame.recycle()
+            frame = null
+            val out = ByteArrayOutputStream()
+            val ok = bitmap.compress(Bitmap.CompressFormat.JPEG, VIDEO_THUMB_JPEG_QUALITY, out)
+            val w = bitmap.width
+            val h = bitmap.height
+            bitmap.recycle()
+            if (!ok) return null
+            CompressedImage(
+                bytes = out.toByteArray(),
+                width = w,
+                height = h,
+                mimeType = "image/jpeg",
+                filename = "thumb.jpg",
+            )
+        } catch (e: Throwable) {
+            Log.w(TAG, "extractVideoThumbnailJpeg failed path=${file.absolutePath}", e)
+            null
+        } finally {
+            frame?.recycle()
+            runCatching { retriever.release() }
+        }
+    }
+
+    class CompressedImage(
         val bytes: ByteArray,
         val width: Int,
         val height: Int,

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -11,6 +11,9 @@
     <string name="common_create">Tạo</string>
     <string name="common_confirm">Xác nhận</string>
     <string name="common_close">Đóng</string>
+    <string name="toast_title_success">Thành công</string>
+    <string name="toast_title_error">Lỗi</string>
+    <string name="toast_title_info">Thông tin</string>
     <string name="common_open_settings">Mở cài đặt</string>
     <string name="common_retry">Thử lại</string>
     <string name="common_refresh">Làm mới</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,9 @@
     <string name="common_create">Create</string>
     <string name="common_confirm">Confirm</string>
     <string name="common_close">Close</string>
+    <string name="toast_title_success">Success</string>
+    <string name="toast_title_error">Error</string>
+    <string name="toast_title_info">Info</string>
     <string name="common_open_settings">Open Settings</string>
     <string name="common_retry">Retry</string>
     <string name="common_refresh">Refresh</string>


### PR DESCRIPTION
Split sendMutex from resultMutex, cap large uploads at 2 parallel, and clear pendingAttachmentEntity on all paths. Cache upload-pending flags per cell bind, smooth PhotoViewer spinner fade, add video thumb extract.