### PR TITLE
fix: check 32 byte to show ...

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/DialogsController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/DialogsController.kt
@@ -20,6 +20,7 @@ import com.mezon.mobile.home.chat.MessageEntity
 import com.mezon.mobile.home.messages.DirectMessage
 import com.mezon.mobile.home.messages.DmParticipant
 import com.mezon.mobile.home.messages.extractParticipants
+import com.mezon.mobile.home.messages.formatDirectMessagePreview
 import com.mezon.mobile.home.messages.toDirectMessage
 import com.mezon.mobile.home.messages.toDirectMessageFromIncoming
 import com.mezon.mobile.network.ApiCacheTracker
@@ -892,8 +893,12 @@ class DialogsController @Inject constructor(
                 }
                 val newPreview = if (!isContentMutation ||
                     msg.code == CODE_CHAT_UPDATE ||
-                    msg.code == MessageEntity.CODE_UPDATE_EPHEMERAL)
-                    messagePreviewForDialog(appContext, msg.content, msg.attachments, msg.code) else baseDm.lastMessageContent
+                    msg.code == MessageEntity.CODE_UPDATE_EPHEMERAL
+                ) {
+                    formatDirectMessagePreview(messagePreviewForDialog(appContext, msg.content, msg.attachments, msg.code))
+                } else {
+                    baseDm.lastMessageContent
+                }
 
                 val canAdvanceTimeline = !isContentMutation && !isEphemeralControl && msg.messageId > 0L
 
@@ -1044,7 +1049,7 @@ class DialogsController @Inject constructor(
                 val sameTsHeader = m.id == 0L && ts > 0L && ts == next.lastSentMessageTs
                 val needsPreview = next.lastMessageContent.isBlank() || sameLastMessage || sameTsHeader || isNewer
                 if (needsPreview) {
-                    val preview = messagePreviewForDialog(appContext, m.content)
+                    val preview = formatDirectMessagePreview(messagePreviewForDialog(appContext, m.content))
                     if (preview.isNotBlank() && preview != next.lastMessageContent) {
                         changed = true
                         next = next.copy(lastMessageContent = preview)

--- a/app/src/main/java/com/mezon/mobile/home/messages/DirectMessage.kt
+++ b/app/src/main/java/com/mezon/mobile/home/messages/DirectMessage.kt
@@ -83,6 +83,23 @@ data class DirectMessage(
     }
 }
 
+private const val PREVIEW_MAX_UTF8_BYTES = 32
+private const val PREVIEW_ELLIPSIS_THRESHOLD_BYTES = PREVIEW_MAX_UTF8_BYTES - 3
+private const val PREVIEW_ELLIPSIS = "..."
+
+fun formatDirectMessagePreview(preview: String): String {
+    if (preview.isEmpty() || preview.endsWith(PREVIEW_ELLIPSIS)) return preview
+
+    val bytes = preview.toByteArray(Charsets.UTF_8)
+    if (bytes.size <= PREVIEW_MAX_UTF8_BYTES) {
+        return if (bytes.size >= PREVIEW_ELLIPSIS_THRESHOLD_BYTES) preview + PREVIEW_ELLIPSIS else preview
+    }
+
+    var end = PREVIEW_MAX_UTF8_BYTES
+    while (end > 0 && (bytes[end - 1].toInt() and 0xC0) == 0x80) end--
+    if (end > 0 && (bytes[end - 1].toInt() and 0x80) != 0) end--
+    return String(bytes, 0, end, Charsets.UTF_8) + PREVIEW_ELLIPSIS
+}
 
 fun ChannelDescription.toDirectMessage(currentUserId: Long, previewContext: android.content.Context? = null): DirectMessage {
     val isGroup = type == CHANNEL_TYPE_GROUP
@@ -140,8 +157,9 @@ fun ChannelDescription.toDirectMessage(currentUserId: Long, previewContext: andr
                 previewContext,
                 lastSentMessage.content
             )
+        } else {
+            parseContentPreview(lastSentMessage.content)
         }
-        else parseContentPreview(lastSentMessage.content)
     } else ""
 
     val groupCreatorId = if (type == CHANNEL_TYPE_GROUP) creatorId else 0L
@@ -153,7 +171,7 @@ fun ChannelDescription.toDirectMessage(currentUserId: Long, previewContext: andr
         avatarUrl = avatarUrl,
         displayName = displayName,
         username = if (isGroup) displayName else username,
-        lastMessageContent = lastMsgContent,
+        lastMessageContent = formatDirectMessagePreview(lastMsgContent),
         unreadCount = countMessUnread,
         isOnline = false,
         isMute = isMute,
@@ -181,7 +199,7 @@ fun ChannelMessage.toDirectMessageFromIncoming(
         !isFromMe -> senderName.ifBlank { channelLabel }
         else -> channelLabel.ifBlank { senderName }
     }
-    val preview = messagePreviewForDialog(previewContext, content, attachments, code)
+    val preview = formatDirectMessagePreview(messagePreviewForDialog(previewContext, content, attachments, code))
     val ts = createTimeSeconds.toLong() and 0xFFFF_FFFFL
     val unread = when {
         isOpen -> 0


### PR DESCRIPTION
<img width="383" height="70" alt="image" src="https://github.com/user-attachments/assets/3f2f7df1-e946-410b-ae3f-fab0c775f3f8" />

## 1. Root Cause
The conversation-list message preview did not append `...` correctly for long messages.

There were two issues:
- The old logic only checked `>= 31 bytes` then appended `...`, **without handling UTF-8**, so it could cut a multi-byte character in half.
- In the conversation-list path (`toDirectMessage`), the content is **already truncated by the backend**. The backend truncates to a 32-byte window then backs off to a character boundary (Go `ExtractTTruncated` logic), which can drop an entire complete 3-byte character.
  - Example: `"Chắc cũng làm được nhỉ?"` (33 bytes) → backend returns `"Chắc cũng làm được nh"` (29 bytes; the `ỉ` ending exactly at byte 32 is backed off and dropped).
  - 29 bytes < 31, so `...` was never appended.

## 2. Solution
Rewrote `formatDirectMessagePreview` to match the backend's UTF-8 logic:
- **`> 32 bytes`** (full content, e.g. live incoming messages): truncate safely on UTF-8 byte boundaries — drop trailing continuation bytes `0b10xxxxxx`, then drop a dangling lead byte of an incomplete character — and append `...`.
- **`<= 32 bytes`** (content already truncated by the backend): append `...` when `>= 29 bytes` (= 32 − 3, since the backoff can drop up to one full 3-byte character); otherwise keep it as is.

> Note: the 29-byte threshold is a heuristic — a complete message of 29–32 bytes will also get `...`. If the last character is a 4-byte emoji it may truncate to 28 bytes (switch to `−4` if that needs to be covered).

## 3. Selftest
- [ ] Build succeeds
- [ ] Tested on device/emulator
- [ ] No regression on DM / group lists
