### PR TITLE
feat(chat): presign CDN URLs and send attachments before MinIO upload 

### DIFF
--- a/app/src/main/java/com/mezon/mobile/core/NotificationCenter.kt
+++ b/app/src/main/java/com/mezon/mobile/core/NotificationCenter.kt
@@ -144,6 +144,7 @@ class NotificationCenter(val currentAccount: Int) {
 
         val topicsNeedReload = nextId()
         val attachmentUploadProgress = nextId()
+        val attachmentUploadFinished = nextId()
 
         const val UPDATE_MASK_NAME = 1
         const val UPDATE_MASK_AVATAR = 2

--- a/app/src/main/java/com/mezon/mobile/home/ChatController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChatController.kt
@@ -39,6 +39,7 @@ import com.mezon.mobile.session.SessionManager
 import com.mezon.mobile.BuildConfig
 import com.mezon.mobile.util.AttachmentUploadProgressStore
 import com.mezon.mobile.util.AttachmentUploader
+import com.mezon.mobile.util.PresignFinishContent
 import com.mezon.mobile.util.MENTION_HERE_USER_ID
 import com.mezon.mobile.util.MezonSnowflake
 import com.mezon.mobile.util.firstReferenceMessageId
@@ -1309,6 +1310,7 @@ class ChatController @Inject constructor(
         private const val SHARE_MAX_RETRIES = 5
         private const val SHARE_RETRY_DELAY_MS = 4000L
         private const val ATTACHMENT_UPLOAD_PARALLELISM = 4
+        private const val PRESIGN_EDIT_BATCH_SIZE = 4
         private const val IMAGE_COMPRESSION_PARALLELISM = 2
         private const val LARGE_ATTACHMENT_BYTES = 50L * 1024 * 1024
         private const val LARGE_ATTACHMENT_PARALLELISM = 3
@@ -1412,9 +1414,11 @@ class ChatController @Inject constructor(
             hasContentExtras -> buildTextContentWithEmojis(text, null, emojiMarkers, null, hashtags, ogpMarker)
             else -> buildTextContent(text)
         }
-        val optimisticContent = mergePendingMentionsIntoContent(
-            mergeRefsIntoOptimisticContent(wireBase, references),
-            mentions
+        val optimisticContent = PresignFinishContent.injectEmptyPresignFinish(
+            mergePendingMentionsIntoContent(
+                mergeRefsIntoOptimisticContent(wireBase, references),
+                mentions
+            )
         )
         val mentionEveryone = mentions?.any { it.userId == ID_MENTION_HERE } == true
         val protoMentions = mentions?.map { m ->
@@ -1701,6 +1705,7 @@ class ChatController @Inject constructor(
             }
 
             val attachmentsToSend = preparedSlots.map { it.attachment }
+            val contentWithPresign = PresignFinishContent.injectEmptyPresignFinish(params.wireContent)
             preparedSlots.forEach { slot ->
                 Log.d(TAG, "presign ready index=${slot.index} filename=${slot.attachment.filename} cdnUrl=${slot.attachment.url} thumb=${slot.attachment.thumbnail}")
             }
@@ -1710,7 +1715,7 @@ class ChatController @Inject constructor(
                 this.channelId = params.channelId
                 this.mode = params.mode
                 this.isPublic = params.isPublic
-                this.content = params.wireContent
+                this.content = contentWithPresign
                 this.attachments.addAll(attachmentsToSend)
                 params.protoMentions?.let { this.mentions.addAll(it) }
                 params.references?.let { this.references.addAll(it) }
@@ -1730,23 +1735,96 @@ class ChatController @Inject constructor(
             val uploadedByIndex: List<MessageAttachment?> = items.indices.map { preparedByIndex[it]?.attachment }
             val updatedEntity = applyLocalAfterFirstSendOrdered(
                 params.cacheKey, params.tempId, realMessageId,
-                params.allItems, uploadedByIndex, presignFailedIndices,
+                params.allItems, uploadedByIndex, presignFailedIndices, contentWithPresign,
             )
             notificationCenter.postNotificationOnMainThread(
                 NotificationCenter.pendingMessageSent, params.cacheKey, params.tempId, realMessageId
             )
             notificationCenter.postNotificationOnMainThread(
                 NotificationCenter.messageDidUpdate, params.cacheKey, updatedEntity,
-                NotificationCenter.UPDATE_MASK_ATTACHMENTS,
+                NotificationCenter.UPDATE_MASK_ATTACHMENTS or NotificationCenter.UPDATE_MASK_MESSAGE_TEXT,
             )
+
+            val presignFinishedKeys = ArrayList<String>()
+            var lastSyncedPresignCount = 0
+            val presignMutex = Mutex()
+            var isPresignSyncInFlight = false
+
+            suspend fun applyLocalPresignFinishSnapshot() {
+                val snapshot = presignMutex.withLock { presignFinishedKeys.toList() }
+                if (snapshot.isEmpty()) return
+                val content = PresignFinishContent.injectPresignFinish(params.wireContent, snapshot)
+                applyLocalPresignContentUpdate(params.cacheKey, realMessageId, content)
+            }
+
+            suspend fun maybeSyncPresignFinishToServer(forceFlush: Boolean) {
+                val snapshot: List<String>
+                val pendingNew: Int
+                presignMutex.withLock {
+                    if (presignFinishedKeys.isEmpty()) return
+                    pendingNew = presignFinishedKeys.size - lastSyncedPresignCount
+                    if (!forceFlush && pendingNew < PRESIGN_EDIT_BATCH_SIZE) return
+                    if (isPresignSyncInFlight) return
+                    isPresignSyncInFlight = true
+                    snapshot = presignFinishedKeys.toList()
+                }
+                try {
+                    val content = PresignFinishContent.injectPresignFinish(params.wireContent, snapshot)
+                    val maxAttempts = if (forceFlush) 2 else 1
+                    var synced = false
+                    for (attempt in 1..maxAttempts) {
+                        try {
+                            channelUpdate(
+                                apiUrl, token,
+                                params.clanId, params.channelId, params.mode, params.isPublic,
+                                realMessageId, content, params.protoMentions, attachmentsToSend,
+                                hideEditted = true, topicId = params.topicId,
+                            )
+                            synced = true
+                            break
+                        } catch (e: Exception) {
+                            if (attempt == maxAttempts) {
+                                Log.e(TAG, "presign_finish sync failed messageId=$realMessageId", e)
+                            }
+                        }
+                    }
+                    if (synced) {
+                        presignMutex.withLock {
+                            lastSyncedPresignCount = snapshot.size
+                            job.uploadedCount = snapshot.size
+                        }
+                    }
+                } finally {
+                    presignMutex.withLock { isPresignSyncInFlight = false }
+                }
+            }
 
             val backgroundUploadFailed = coroutineScope {
                 preparedSlots.map { slot ->
                     async(ioDispatcher) {
-                        executeBackgroundAttachmentUpload(slot, apiUrl, token, params.maxRetriesPerFile)
+                        val ok = executeBackgroundAttachmentUpload(slot, apiUrl, token, params.maxRetriesPerFile)
+                        if (ok) {
+                            val key = PresignFinishContent.presignKey(slot.attachment.url)
+                            if (key.isNotEmpty()) {
+                                var shouldApplyLocal = false
+                                presignMutex.withLock {
+                                    if (!presignFinishedKeys.contains(key)) {
+                                        presignFinishedKeys.add(key)
+                                        shouldApplyLocal = true
+                                    }
+                                }
+                                if (shouldApplyLocal) {
+                                    applyLocalPresignFinishSnapshot()
+                                }
+                                maybeSyncPresignFinishToServer(forceFlush = false)
+                            }
+                        }
+                        !ok
                     }
-                }.awaitAll().any { !it }
+                }.awaitAll().any { it }
             }
+            maybeSyncPresignFinishToServer(forceFlush = true)
+            preparedSlots.forEach { AttachmentUploadProgressStore.clear(it.progressKey) }
             if (backgroundUploadFailed) {
                 applyLocalBackgroundUploadFailure(params.cacheKey, realMessageId)
             }
@@ -1779,7 +1857,7 @@ class ChatController @Inject constructor(
     }
 
     private fun clearAttachmentUploadProgress(progressKey: String) {
-        AttachmentUploadProgressStore.clear(progressKey)
+        AttachmentUploadProgressStore.clearProgress(progressKey)
     }
 
     private suspend fun prepareAndPresignAttachment(
@@ -1854,7 +1932,7 @@ class ChatController @Inject constructor(
         }
         return PreparedAttachmentSlot(
             index = index,
-            progressKey = item.uri.toString(),
+            progressKey = presigned.cdnUrl,
             attachment = attachment,
             plan = presigned.plan,
             bytes = bytes,
@@ -1890,7 +1968,7 @@ class ChatController @Inject constructor(
         }
         return PreparedAttachmentSlot(
             index = index,
-            progressKey = item.uri.toString(),
+            progressKey = presigned.cdnUrl,
             attachment = attachment,
             plan = presigned.plan,
             file = file,
@@ -1934,6 +2012,21 @@ class ChatController @Inject constructor(
         }
     }
 
+    private suspend fun uploadVideoThumbnailIfPresent(
+        slot: PreparedAttachmentSlot,
+        apiUrl: String,
+        token: String,
+    ) {
+        val thumb = slot.thumbPlan ?: return
+        try {
+            AttachmentUploader.executeUploadPlan(
+                api, apiUrl, token, thumb.plan, bytes = thumb.bytes,
+            )
+        } catch (e: Exception) {
+            Log.w(TAG, "Video thumbnail upload failed for ${slot.attachment.filename}", e)
+        }
+    }
+
     private suspend fun executeBackgroundAttachmentUpload(
         slot: PreparedAttachmentSlot,
         apiUrl: String,
@@ -1949,11 +2042,11 @@ class ChatController @Inject constructor(
                         api, apiUrl, token, slot.plan,
                         bytes = slot.bytes, file = slot.file, onProgress = onProgress,
                     )
-                    slot.thumbPlan?.let { thumb ->
-                        AttachmentUploader.executeUploadPlan(
-                            api, apiUrl, token, thumb.plan, bytes = thumb.bytes,
-                        )
-                    }
+                    uploadVideoThumbnailIfPresent(slot, apiUrl, token)
+                    AttachmentUploadProgressStore.markUploadComplete(slot.progressKey)
+                    notificationCenter.postNotificationOnMainThread(
+                        NotificationCenter.attachmentUploadFinished, slot.progressKey,
+                    )
                     Log.d(TAG, "Background upload done: ${slot.attachment.filename} → ${slot.attachment.url}")
                     return true
                 } catch (e: Exception) {
@@ -2141,6 +2234,31 @@ class ChatController @Inject constructor(
         return attachmentFieldsFromUploaded(attachments, emptyList())
     }
 
+    private suspend fun applyLocalPresignContentUpdate(
+        cacheKey: Long,
+        messageId: Long,
+        content: String,
+    ) {
+        val existing = withContext(ioDispatcher) { messageDao.getById(cacheKey, messageId) } ?: return
+        val presignOnly = PresignFinishContent.isPresignFinishOnlyChange(content, existing.content)
+        val updated = existing.copy(
+            content = content,
+            hideEditted = true,
+            updateTimeSeconds = if (presignOnly) 0L else existing.updateTimeSeconds,
+        )
+        appScope.launch(ioDispatcher) { messageDao.upsert(updated) }
+        synchronized(this) {
+            val last = dialogMessage.get(cacheKey)
+            if (last != null && last.id == messageId) {
+                dialogMessage.put(cacheKey, updated)
+            }
+        }
+        notificationCenter.postNotificationOnMainThread(
+            NotificationCenter.messageDidUpdate, cacheKey, updated,
+            NotificationCenter.UPDATE_MASK_MESSAGE_TEXT or NotificationCenter.UPDATE_MASK_ATTACHMENTS,
+        )
+    }
+
     private suspend fun applyLocalAfterFirstSendOrdered(
         cacheKey: Long,
         tempId: Long,
@@ -2148,6 +2266,7 @@ class ChatController @Inject constructor(
         allItems: List<AttachmentPickerItem>,
         uploadedByIndex: List<MessageAttachment?>,
         failedIndices: Set<Int>,
+        contentWithPresign: String = "",
     ): MessageEntity {
         val existing = synchronized(this) { pendingAttachmentEntityByTempId.get(tempId) }
             ?: withContext(ioDispatcher) { messageDao.getById(cacheKey, realMessageId) }
@@ -2165,6 +2284,7 @@ class ChatController @Inject constructor(
             isMe = true,
         )).copy(
             id = realMessageId,
+            content = contentWithPresign.ifBlank { existing?.content.orEmpty() },
             attachmentUrl = fields.attachmentUrl,
             attachmentThumb = fields.attachmentThumb,
             attachmentWidth = fields.attachmentWidth,
@@ -2176,6 +2296,7 @@ class ChatController @Inject constructor(
             extraAttachmentsJson = fields.extraAttachmentsJson,
             messageType = fields.messageType,
             sendState = MessageEntity.SEND_STATE_SENT,
+            hideEditted = true,
             isError = hasError,
         )
         appScope.launch(ioDispatcher) { messageDao.upsert(updated) }
@@ -2339,13 +2460,19 @@ class ChatController @Inject constructor(
             existingCount > incomingCount ||
             (expectedTotal > incomingCount && hasAnyLocalAttachmentUrl(existing))
         )
+        val mergedContent = PresignFinishContent.mergePresignFinishContent(base.content, incoming.content)
+        val presignOnly = PresignFinishContent.isPresignFinishOnlyChange(mergedContent, base.content)
         if (!preserveLocalAttachments) {
-            return incoming.copy(content = resolveEchoContent(incoming.content, base.content))
+            return incoming.copy(
+                content = resolveEchoContent(mergedContent, base.content),
+                updateTimeSeconds = if (presignOnly) base.updateTimeSeconds else incoming.updateTimeSeconds,
+                hideEditted = incoming.hideEditted || presignOnly,
+            )
         }
         return base.copy(
-            content = resolveEchoContent(base.content, incoming.content),
-            updateTimeSeconds = incoming.updateTimeSeconds,
-            hideEditted = incoming.hideEditted,
+            content = resolveEchoContent(base.content, mergedContent),
+            updateTimeSeconds = if (presignOnly) base.updateTimeSeconds else incoming.updateTimeSeconds,
+            hideEditted = incoming.hideEditted || presignOnly,
             code = incoming.code,
         )
     }

--- a/app/src/main/java/com/mezon/mobile/home/ChatController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChatController.kt
@@ -77,6 +77,8 @@ import com.mezon.mezon.rtapi.channelMessageUpdate
 import com.mezon.mobile.network.ConnectionState
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.Dispatchers
@@ -157,8 +159,18 @@ class ChatController @Inject constructor(
     private val imageCompressionSlots = Semaphore(IMAGE_COMPRESSION_PARALLELISM)
     private val largeUploadSlots = Semaphore(LARGE_ATTACHMENT_PARALLELISM)
 
-    private class CachedAttachment(
-        val item: AttachmentPickerItem,
+    private class PreparedAttachmentSlot(
+        val index: Int,
+        val progressKey: String,
+        val attachment: MessageAttachment,
+        val plan: AttachmentUploader.UploadExecutionPlan,
+        val bytes: ByteArray? = null,
+        val file: java.io.File? = null,
+        val thumbPlan: PreparedThumbUpload? = null,
+    )
+
+    private class PreparedThumbUpload(
+        val plan: AttachmentUploader.UploadExecutionPlan,
         val bytes: ByteArray,
     )
 
@@ -1642,65 +1654,64 @@ class ChatController @Inject constructor(
         }
 
         val cdnBaseUrl = BuildConfig.MEZON_BASE_IMG_URL
-        val uploadedByIndex = arrayOfNulls<MessageAttachment>(items.size)
-        val failedIndices = HashSet<Int>()
-        var messageSent = false
-        var firstSendStarted = false
-        var realMessageId = 0L
-        var lastSyncedUploadCount = 0
+        val preparedByIndex = arrayOfNulls<PreparedAttachmentSlot>(items.size)
+        val presignFailedIndices = HashSet<Int>()
         val resultMutex = Mutex()
-        val sendMutex = Mutex()
+        val uploadSlots = Semaphore(ATTACHMENT_UPLOAD_PARALLELISM)
+        var realMessageId = 0L
 
-        suspend fun flushAttachmentUpdate(updateError: Boolean = false) {
-            var proceed = false
-            var uploadedSnapshot: List<MessageAttachment?> = emptyList()
-            var failedSnapshot: Set<Int> = emptySet()
-            var uploadedCount = 0
-            var targetMessageId = 0L
-            resultMutex.withLock {
-                if (messageSent && realMessageId != 0L) {
-                    uploadedSnapshot = uploadedByIndex.toList()
-                    failedSnapshot = failedIndices.toSet()
-                    uploadedCount = uploadedSnapshot.count { it != null }
-                    targetMessageId = realMessageId
-                    proceed = updateError || uploadedCount != lastSyncedUploadCount || failedSnapshot.isNotEmpty()
-                }
-            }
-            if (!proceed) return
-            if (uploadedCount > 1) {
-                try {
-                    channelUpdate(
-                        apiUrl, token,
-                        params.clanId, params.channelId, params.mode, params.isPublic,
-                        targetMessageId, params.wireContent, params.protoMentions, uploadedSnapshot.filterNotNull(),
-                        topicId = params.topicId,
-                    )
-                    resultMutex.withLock {
-                        if (uploadedCount > lastSyncedUploadCount) lastSyncedUploadCount = uploadedCount
+        try {
+            coroutineScope {
+                items.mapIndexed { index, item ->
+                    async(ioDispatcher) {
+                        if (item == null) {
+                            resultMutex.withLock { presignFailedIndices.add(index) }
+                            return@async
+                        }
+                        val slot = when {
+                            item.size > LARGE_ATTACHMENT_BYTES -> largeUploadSlots.withPermit {
+                                prepareAndPresignAttachment(
+                                    index, item, contentResolver, apiUrl, token, cdnBaseUrl, params.maxRetriesPerFile,
+                                )
+                            }
+                            else -> uploadSlots.withPermit {
+                                prepareAndPresignAttachment(
+                                    index, item, contentResolver, apiUrl, token, cdnBaseUrl, params.maxRetriesPerFile,
+                                )
+                            }
+                        }
+                        resultMutex.withLock {
+                            if (slot == null) {
+                                presignFailedIndices.add(index)
+                            } else {
+                                preparedByIndex[index] = slot
+                            }
+                        }
                     }
-                } catch (e: Exception) {
-                    Log.e(TAG, "Incremental send: attachment batch update failed messageId=$targetMessageId", e)
-                    applyLocalOrderedAttachmentUpdate(
-                        params.cacheKey, targetMessageId, params.allItems,
-                        uploadedSnapshot, failedSnapshot, updateError = true,
-                    )
-                    return
-                }
+                }.awaitAll()
             }
-            applyLocalOrderedAttachmentUpdate(
-                params.cacheKey, targetMessageId, params.allItems,
-                uploadedSnapshot, failedSnapshot, updateError = updateError,
-            )
-        }
 
-        suspend fun dispatchFirstMessage(attachment: MessageAttachment) {
+            val preparedSlots = preparedByIndex.filterNotNull().sortedBy { it.index }
+            val firstItemValid = items.firstOrNull() != null
+            if (preparedSlots.isEmpty() || (firstItemValid && preparedByIndex[0] == null)) {
+                notificationCenter.postNotificationOnMainThread(
+                    NotificationCenter.pendingMessageError, params.cacheKey, params.tempId
+                )
+                return
+            }
+
+            val attachmentsToSend = preparedSlots.map { it.attachment }
+            preparedSlots.forEach { slot ->
+                Log.d(TAG, "presign ready index=${slot.index} filename=${slot.attachment.filename} cdnUrl=${slot.attachment.url} thumb=${slot.attachment.thumbnail}")
+            }
+            Log.d(TAG, "send message with ${attachmentsToSend.size} attachment(s): ${attachmentsToSend.joinToString { it.url }}")
             val request = channelMessageSend {
                 this.clanId = params.clanId
                 this.channelId = params.channelId
                 this.mode = params.mode
                 this.isPublic = params.isPublic
                 this.content = params.wireContent
-                this.attachments.add(attachment)
+                this.attachments.addAll(attachmentsToSend)
                 params.protoMentions?.let { this.mentions.addAll(it) }
                 params.references?.let { this.references.addAll(it) }
                 this.mentionEveryone = params.mentionEveryone
@@ -1708,93 +1719,42 @@ class ChatController @Inject constructor(
                 if (params.topicId != 0L) this.topicId = params.topicId
             }
             val ack = channelSend(apiUrl, token, request)
-            val newMessageId = ack.messageId
-            val uploadedSnapshot: List<MessageAttachment?>
-            val failedSnapshot: Set<Int>
-            resultMutex.withLock {
-                realMessageId = newMessageId
-                messageSent = true
-                job.realMessageId = newMessageId
-                lastSyncedUploadCount = 1
-                uploadedSnapshot = uploadedByIndex.toList()
-                failedSnapshot = failedIndices.toSet()
-            }
+            realMessageId = ack.messageId
+            Log.d(TAG, "message sent messageId=$realMessageId cdnUrls=${attachmentsToSend.joinToString { it.url }}")
+            job.realMessageId = realMessageId
             synchronized(this) {
-                attachmentJobsByRealId.put(newMessageId, job)
+                attachmentJobsByRealId.put(realMessageId, job)
             }
             markForwardTargetUsed(params.channelId, params.channelType)
+
+            val uploadedByIndex: List<MessageAttachment?> = items.indices.map { preparedByIndex[it]?.attachment }
             val updatedEntity = applyLocalAfterFirstSendOrdered(
-                params.cacheKey, params.tempId, newMessageId,
-                params.allItems, uploadedSnapshot, failedSnapshot,
+                params.cacheKey, params.tempId, realMessageId,
+                params.allItems, uploadedByIndex, presignFailedIndices,
             )
             notificationCenter.postNotificationOnMainThread(
-                NotificationCenter.pendingMessageSent, params.cacheKey, params.tempId, newMessageId
+                NotificationCenter.pendingMessageSent, params.cacheKey, params.tempId, realMessageId
             )
             notificationCenter.postNotificationOnMainThread(
                 NotificationCenter.messageDidUpdate, params.cacheKey, updatedEntity,
                 NotificationCenter.UPDATE_MASK_ATTACHMENTS,
             )
-        }
 
-        val uploadSlots = Semaphore(ATTACHMENT_UPLOAD_PARALLELISM)
-
-        suspend fun recordResult(index: Int, attachment: MessageAttachment?) {
-            var firstToSend: MessageAttachment? = null
-            var shouldFlush = false
-            resultMutex.withLock {
-                if (attachment == null) {
-                    failedIndices.add(index)
-                    job.failedCount = failedIndices.size
-                } else {
-                    uploadedByIndex[index] = attachment
-                    job.uploadedCount = uploadedByIndex.count { it != null }
-                    if (!messageSent && !firstSendStarted) {
-                        firstSendStarted = true
-                        firstToSend = attachment
+            val backgroundUploadFailed = coroutineScope {
+                preparedSlots.map { slot ->
+                    async(ioDispatcher) {
+                        executeBackgroundAttachmentUpload(slot, apiUrl, token, params.maxRetriesPerFile)
                     }
-                }
-                if (firstToSend == null && messageSent &&
-                    uploadedByIndex.count { it != null } - lastSyncedUploadCount >= ATTACHMENT_UPLOAD_PARALLELISM
-                ) {
-                    shouldFlush = true
-                }
+                }.awaitAll().any { !it }
             }
-            val toSend = firstToSend
-            if (toSend != null) {
-                sendMutex.withLock { dispatchFirstMessage(toSend) }
-            } else if (shouldFlush) {
-                sendMutex.withLock { flushAttachmentUpdate() }
+            if (backgroundUploadFailed) {
+                applyLocalBackgroundUploadFailure(params.cacheKey, realMessageId)
             }
-        }
-
-        try {
-            coroutineScope {
-                items.forEachIndexed { index, item ->
-                    launch(ioDispatcher) {
-                        val attachment = when {
-                            item == null -> null
-                            item.size > LARGE_ATTACHMENT_BYTES -> largeUploadSlots.withPermit {
-                                loadAndUploadAttachment(
-                                    item, contentResolver, apiUrl, token, cdnBaseUrl, params.maxRetriesPerFile,
-                                )
-                            }
-                            else -> uploadSlots.withPermit {
-                                loadAndUploadAttachment(
-                                    item, contentResolver, apiUrl, token, cdnBaseUrl, params.maxRetriesPerFile,
-                                )
-                            }
-                        }
-                        recordResult(index, attachment)
-                    }
-                }
-            }
-            if (messageSent) sendMutex.withLock { flushAttachmentUpdate() }
-
-            if (!messageSent) {
-                notificationCenter.postNotificationOnMainThread(
-                    NotificationCenter.pendingMessageError, params.cacheKey, params.tempId
-                )
-            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to send message with presigned attachments", e)
+            notificationCenter.postNotificationOnMainThread(
+                NotificationCenter.pendingMessageError, params.cacheKey, params.tempId
+            )
         } finally {
             synchronized(this) {
                 attachmentJobsByTempId.remove(params.tempId)
@@ -1822,58 +1782,128 @@ class ChatController @Inject constructor(
         AttachmentUploadProgressStore.clear(progressKey)
     }
 
-    private suspend fun loadAndUploadAttachment(
+    private suspend fun prepareAndPresignAttachment(
+        index: Int,
         item: AttachmentPickerItem,
         contentResolver: android.content.ContentResolver,
         apiUrl: String,
         token: String,
         cdnBaseUrl: String,
         maxRetries: Int,
-    ): MessageAttachment? {
-        val progressKey = item.uri.toString()
-        val onProgress = attachmentUploadProgressCallback(progressKey)
-        try {
-            if (!item.isVideo && AttachmentUploader.isCompressibleImage(item.mimeType)) {
-                val compressed = imageCompressionSlots.withPermit {
-                    AttachmentUploader.compressImageFromUri(
-                        contentResolver, item.uri, item.mimeType, item.filename, item.size,
-                    )
+    ): PreparedAttachmentSlot? {
+        for (attempt in 1..maxRetries) {
+            try {
+                if (!item.isVideo && AttachmentUploader.isCompressibleImage(item.mimeType)) {
+                    val compressed = imageCompressionSlots.withPermit {
+                        AttachmentUploader.compressImageFromUri(
+                            contentResolver, item.uri, item.mimeType, item.filename, item.size,
+                        )
+                    }
+                    if (compressed != null) {
+                        val uploadItem = item.copy(
+                            filename = compressed.filename,
+                            mimeType = compressed.mimeType,
+                            width = compressed.width,
+                            height = compressed.height,
+                            size = compressed.bytes.size.toLong(),
+                        )
+                        return presignCachedAttachment(index, uploadItem, compressed.bytes, apiUrl, token, cdnBaseUrl)
+                    }
                 }
-                if (compressed != null) {
-                    val uploadItem = item.copy(
-                        filename = compressed.filename,
-                        mimeType = compressed.mimeType,
-                        width = compressed.width,
-                        height = compressed.height,
-                        size = compressed.bytes.size.toLong(),
-                    )
-                    return uploadCachedAttachment(
-                        CachedAttachment(uploadItem, compressed.bytes),
-                        apiUrl, token, cdnBaseUrl, maxRetries, onProgress,
-                    )
-                }
-            }
 
-            val tmpFile = AttachmentUploader.copyUriToTempFile(
-                contentResolver, item.uri, item.mimeType, appContext.cacheDir,
-            )
-            if (tmpFile == null) {
-                Log.e(TAG, "Failed to read file or over size: ${item.filename}")
-                return null
+                val tmpFile = AttachmentUploader.copyUriToTempFile(
+                    contentResolver, item.uri, item.mimeType, appContext.cacheDir,
+                ) ?: return null
+                return try {
+                    presignStreamedAttachment(index, item, tmpFile, apiUrl, token, cdnBaseUrl)
+                } catch (e: Exception) {
+                    runCatching { tmpFile.delete() }
+                    throw e
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to presign attachment: ${item.filename}", e)
+                if (attempt < maxRetries) delay(SHARE_RETRY_DELAY_MS)
             }
-            return try {
-                uploadStreamedAttachment(
-                    item, tmpFile, apiUrl, token, cdnBaseUrl, maxRetries, onProgress,
-                )
-            } finally {
-                runCatching { tmpFile.delete() }
-            }
-        } finally {
-            clearAttachmentUploadProgress(progressKey)
         }
+        return null
     }
 
-    private suspend fun uploadVideoThumbnailIfNeeded(
+    private suspend fun presignCachedAttachment(
+        index: Int,
+        item: AttachmentPickerItem,
+        bytes: ByteArray,
+        apiUrl: String,
+        token: String,
+        cdnBaseUrl: String,
+    ): PreparedAttachmentSlot {
+        val timestamp = System.currentTimeMillis() / 1000
+        val sanitizedName = item.filename.replace(FILENAME_SANITIZE_REGEX, "_")
+        val uploadFilename = "${timestamp}_$sanitizedName"
+        val presigned = AttachmentUploader.presignAttachmentBytes(
+            api, apiUrl, token, uploadFilename, item.mimeType, item.size,
+            item.width, item.height, cdnBaseUrl,
+        )
+        val attachment = messageAttachment {
+            this.filename = item.filename
+            this.url = presigned.cdnUrl
+            this.filetype = item.mimeType
+            this.size = item.size.toInt()
+            this.width = item.width
+            this.height = item.height
+            if (item.duration > 0) this.duration = item.duration
+        }
+        return PreparedAttachmentSlot(
+            index = index,
+            progressKey = item.uri.toString(),
+            attachment = attachment,
+            plan = presigned.plan,
+            bytes = bytes,
+        )
+    }
+
+    private suspend fun presignStreamedAttachment(
+        index: Int,
+        item: AttachmentPickerItem,
+        file: java.io.File,
+        apiUrl: String,
+        token: String,
+        cdnBaseUrl: String,
+    ): PreparedAttachmentSlot {
+        val fileSize = file.length()
+        val timestamp = System.currentTimeMillis() / 1000
+        val sanitizedName = item.filename.replace(FILENAME_SANITIZE_REGEX, "_")
+        val uploadFilename = "${timestamp}_$sanitizedName"
+        val thumbSlot = presignVideoThumbnailIfNeeded(item, file, apiUrl, token, cdnBaseUrl, timestamp, sanitizedName)
+        val presigned = AttachmentUploader.presignAttachmentFromFile(
+            api, apiUrl, token, uploadFilename, item.mimeType, fileSize,
+            item.width, item.height, cdnBaseUrl,
+        )
+        val attachment = messageAttachment {
+            this.filename = item.filename
+            this.url = presigned.cdnUrl
+            this.filetype = item.mimeType
+            this.size = fileSize.toInt()
+            this.width = item.width
+            this.height = item.height
+            if (item.duration > 0) this.duration = item.duration
+            if (thumbSlot != null) thumbnail = thumbSlot.cdnUrl
+        }
+        return PreparedAttachmentSlot(
+            index = index,
+            progressKey = item.uri.toString(),
+            attachment = attachment,
+            plan = presigned.plan,
+            file = file,
+            thumbPlan = thumbSlot?.upload,
+        )
+    }
+
+    private data class PresignedVideoThumb(
+        val cdnUrl: String,
+        val upload: PreparedThumbUpload,
+    )
+
+    private suspend fun presignVideoThumbnailIfNeeded(
         item: AttachmentPickerItem,
         file: java.io.File,
         apiUrl: String,
@@ -1881,107 +1911,77 @@ class ChatController @Inject constructor(
         cdnBaseUrl: String,
         timestamp: Long,
         sanitizedName: String,
-    ): String {
-        if (!item.isVideo && !com.mezon.mobile.util.AttachmentUploader.isVideoMimeType(item.mimeType)) {
-            return ""
+    ): PresignedVideoThumb? {
+        if (!item.isVideo && !AttachmentUploader.isVideoMimeType(item.mimeType)) {
+            return null
         }
-        val thumb = com.mezon.mobile.util.AttachmentUploader.extractVideoThumbnailJpeg(file) ?: return ""
+        val thumb = AttachmentUploader.extractVideoThumbnailJpeg(file) ?: return null
         val dot = sanitizedName.lastIndexOf('.')
         val base = if (dot > 0) sanitizedName.substring(0, dot) else sanitizedName
         val thumbFilename = "${timestamp}_${base}_thumb.jpg"
         return try {
-            val thumbUpload = com.mezon.mobile.util.AttachmentUploader.uploadAttachmentBytes(
-                api, apiUrl, token, thumbFilename, thumb.mimeType, thumb.bytes,
+            val presigned = AttachmentUploader.presignAttachmentBytes(
+                api, apiUrl, token, thumbFilename, thumb.mimeType, thumb.bytes.size.toLong(),
                 thumb.width, thumb.height, cdnBaseUrl,
             )
-            thumbUpload.cdnUrl
+            PresignedVideoThumb(
+                cdnUrl = presigned.cdnUrl,
+                upload = PreparedThumbUpload(presigned.plan, thumb.bytes),
+            )
         } catch (e: Exception) {
-            Log.w(TAG, "Video thumbnail upload failed for ${item.filename}", e)
-            ""
+            Log.w(TAG, "Video thumbnail presign failed for ${item.filename}", e)
+            null
         }
     }
 
-    private suspend fun uploadStreamedAttachment(
-        item: AttachmentPickerItem,
-        file: java.io.File,
+    private suspend fun executeBackgroundAttachmentUpload(
+        slot: PreparedAttachmentSlot,
         apiUrl: String,
         token: String,
-        cdnBaseUrl: String,
         maxRetries: Int,
-        onProgress: ((uploaded: Long, total: Long) -> Unit)? = null,
-    ): MessageAttachment? {
-        val fileSize = file.length()
-        for (attempt in 1..maxRetries) {
-            try {
-                val timestamp = System.currentTimeMillis() / 1000
-                val sanitizedName = item.filename.replace(FILENAME_SANITIZE_REGEX, "_")
-                val uploadFilename = "${timestamp}_$sanitizedName"
-                val uploadResult = com.mezon.mobile.util.AttachmentUploader.uploadAttachmentFromFile(
-                    api, apiUrl, token, uploadFilename, item.mimeType, file, fileSize,
-                    item.width, item.height, cdnBaseUrl, onProgress,
-                )
-                val thumbUrl = uploadVideoThumbnailIfNeeded(
-                    item, file, apiUrl, token, cdnBaseUrl, timestamp, sanitizedName,
-                )
-                Log.d(TAG, "Uploaded: ${item.filename} → ${uploadResult.cdnUrl}")
-                return messageAttachment {
-                    this.filename = item.filename
-                    this.url = uploadResult.cdnUrl
-                    this.filetype = item.mimeType
-                    this.size = fileSize.toInt()
-                    this.width = item.width
-                    this.height = item.height
-                    if (item.duration > 0) this.duration = item.duration
-                    if (thumbUrl.isNotEmpty()) thumbnail = thumbUrl
+    ): Boolean {
+        val onProgress = attachmentUploadProgressCallback(slot.progressKey)
+        try {
+            Log.d(TAG, "background upload start cdnUrl=${slot.attachment.url}")
+            for (attempt in 1..maxRetries) {
+                try {
+                    AttachmentUploader.executeUploadPlan(
+                        api, apiUrl, token, slot.plan,
+                        bytes = slot.bytes, file = slot.file, onProgress = onProgress,
+                    )
+                    slot.thumbPlan?.let { thumb ->
+                        AttachmentUploader.executeUploadPlan(
+                            api, apiUrl, token, thumb.plan, bytes = thumb.bytes,
+                        )
+                    }
+                    Log.d(TAG, "Background upload done: ${slot.attachment.filename} → ${slot.attachment.url}")
+                    return true
+                } catch (e: Exception) {
+                    Log.e(TAG, "Background upload attempt $attempt failed: ${slot.attachment.filename}", e)
+                    if (attempt < maxRetries) delay(SHARE_RETRY_DELAY_MS)
                 }
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to upload attachment: ${item.filename}", e)
-                if (attempt < maxRetries) delay(SHARE_RETRY_DELAY_MS)
             }
+            return false
+        } finally {
+            clearAttachmentUploadProgress(slot.progressKey)
+            runCatching { slot.file?.delete() }
         }
-        return null
     }
 
-    private suspend fun uploadCachedAttachment(
-        cached: CachedAttachment,
-        apiUrl: String,
-        token: String,
-        cdnBaseUrl: String,
-        maxRetries: Int,
-        onProgress: ((uploaded: Long, total: Long) -> Unit)? = null,
-    ): MessageAttachment? {
-        val item = cached.item
-        for (attempt in 1..maxRetries) {
-            try {
-                val timestamp = System.currentTimeMillis() / 1000
-                val sanitizedName = item.filename.replace(FILENAME_SANITIZE_REGEX, "_")
-                val uploadFilename = "${timestamp}_$sanitizedName"
-                val uploadResult = com.mezon.mobile.util.AttachmentUploader.uploadAttachmentBytes(
-                    api, apiUrl, token, uploadFilename, item.mimeType, cached.bytes,
-                    item.width, item.height, cdnBaseUrl, onProgress,
-                )
-                return messageAttachment {
-                    this.filename = item.filename
-                    this.url = uploadResult.cdnUrl
-                    this.filetype = item.mimeType
-                    this.size = item.size.toInt()
-                    this.width = item.width
-                    this.height = item.height
-                    if (item.duration > 0) this.duration = item.duration
-                }
-            } catch (e: Exception) {
-                if (maxRetries > 1) {
-                    Log.e(TAG, "Upload attempt $attempt failed for ${item.filename}", e)
-                } else {
-                    Log.e(TAG, "Failed to upload attachment: ${item.filename}", e)
-                }
-                if (attempt < maxRetries) delay(SHARE_RETRY_DELAY_MS)
+    private suspend fun applyLocalBackgroundUploadFailure(cacheKey: Long, messageId: Long) {
+        val existing = withContext(ioDispatcher) { messageDao.getById(cacheKey, messageId) } ?: return
+        val updated = existing.copy(isError = true)
+        appScope.launch(ioDispatcher) { messageDao.upsert(updated) }
+        synchronized(this) {
+            val last = dialogMessage.get(cacheKey)
+            if (last != null && last.id == messageId) {
+                dialogMessage.put(cacheKey, updated)
             }
         }
-        if (maxRetries > 1) {
-            Log.e(TAG, "All retries exhausted for ${item.filename}")
-        }
-        return null
+        notificationCenter.postNotificationOnMainThread(
+            NotificationCenter.messageDidUpdate, cacheKey, updated,
+            NotificationCenter.UPDATE_MASK_SEND_STATE,
+        )
     }
 
     private fun buildExtraAttachmentsJson(

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -1020,6 +1020,13 @@ open class ChatFragment : BaseFragment() {
             AndroidUtilities.runOnUIThread(work, 250L)
         }
 
+        observe(NotificationCenter.attachmentUploadFinished) { _, _, args ->
+            if (isPaused || fragmentView == null) return@observe
+            val cdnUrl = args.firstOrNull() as? String ?: return@observe
+            if (!messageListHasAttachmentUrl(cdnUrl)) return@observe
+            updateVisibleRows(NotificationCenter.UPDATE_MASK_UPLOAD_PROGRESS)
+        }
+
         observe(NotificationCenter.messageDidUpdate) { _, _, args ->
             if (args.size < 2 || args[0] != messageListKey) return@observe
             val updateEntity = args[1] as? MessageEntity ?: return@observe
@@ -3647,6 +3654,15 @@ open class ChatFragment : BaseFragment() {
             for (extra in msg.extraAttachments) {
                 if (extra.url == key && msg.isAttachmentUploadPending(extra.url)) return true
             }
+        }
+        return false
+    }
+
+    private fun messageListHasAttachmentUrl(url: String): Boolean {
+        if (url.isEmpty()) return false
+        for (msg in messages) {
+            if (msg.attachmentUrl == url) return true
+            if (msg.extraAttachments.any { it.url == url }) return true
         }
         return false
     }

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
@@ -29,6 +29,7 @@ import com.mezon.mobile.core.NotificationCenter
 import com.mezon.mobile.core.ThemeColors
 import com.mezon.mobile.ui.cells.MezonIcon
 import com.mezon.mobile.util.FileUtils
+import com.mezon.mobile.util.PresignFinishContent
 import com.mezon.mobile.util.avatarImgproxyUrl
 import com.mezon.mobile.util.createImgproxyUrl
 import com.mezon.mobile.util.getEmojiDirectUrl
@@ -230,6 +231,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
     private var hasPendingMediaUploads = false
     private var hasPendingFileUploads = false
     private val fileUploadPending = ArrayList<Boolean>()
+    private val filePresignPending = ArrayList<Boolean>()
     private val fileUploadFailed = ArrayList<Boolean>()
     private val fileAttachmentUrls = ArrayList<String>()
     private var fileIconDrawable: Drawable? = null
@@ -470,8 +472,10 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         }
         slotIsVideo.fill(false)
         slotUploadPending.fill(false)
+        slotPresignPending.fill(false)
         slotUploadFailed.fill(false)
         fileUploadPending.clear()
+        filePresignPending.clear()
         fileUploadFailed.clear()
         fileAttachmentUrls.clear()
         hasPendingFileUploads = false
@@ -510,10 +514,11 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         var needInvalidate = false
 
         if (mask == 0) {
+            val presignHash = PresignFinishContent.parseKeys(msg.content)?.joinToString(",").orEmpty().hashCode()
             val contentHash = msg.content.hashCode() xor msg.timestampSeconds.hashCode() xor
                 msg.code xor (if (msg.isForwarded) 1 else 0) xor
                 msg.updateTimeSeconds.hashCode() xor (if (msg.hideEditted) 2 else 0) xor
-                msg.rplCount xor msg.topicId.hashCode() xor
+                msg.rplCount xor msg.topicId.hashCode() xor presignHash xor
                 msg.attachmentUrl.hashCode() xor msg.extraAttachmentsJson.hashCode() xor
                 (pollBridge?.stateFingerprint(msg.id) ?: 0)
             if (msg.id == lastBoundId && contentHash == lastBoundContentHash && isCombined == lastBoundCombined) {
@@ -585,6 +590,12 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
                 hasExplicitTextBody = messageHasExplicitTextBody(msg.content)
                 rebuildLayout = true
             }
+            if (drawPhotoImage && PresignFinishContent.hasPresignFinishField(msg.content)) {
+                hasPendingMediaUploads = msg.hasPendingMediaAttachmentUploads()
+                hasPendingFileUploads = msg.allFileAttachments.any { msg.isAttachmentUploadPending(it.url) }
+                loadPhotoImage(msg)
+                needInvalidate = true
+            }
         }
 
         if ((mask and NotificationCenter.UPDATE_MASK_SEND_STATE) != 0) {
@@ -638,6 +649,11 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         }
 
         if ((mask and NotificationCenter.UPDATE_MASK_UPLOAD_PROGRESS) != 0) {
+            val m = newMsg ?: messageEntity
+            if (m != null && drawPhotoImage) {
+                hasPendingMediaUploads = m.hasPendingMediaAttachmentUploads()
+                loadPhotoImage(m)
+            }
             needInvalidate = true
         }
 
@@ -799,12 +815,14 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
     private val videoThumbJobs = ArrayList<Job?>()
     private val slotIsVideo = ArrayList<Boolean>()
     private val slotUploadPending = ArrayList<Boolean>()
+    private val slotPresignPending = ArrayList<Boolean>()
     private val slotUploadFailed = ArrayList<Boolean>()
     private val mediaSlotUrls = ArrayList<String>()
 
     private fun ensureSlotCapacity(count: Int) {
         while (slotIsVideo.size < count) slotIsVideo.add(false)
         while (slotUploadPending.size < count) slotUploadPending.add(false)
+        while (slotPresignPending.size < count) slotPresignPending.add(false)
         while (slotUploadFailed.size < count) slotUploadFailed.add(false)
         while (mediaSlotUrls.size < count) mediaSlotUrls.add("")
         while (videoThumbJobs.size < count) videoThumbJobs.add(null)
@@ -850,11 +868,13 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         ensureSlotCapacity(mediaGridCount)
         for (i in 0 until slotIsVideo.size) slotIsVideo[i] = false
         for (i in 0 until slotUploadPending.size) slotUploadPending[i] = false
+        for (i in 0 until slotPresignPending.size) slotPresignPending[i] = false
         for (i in 0 until slotUploadFailed.size) slotUploadFailed[i] = false
         for (i in 0 until mediaSlotUrls.size) mediaSlotUrls[i] = ""
 
         if (mediaGridCount == 0) return
 
+        val presignPendingFlags = msg.mediaPresignPendingFlags()
         val uploadPendingFlags = msg.mediaUploadPendingFlags()
         val uploadFailedFlags = if (msg.hasPartialAttachmentUploadFailure) {
             msg.mediaUploadFailedFlags()
@@ -886,10 +906,13 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             val isLocalUri = att.url.startsWith("content://") || att.url.startsWith("file://")
             val isVideo = att.filetype.startsWith("video/", true)
             slotIsVideo[i] = isVideo
-            slotUploadPending[i] = uploadPendingFlags.getOrElse(i) { false }
+            slotPresignPending[i] = presignPendingFlags.getOrElse(i) { false }
+            slotUploadPending[i] = !slotPresignPending[i] && uploadPendingFlags.getOrElse(i) { false }
             slotUploadFailed[i] = uploadFailedFlags.getOrElse(i) { false }
             mediaSlotUrls[i] = att.url
-            if (isLocalUri && isVideo) {
+            if (slotPresignPending[i] || (slotUploadPending[i] && !isLocalUri)) {
+                receiver.recycle()
+            } else if (isLocalUri && isVideo) {
                 receiver.recycle()
                 loadLocalVideoThumbnail(att.url, i)
             } else if (isLocalUri) {
@@ -1763,6 +1786,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
 
         val files = msg.allFileAttachments
         fileUploadPending.clear()
+        filePresignPending.clear()
         fileUploadFailed.clear()
         fileAttachmentUrls.clear()
         val fileFailedFlags = if (msg.hasPartialAttachmentUploadFailure) {
@@ -1772,7 +1796,10 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         }
         for ((index, att) in files.withIndex()) {
             fileAttachmentUrls.add(att.url)
-            fileUploadPending.add(msg.isAttachmentUploadPending(att.url))
+            filePresignPending.add(msg.isPresignAttachmentPending(att.url))
+            fileUploadPending.add(
+                !filePresignPending.last() && msg.isAttachmentUploadPending(att.url)
+            )
             fileUploadFailed.add(fileFailedFlags.getOrElse(index) { false })
         }
         val first = files.firstOrNull()
@@ -2788,6 +2815,17 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         canvas.drawLine(cx, cy, cx + handLen * 0.7f, cy, SENDING_HAND_PAINT)
     }
 
+    private fun drawPresignPendingPlaceholder(
+        canvas: Canvas, x: Float, y: Float, w: Float, h: Float, radius: Float,
+    ) {
+        tmpRect.set(x, y, x + w, y + h)
+        if (radius > 0) {
+            canvas.drawRoundRect(tmpRect, radius, radius, SPINNER_OVERLAY_PAINT)
+        } else {
+            canvas.drawRect(tmpRect, SPINNER_OVERLAY_PAINT)
+        }
+    }
+
     private fun drawAttachmentUploadSpinner(
         canvas: Canvas, x: Float, y: Float, w: Float, h: Float, radius: Float, progress: Float = 0f,
     ) {
@@ -2881,6 +2919,10 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         photoImage.draw(canvas)
         if (isSlotUploadFailed(0)) {
             drawAttachmentUploadFailed(canvas, imgX, yOff, photoWidth.toFloat(), photoHeight.toFloat(), 0f)
+        } else if (isSlotPresignPending(0)) {
+            drawPresignPendingPlaceholder(
+                canvas, imgX, yOff, photoWidth.toFloat(), photoHeight.toFloat(), 0f,
+            )
         } else if (isSlotUploadPending(0)) {
             val url = mediaSlotUrls.getOrNull(0).orEmpty()
             val progress = if (url.isNotEmpty()) msg.attachmentUploadProgress(url) else 0f
@@ -3101,9 +3143,10 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         val textX = innerX + FILE_ICON_SIZE + FILE_ICON_GAP
         val totalTextH = textH.toFloat()
         var textY = innerY + (cardH - FILE_ROW_V_PAD * 2 - totalTextH) / 2f
+        val filePresign = filePresignPending.getOrNull(fileIndex) == true
         val filePending = fileUploadPending.getOrNull(fileIndex) == true
         val fileFailed = fileUploadFailed.getOrNull(fileIndex) == true
-        val spinnerReserve = if (filePending || fileFailed) {
+        val spinnerReserve = if (filePending || filePresign || fileFailed) {
             UPLOAD_PROGRESS_INDICATOR_W + UPLOAD_SPINNER_TRAILING_GAP
         } else {
             0f
@@ -3133,6 +3176,14 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             canvas.drawCircle(badgeCx, badgeCy, UPLOAD_FAILED_BADGE_RADIUS, UPLOAD_FAILED_BADGE_PAINT)
             val baseline = badgeCy - (UPLOAD_FAILED_ICON_PAINT.descent() + UPLOAD_FAILED_ICON_PAINT.ascent()) / 2f
             canvas.drawText(UPLOAD_FAILED_ICON_TEXT, badgeCx, baseline, UPLOAD_FAILED_ICON_PAINT)
+        } else if (filePresign) {
+            val indicatorW = UPLOAD_PROGRESS_INDICATOR_W
+            val indicatorH = SPINNER_SIDE * 2
+            val sx = x + cardW - FILE_ROW_H_PAD - indicatorW
+            val centerY = y + cardH / 2f
+            drawPresignPendingPlaceholder(
+                canvas, sx, centerY - indicatorH / 2f, indicatorW, indicatorH, FILE_ROW_RADIUS,
+            )
         } else if (filePending) {
             val url = fileAttachmentUrls.getOrNull(fileIndex).orEmpty()
             val progress = msg.attachmentUploadProgress(url)
@@ -3323,6 +3374,10 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         return slotUploadPending.getOrNull(slot) == true
     }
 
+    private fun isSlotPresignPending(slot: Int): Boolean {
+        return slotPresignPending.getOrNull(slot) == true
+    }
+
     private fun drawGridCell(canvas: Canvas, slot: Int, x: Float, y: Float, w: Float, h: Float, isDark: Boolean): Boolean {
         var needsRedraw = false
         val receiver = mediaReceiver(slot)
@@ -3330,7 +3385,9 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             drawAttachmentUploadFailed(canvas, x, y, w, h, MEDIA_RADIUS)
             return needsRedraw
         }
-        if (isSlotUploadPending(slot)) {
+        if (isSlotPresignPending(slot)) {
+            drawPresignPendingPlaceholder(canvas, x, y, w, h, MEDIA_RADIUS)
+        } else if (isSlotUploadPending(slot)) {
             val msg = messageEntity
             val url = mediaSlotUrls.getOrNull(slot).orEmpty()
             val progress = if (msg != null && url.isNotEmpty()) msg.attachmentUploadProgress(url) else 0f
@@ -3375,7 +3432,9 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             drawAttachmentUploadFailed(canvas, imgX, imgY, w, h, MEDIA_RADIUS)
             return
         }
-        if (isSlotUploadPending(0)) {
+        if (isSlotPresignPending(0)) {
+            drawPresignPendingPlaceholder(canvas, imgX, imgY, w, h, MEDIA_RADIUS)
+        } else if (isSlotUploadPending(0)) {
             val url = mediaSlotUrls.getOrNull(0).orEmpty()
             val progress = if (url.isNotEmpty()) msg.attachmentUploadProgress(url) else 0f
             drawAttachmentUploadSpinner(canvas, imgX, imgY, w, h, MEDIA_RADIUS, progress)

--- a/app/src/main/java/com/mezon/mobile/home/chat/ImageReceiver.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ImageReceiver.kt
@@ -17,6 +17,10 @@ import java.util.LinkedHashSet
 
 class ImageReceiver(private val parentView: View) {
 
+    companion object {
+        private const val IMAGE_LOAD_TAG = "ImageReceiver"
+    }
+
     private var imageBitmap: Bitmap? = null
     private var thumbBitmap: Bitmap? = null
     private var animatedDrawable: Drawable? = null
@@ -264,6 +268,10 @@ class ImageReceiver(private val parentView: View) {
 
     private fun onLoadError(failedUrl: String, rw: Int, rh: Int, loader: MezonImageLoader) {
         val chain = buildMainImageFallbackUrls(failedUrl)
+        android.util.Log.w(
+            IMAGE_LOAD_TAG,
+            "load failed url=$failedUrl fallbacks=${chain.joinToString()}",
+        )
         if (chain.isEmpty()) {
             loadExhausted = true
             mainCancellable = null

--- a/app/src/main/java/com/mezon/mobile/home/chat/MessageEntity.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/MessageEntity.kt
@@ -15,6 +15,7 @@ import com.mezon.mobile.network.STREAM_MODE_CHANNEL
 import com.mezon.mobile.network.STREAM_MODE_THREAD
 import com.mezon.mobile.util.AttachmentUploadProgressStore
 import com.mezon.mobile.util.MENTION_HERE_USER_ID
+import com.mezon.mobile.util.PresignFinishContent
 
 data class AttachmentInfo(
     val url: String,
@@ -317,11 +318,27 @@ data class MessageEntity(
         return url.startsWith("content://") || url.startsWith("file://")
     }
 
+    fun presignFinishKeys(): List<String>? = PresignFinishContent.parseKeys(content)
+
+    fun isPresignAttachmentPending(url: String): Boolean {
+        if (isMe) return false
+        val keys = presignFinishKeys() ?: return false
+        if (isLocalAttachmentUrl(url)) return false
+        val key = PresignFinishContent.presignKey(url)
+        return key.isNotEmpty() && !keys.contains(key)
+    }
+
     fun isAttachmentUploadPending(url: String): Boolean {
-        if (!isLocalAttachmentUrl(url)) return false
         if (attachmentUploadFailed(url)) return false
-        if (url == attachmentUrl && isError) return false
-        return true
+        if (isLocalAttachmentUrl(url)) {
+            if (url == attachmentUrl && isError) return false
+            return true
+        }
+        if (!isMe) return false
+        val keys = presignFinishKeys() ?: return false
+        val key = PresignFinishContent.presignKey(url)
+        if (key.isEmpty() || keys.contains(key)) return false
+        return !AttachmentUploadProgressStore.isUploadComplete(url)
     }
 
     fun attachmentUploadProgress(url: String): Float =
@@ -346,10 +363,19 @@ data class MessageEntity(
 
     private fun isMediaUploadPending(att: AttachmentInfo, index: Int, errorUrls: Set<String>): Boolean {
         val url = att.url
-        if (!isLocalAttachmentUrl(url)) return false
+        if (isPresignAttachmentPending(url)) return false
+        if (!isLocalAttachmentUrl(url)) {
+            return isAttachmentUploadPending(url)
+        }
         if (url in errorUrls) return false
         if (index == 0 && attachmentUrl == url && isError) return false
         return true
+    }
+
+    fun mediaPresignPendingFlags(): List<Boolean> {
+        val media = allImageAttachments
+        if (media.isEmpty()) return emptyList()
+        return media.map { isPresignAttachmentPending(it.url) }
     }
 
     fun isMediaAttachmentUploadPending(mediaIndex: Int): Boolean {

--- a/app/src/main/java/com/mezon/mobile/util/AttachmentUploadProgressStore.kt
+++ b/app/src/main/java/com/mezon/mobile/util/AttachmentUploadProgressStore.kt
@@ -4,6 +4,7 @@ object AttachmentUploadProgressStore {
 
     private val lock = Any()
     private val progressByKey = HashMap<String, Float>()
+    private val uploadCompleteByKey = HashSet<String>()
 
     fun setProgressIfBucketChanged(key: String, value: Float): Boolean {
         if (key.isEmpty()) return false
@@ -24,10 +25,33 @@ object AttachmentUploadProgressStore {
         }
     }
 
+    fun markUploadComplete(key: String) {
+        if (key.isEmpty()) return
+        synchronized(lock) {
+            uploadCompleteByKey.add(key)
+            progressByKey.remove(key)
+        }
+    }
+
+    fun isUploadComplete(key: String): Boolean {
+        if (key.isEmpty()) return false
+        synchronized(lock) {
+            return key in uploadCompleteByKey
+        }
+    }
+
+    fun clearProgress(key: String) {
+        if (key.isEmpty()) return
+        synchronized(lock) {
+            progressByKey.remove(key)
+        }
+    }
+
     fun clear(key: String) {
         if (key.isEmpty()) return
         synchronized(lock) {
             progressByKey.remove(key)
+            uploadCompleteByKey.remove(key)
         }
     }
 }

--- a/app/src/main/java/com/mezon/mobile/util/AttachmentUploader.kt
+++ b/app/src/main/java/com/mezon/mobile/util/AttachmentUploader.kt
@@ -52,6 +52,27 @@ object AttachmentUploader {
         val cdnUrl: String,
     )
 
+    sealed class UploadExecutionPlan {
+        data class SinglePut(
+            val presignedUrl: String,
+            val mimeType: String,
+        ) : UploadExecutionPlan()
+
+        data class Multipart(
+            val uploadId: String,
+            val presignedUrls: List<String>,
+            val serverFilename: String,
+            val mimeType: String,
+            val fileSize: Long,
+        ) : UploadExecutionPlan()
+    }
+
+    data class PresignedFileResult(
+        val serverFilename: String,
+        val cdnUrl: String,
+        val plan: UploadExecutionPlan,
+    )
+
     fun isOverSizeLimit(sizeBytes: Long, mimeType: String): Boolean =
         AttachmentPickerItem.isOverSizeLimit(sizeBytes, mimeType)
 
@@ -243,6 +264,106 @@ object AttachmentUploader {
         return "$base.$newExt"
     }
 
+    suspend fun presignAttachmentBytes(
+        api: MezonApi,
+        apiUrl: String,
+        token: String,
+        uploadFilename: String,
+        mimeType: String,
+        sizeBytes: Long,
+        width: Int = 0,
+        height: Int = 0,
+        cdnBaseUrl: String,
+    ): PresignedFileResult {
+        if (willUseMultipart(sizeBytes)) {
+            try {
+                return presignMultipartBytes(
+                    api, apiUrl, token, uploadFilename, mimeType, sizeBytes.toInt(),
+                    width, height, cdnBaseUrl,
+                )
+            } catch (_: MultipartNotApplicable) {
+                skipMultipartStartForSession = true
+            } catch (e: Exception) {
+                Log.w(TAG, "Multipart presign failed, falling back to single PUT: $uploadFilename", e)
+            }
+        }
+        val presign = api.uploadAttachmentFile(
+            apiUrl, token, uploadFilename, mimeType, sizeBytes.toInt(), width, height,
+        )
+        val cdnUrl = "$cdnBaseUrl/${presign.filename}"
+        Log.d(TAG, "presign bytes file=$uploadFilename cdnUrl=$cdnUrl minioUrl=${presign.url}")
+        return PresignedFileResult(
+            serverFilename = presign.filename,
+            cdnUrl = cdnUrl,
+            plan = UploadExecutionPlan.SinglePut(presign.url, mimeType),
+        )
+    }
+
+    suspend fun presignAttachmentFromFile(
+        api: MezonApi,
+        apiUrl: String,
+        token: String,
+        uploadFilename: String,
+        mimeType: String,
+        fileSize: Long,
+        width: Int = 0,
+        height: Int = 0,
+        cdnBaseUrl: String,
+    ): PresignedFileResult {
+        if (willUseMultipart(fileSize)) {
+            try {
+                return presignMultipartFromFile(
+                    api, apiUrl, token, uploadFilename, mimeType, fileSize.toInt(),
+                    width, height, cdnBaseUrl,
+                )
+            } catch (_: MultipartNotApplicable) {
+                skipMultipartStartForSession = true
+            } catch (e: Exception) {
+                Log.w(TAG, "Multipart presign failed, falling back to single PUT: $uploadFilename", e)
+            }
+        }
+        val presign = api.uploadAttachmentFile(
+            apiUrl, token, uploadFilename, mimeType, fileSize.toInt(), width, height,
+        )
+        val cdnUrl = "$cdnBaseUrl/${presign.filename}"
+        Log.d(TAG, "presign file=$uploadFilename cdnUrl=$cdnUrl minioUrl=${presign.url}")
+        return PresignedFileResult(
+            serverFilename = presign.filename,
+            cdnUrl = cdnUrl,
+            plan = UploadExecutionPlan.SinglePut(presign.url, mimeType),
+        )
+    }
+
+    suspend fun executeUploadPlan(
+        api: MezonApi,
+        apiUrl: String,
+        token: String,
+        plan: UploadExecutionPlan,
+        bytes: ByteArray? = null,
+        file: File? = null,
+        onProgress: ((uploaded: Long, total: Long) -> Unit)? = null,
+    ) {
+        when (plan) {
+            is UploadExecutionPlan.SinglePut -> {
+                Log.d(TAG, "minio PUT start url=${plan.presignedUrl}")
+                val total = bytes?.size?.toLong() ?: file?.length() ?: 0L
+                onProgress?.invoke(0, total)
+                when {
+                    bytes != null -> api.putFileToPresignedUrl(plan.presignedUrl, bytes, plan.mimeType)
+                    file != null -> api.putFileToPresignedUrlFromFile(plan.presignedUrl, file, plan.mimeType)
+                    else -> throw IllegalArgumentException("executeUploadPlan SinglePut requires bytes or file")
+                }
+                onProgress?.invoke(total, total)
+                Log.d(TAG, "minio PUT done url=${plan.presignedUrl}")
+            }
+            is UploadExecutionPlan.Multipart -> {
+                Log.d(TAG, "minio multipart PUT start uploadId=${plan.uploadId} cdnFile=${plan.serverFilename} parts=${plan.presignedUrls.size}")
+                executeMultipartPlan(api, apiUrl, token, plan, bytes, file, onProgress)
+                Log.d(TAG, "minio multipart PUT done uploadId=${plan.uploadId} cdnFile=${plan.serverFilename}")
+            }
+        }
+    }
+
     suspend fun uploadAttachmentBytes(
         api: MezonApi,
         apiUrl: String,
@@ -257,21 +378,13 @@ object AttachmentUploader {
     ): UploadedFileResult {
         val totalBytes = bytes.size.toLong()
         onProgress?.invoke(0, totalBytes)
-        if (willUseMultipart(totalBytes)) {
-            try {
-                return uploadMultipart(
-                    api, apiUrl, token, uploadFilename, mimeType, bytes,
-                    width, height, cdnBaseUrl, onProgress,
-                )
-            } catch (_: MultipartNotApplicable) {
-                skipMultipartStartForSession = true
-            } catch (e: Exception) {
-                Log.w(TAG, "Multipart upload failed, falling back to single PUT: $uploadFilename", e)
-            }
-        }
-        return uploadSinglePut(
-            api, apiUrl, token, uploadFilename, mimeType, bytes,
-            width, height, cdnBaseUrl, onProgress,
+        val presigned = presignAttachmentBytes(
+            api, apiUrl, token, uploadFilename, mimeType, totalBytes, width, height, cdnBaseUrl,
+        )
+        executeUploadPlan(api, apiUrl, token, presigned.plan, bytes = bytes, onProgress = onProgress)
+        return UploadedFileResult(
+            serverFilename = presigned.serverFilename,
+            cdnUrl = presigned.cdnUrl,
         )
     }
 
@@ -349,112 +462,174 @@ object AttachmentUploader {
         onProgress: ((uploaded: Long, total: Long) -> Unit)? = null,
     ): UploadedFileResult {
         onProgress?.invoke(0, fileSize)
-        if (willUseMultipart(fileSize)) {
-            try {
-                return uploadMultipartFromFile(
-                    api, apiUrl, token, uploadFilename, mimeType, file, fileSize,
-                    width, height, cdnBaseUrl, onProgress,
-                )
-            } catch (_: MultipartNotApplicable) {
-                skipMultipartStartForSession = true
-            } catch (e: Exception) {
-                Log.w(TAG, "Multipart upload failed, falling back to single PUT: $uploadFilename", e)
-            }
-        }
-        return uploadSinglePutFromFile(
-            api, apiUrl, token, uploadFilename, mimeType, file, fileSize,
-            width, height, cdnBaseUrl, onProgress,
+        val presigned = presignAttachmentFromFile(
+            api, apiUrl, token, uploadFilename, mimeType, fileSize, width, height, cdnBaseUrl,
         )
-    }
-
-    private suspend fun uploadSinglePutFromFile(
-        api: MezonApi,
-        apiUrl: String,
-        token: String,
-        uploadFilename: String,
-        mimeType: String,
-        file: File,
-        fileSize: Long,
-        width: Int,
-        height: Int,
-        cdnBaseUrl: String,
-        onProgress: ((uploaded: Long, total: Long) -> Unit)?,
-    ): UploadedFileResult {
-        val presign = api.uploadAttachmentFile(
-            apiUrl, token, uploadFilename, mimeType, fileSize.toInt(), width, height,
-        )
-        api.putFileToPresignedUrlFromFile(presign.url, file, mimeType)
-        onProgress?.invoke(fileSize, fileSize)
+        executeUploadPlan(api, apiUrl, token, presigned.plan, file = file, onProgress = onProgress)
         return UploadedFileResult(
-            serverFilename = presign.filename,
-            cdnUrl = "$cdnBaseUrl/${presign.filename}",
+            serverFilename = presigned.serverFilename,
+            cdnUrl = presigned.cdnUrl,
         )
     }
 
-    private suspend fun uploadMultipartFromFile(
+    private suspend fun presignMultipartFromFile(
         api: MezonApi,
         apiUrl: String,
         token: String,
         uploadFilename: String,
         mimeType: String,
-        file: File,
-        fileSize: Long,
+        sizeBytes: Int,
         width: Int,
         height: Int,
         cdnBaseUrl: String,
-        onProgress: ((uploaded: Long, total: Long) -> Unit)?,
-    ): UploadedFileResult {
-        val requestedPartCount = multipartPartCount(fileSize)
+    ): PresignedFileResult {
+        val requestedPartCount = multipartPartCount(sizeBytes.toLong())
         val start = api.multipartUploadAttachmentFileStart(
-            apiUrl, token, uploadFilename, mimeType, fileSize.toInt(), width, height,
+            apiUrl, token, uploadFilename, mimeType, sizeBytes, width, height,
             partCount = requestedPartCount,
         )
         val urls = start.urlsList
         val uploadId = start.uploadId
         val serverFilename = start.filename.ifEmpty { uploadFilename }
         val cdnUrl = "$cdnBaseUrl/$serverFilename"
-
         if (urls.size == 1 && uploadId.isEmpty()) {
-            api.putFileToPresignedUrlFromFile(urls[0], file, mimeType)
-            onProgress?.invoke(fileSize, fileSize)
-            return UploadedFileResult(
+            Log.d(TAG, "presign multipart→single file=$uploadFilename cdnUrl=$cdnUrl minioUrl=${urls[0]}")
+            return PresignedFileResult(
                 serverFilename = serverFilename,
                 cdnUrl = cdnUrl,
+                plan = UploadExecutionPlan.SinglePut(urls[0], mimeType),
             )
         }
-
         if (urls.isEmpty() || uploadId.isEmpty()) {
             throw MultipartNotApplicable()
         }
+        Log.d(TAG, "presign multipart file=$uploadFilename cdnUrl=$cdnUrl uploadId=$uploadId parts=${urls.size}")
+        return PresignedFileResult(
+            serverFilename = serverFilename,
+            cdnUrl = cdnUrl,
+            plan = UploadExecutionPlan.Multipart(
+                uploadId = uploadId,
+                presignedUrls = urls,
+                serverFilename = serverFilename,
+                mimeType = mimeType,
+                fileSize = sizeBytes.toLong(),
+            ),
+        )
+    }
 
-        val partCount = urls.size
-        val semaphore = Semaphore(PARALLEL_PART_UPLOADS_FILE)
-        val uploadedLock = Any()
-        var uploadedBytes = 0L
-        val partResults = coroutineScope {
-            urls.mapIndexed { index, url ->
-                async {
-                    semaphore.withPermit {
-                        val offset = index.toLong() * MULTIPART_PART_SIZE
-                        val endExclusive = if (index == partCount - 1) fileSize else offset + MULTIPART_PART_SIZE
-                        val len = endExclusive - offset
-                        val etag = api.putFilePartRangeToPresignedUrl(
-                            url, file, offset, len, mimeType,
-                        )
-                        synchronized(uploadedLock) {
-                            uploadedBytes += len
-                            onProgress?.invoke(uploadedBytes, fileSize)
-                        }
-                        (index + 1) to etag
-                    }
-                }
-            }.awaitAll().sortedBy { it.first }
+    private suspend fun presignMultipartBytes(
+        api: MezonApi,
+        apiUrl: String,
+        token: String,
+        uploadFilename: String,
+        mimeType: String,
+        sizeBytes: Int,
+        width: Int,
+        height: Int,
+        cdnBaseUrl: String,
+    ): PresignedFileResult {
+        val requestedPartCount = multipartPartCount(sizeBytes.toLong())
+        val start = api.multipartUploadAttachmentFileStart(
+            apiUrl, token, uploadFilename, mimeType, sizeBytes, width, height,
+            partCount = requestedPartCount,
+        )
+        val urls = start.urlsList
+        val uploadId = start.uploadId
+        val serverFilename = start.filename.ifEmpty { uploadFilename }
+        val cdnUrl = "$cdnBaseUrl/$serverFilename"
+        if (urls.size == 1 && uploadId.isEmpty()) {
+            Log.d(TAG, "presign multipart→single bytes file=$uploadFilename cdnUrl=$cdnUrl minioUrl=${urls[0]}")
+            return PresignedFileResult(
+                serverFilename = serverFilename,
+                cdnUrl = cdnUrl,
+                plan = UploadExecutionPlan.SinglePut(urls[0], mimeType),
+            )
         }
-        val finish = api.multipartUploadAttachmentFileFinish(apiUrl, token, uploadId, partResults, serverFilename)
-        val finalFilename = finish.filename.ifEmpty { serverFilename }
-        return UploadedFileResult(
-            serverFilename = finalFilename,
-            cdnUrl = "$cdnBaseUrl/$finalFilename",
+        if (urls.isEmpty() || uploadId.isEmpty()) {
+            throw MultipartNotApplicable()
+        }
+        Log.d(TAG, "presign multipart bytes file=$uploadFilename cdnUrl=$cdnUrl uploadId=$uploadId parts=${urls.size}")
+        return PresignedFileResult(
+            serverFilename = serverFilename,
+            cdnUrl = cdnUrl,
+            plan = UploadExecutionPlan.Multipart(
+                uploadId = uploadId,
+                presignedUrls = urls,
+                serverFilename = serverFilename,
+                mimeType = mimeType,
+                fileSize = sizeBytes.toLong(),
+            ),
+        )
+    }
+
+    private suspend fun executeMultipartPlan(
+        api: MezonApi,
+        apiUrl: String,
+        token: String,
+        plan: UploadExecutionPlan.Multipart,
+        bytes: ByteArray?,
+        file: File?,
+        onProgress: ((uploaded: Long, total: Long) -> Unit)?,
+    ) {
+        val urls = plan.presignedUrls
+        val partCount = urls.size
+        onProgress?.invoke(0, plan.fileSize)
+        val partResults = if (file != null) {
+            val semaphore = Semaphore(PARALLEL_PART_UPLOADS_FILE)
+            val uploadedLock = Any()
+            var uploadedBytes = 0L
+            coroutineScope {
+                urls.mapIndexed { index, url ->
+                    async {
+                        semaphore.withPermit {
+                            val offset = index.toLong() * MULTIPART_PART_SIZE
+                            val endExclusive = if (index == partCount - 1) {
+                                plan.fileSize
+                            } else {
+                                offset + MULTIPART_PART_SIZE
+                            }
+                            val len = endExclusive - offset
+                            val etag = api.putFilePartRangeToPresignedUrl(
+                                url, file, offset, len, plan.mimeType,
+                            )
+                            synchronized(uploadedLock) {
+                                uploadedBytes += len
+                                onProgress?.invoke(uploadedBytes, plan.fileSize)
+                            }
+                            (index + 1) to etag
+                        }
+                    }
+                }.awaitAll().sortedBy { it.first }
+            }
+        } else {
+            val data = bytes ?: throw IllegalArgumentException("executeMultipartPlan requires bytes or file")
+            val semaphore = Semaphore(PARALLEL_PART_UPLOADS_BYTES)
+            val uploadedLock = Any()
+            var uploadedBytes = 0L
+            coroutineScope {
+                urls.mapIndexed { index, url ->
+                    async {
+                        semaphore.withPermit {
+                            val offset = index * MULTIPART_PART_SIZE
+                            val end = if (index == partCount - 1) {
+                                data.size
+                            } else {
+                                offset + MULTIPART_PART_SIZE
+                            }
+                            val partBytes = data.copyOfRange(offset, end)
+                            val etag = api.putFilePartToPresignedUrl(url, partBytes, plan.mimeType)
+                            synchronized(uploadedLock) {
+                                uploadedBytes += partBytes.size
+                                onProgress?.invoke(uploadedBytes, plan.fileSize)
+                            }
+                            (index + 1) to etag
+                        }
+                    }
+                }.awaitAll().sortedBy { it.first }
+            }
+        }
+        api.multipartUploadAttachmentFileFinish(
+            apiUrl, token, plan.uploadId, partResults, plan.serverFilename,
         )
     }
 
@@ -496,102 +671,6 @@ object AttachmentUploader {
         } finally {
             runCatching { tmpFile.delete() }
         }
-    }
-
-    private suspend fun uploadSinglePut(
-        api: MezonApi,
-        apiUrl: String,
-        token: String,
-        uploadFilename: String,
-        mimeType: String,
-        bytes: ByteArray,
-        width: Int,
-        height: Int,
-        cdnBaseUrl: String,
-        onProgress: ((uploaded: Long, total: Long) -> Unit)?,
-    ): UploadedFileResult {
-        val presign = api.uploadAttachmentFile(
-            apiUrl, token, uploadFilename, mimeType, bytes.size, width, height,
-        )
-        api.putFileToPresignedUrl(presign.url, bytes, mimeType)
-        onProgress?.invoke(bytes.size.toLong(), bytes.size.toLong())
-        return UploadedFileResult(
-            serverFilename = presign.filename,
-            cdnUrl = "$cdnBaseUrl/${presign.filename}",
-        )
-    }
-
-    private suspend fun uploadMultipart(
-        api: MezonApi,
-        apiUrl: String,
-        token: String,
-        uploadFilename: String,
-        mimeType: String,
-        bytes: ByteArray,
-        width: Int,
-        height: Int,
-        cdnBaseUrl: String,
-        onProgress: ((uploaded: Long, total: Long) -> Unit)?,
-    ): UploadedFileResult {
-        val totalSize = bytes.size.toLong()
-        val requestedPartCount = multipartPartCount(totalSize)
-        val start = api.multipartUploadAttachmentFileStart(
-            apiUrl, token, uploadFilename, mimeType, bytes.size, width, height,
-            partCount = requestedPartCount,
-        )
-        val urls = start.urlsList
-        val uploadId = start.uploadId
-
-        if (urls.size == 1 && uploadId.isEmpty()) {
-            api.putFileToPresignedUrl(urls[0], bytes, mimeType)
-            onProgress?.invoke(totalSize, totalSize)
-            val serverFilename = start.filename.ifEmpty { uploadFilename }
-            return UploadedFileResult(
-                serverFilename = serverFilename,
-                cdnUrl = "$cdnBaseUrl/$serverFilename",
-            )
-        }
-
-        if (urls.isEmpty() || uploadId.isEmpty()) {
-            throw MultipartNotApplicable()
-        }
-
-        val partCount = urls.size
-        val semaphore = Semaphore(PARALLEL_PART_UPLOADS_BYTES)
-        val uploadedLock = Any()
-        var uploadedBytes = 0L
-
-        val partResults = coroutineScope {
-            urls.mapIndexed { index, url ->
-                async {
-                    semaphore.withPermit {
-                        val offset = index * MULTIPART_PART_SIZE
-                        val end = if (index == partCount - 1) {
-                            totalSize.toInt()
-                        } else {
-                            offset + MULTIPART_PART_SIZE
-                        }
-                        val partBytes = bytes.copyOfRange(offset, end)
-                        val etag = api.putFilePartToPresignedUrl(url, partBytes, mimeType)
-                        synchronized(uploadedLock) {
-                            uploadedBytes += partBytes.size
-                            onProgress?.invoke(uploadedBytes, totalSize)
-                        }
-                        (index + 1) to etag
-                    }
-                }
-            }.awaitAll().sortedBy { it.first }
-        }
-
-        val finishFilename = start.filename.ifEmpty { uploadFilename }
-        val finish = api.multipartUploadAttachmentFileFinish(
-            apiUrl, token, start.uploadId, partResults, finishFilename,
-        )
-        val serverFilename = finish.filename.ifEmpty { finishFilename }
-        return UploadedFileResult(
-            serverFilename = serverFilename,
-            cdnUrl = "$cdnBaseUrl/$serverFilename",
-        )
     }
 
     private fun stripExifSensitive(file: File) {

--- a/app/src/main/java/com/mezon/mobile/util/ImageProxy.kt
+++ b/app/src/main/java/com/mezon/mobile/util/ImageProxy.kt
@@ -1,9 +1,11 @@
 package com.mezon.mobile.util
 
+import android.util.Log
 import com.mezon.mobile.BuildConfig
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 
+private const val TAG = "ImageProxy"
 private const val IMGPROXY_BASE_URL = BuildConfig.MEZON_IMGPROXY_BASE_URL
 private const val IMGPROXY_KEY = BuildConfig.MEZON_IMGPROXY_KEY
 private const val MAX_BYTES = 2_097_152
@@ -24,7 +26,9 @@ fun createImgproxyUrl(
     val w = widthPx.coerceAtMost(cap)
     val h = heightPx.coerceAtMost(cap)
     val options = "rs:$resizeType:$w:$h:1/mb:$MAX_BYTES"
-    return "$IMGPROXY_BASE_URL/$IMGPROXY_KEY/$options/plain/$sourceUrl@webp"
+    val proxyUrl = "$IMGPROXY_BASE_URL/$IMGPROXY_KEY/$options/plain/$sourceUrl@webp"
+    Log.d(TAG, "create resize=$resizeType ${w}x$h source=$sourceUrl proxy=$proxyUrl")
+    return proxyUrl
 }
 
 fun plainSourceUrlFromImgproxy(processedUrl: String): String? {

--- a/app/src/main/java/com/mezon/mobile/util/PresignFinishContent.kt
+++ b/app/src/main/java/com/mezon/mobile/util/PresignFinishContent.kt
@@ -1,0 +1,111 @@
+package com.mezon.mobile.util
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+object PresignFinishContent {
+    const val FIELD_KEY = "presign_finish"
+
+    fun parseKeys(content: String): List<String>? {
+        if (content.isBlank()) return null
+        return try {
+            val json = JSONObject(content)
+            if (!json.has(FIELD_KEY)) return null
+            val arr = json.optJSONArray(FIELD_KEY) ?: return emptyList()
+            (0 until arr.length()).mapNotNull { i ->
+                arr.optString(i).takeIf { it.isNotEmpty() }
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    fun presignKey(cdnUrl: String): String {
+        val trimmed = cdnUrl.trim()
+        if (trimmed.isEmpty()) return ""
+        val noQuery = trimmed.substringBefore('?')
+        val last = noQuery.substringAfterLast('/')
+        if (last.isEmpty()) return ""
+        val dot = last.lastIndexOf('.')
+        val withoutExt = if (dot > 0) last.substring(0, dot) else last
+        return withoutExt.ifEmpty { last }
+    }
+
+    fun isAttachmentReady(url: String, presignFinish: List<String>?): Boolean {
+        val keys = presignFinish ?: return true
+        val key = presignKey(url)
+        if (key.isEmpty()) return false
+        return keys.contains(key)
+    }
+
+    fun injectPresignFinish(content: String, keys: List<String>): String {
+        return try {
+            val json = if (content.isNotBlank()) JSONObject(content) else JSONObject()
+            val arr = JSONArray()
+            keys.forEach { arr.put(it) }
+            json.put(FIELD_KEY, arr)
+            json.toString()
+        } catch (_: Exception) {
+            content
+        }
+    }
+
+    fun injectEmptyPresignFinish(content: String): String = injectPresignFinish(content, emptyList())
+
+    fun hasPresignFinishField(content: String): Boolean {
+        if (content.isBlank()) return false
+        return try {
+            JSONObject(content).has(FIELD_KEY)
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    fun contentBaseWithoutPresign(content: String): String {
+        if (content.isBlank()) return content
+        return try {
+            val json = JSONObject(content)
+            json.remove(FIELD_KEY)
+            json.toString()
+        } catch (_: Exception) {
+            content
+        }
+    }
+
+    fun mergePresignFinishContent(local: String, server: String): String {
+        val localKeys = parseKeys(local) ?: emptyList()
+        val serverKeys = parseKeys(server) ?: emptyList()
+        if (localKeys.isEmpty() && serverKeys.isEmpty()) {
+            return server.ifBlank { local }
+        }
+        val mergedKeys = if (serverKeys.size >= localKeys.size) {
+            serverKeys
+        } else {
+            val keys = localKeys.toMutableList()
+            serverKeys.forEach { key ->
+                if (!keys.contains(key)) keys.add(key)
+            }
+            keys
+        }
+        val base = if (server.isNotBlank()) {
+            contentBaseWithoutPresign(server)
+        } else {
+            contentBaseWithoutPresign(local)
+        }
+        return injectPresignFinish(base, mergedKeys)
+    }
+
+    fun isPresignFinishOnlyChange(newContent: String, oldContent: String): Boolean {
+        if (newContent.isBlank() || oldContent.isBlank()) return false
+        if (!hasPresignFinishField(newContent)) return false
+        return try {
+            val newJson = JSONObject(newContent)
+            val oldJson = JSONObject(oldContent)
+            newJson.remove(FIELD_KEY)
+            oldJson.remove(FIELD_KEY)
+            newJson.toString() == oldJson.toString()
+        } catch (_: Exception) {
+            false
+        }
+    }
+}


### PR DESCRIPTION
# PR: Incremental attachment upload via `presign_finish` (Android)

> Send flow for messages with images/files: reserve CDN → send message once → upload to MinIO → update `presign_finish` via `UpdateChannelMessage`.

**Branch:** `feat/chat-presign-attachment-upload`  
**Aligned with:** iOS (`docs/pull-request-presign-finish-upload.md` on `mezon-ios`) and web.

---

## Summary

- Media send flow: **presign CDN URL → `sendChannelMessage` once (full attachments + `presign_finish: []`) → upload bytes in parallel → sync `presign_finish`**.
- Viewers only render an attachment when its **presign key** appears in the `presign_finish` array.
- `presign_finish` updates use `hideEditted: true` — no "(edited)" label.
- Sender: per-slot upload overlay (%, spinner); each image appears as soon as it finishes, not when the whole grid completes.
- Video: **best-effort** thumbnail upload — thumb failure does not block video completion.

---

## Previous problems

| Problem | Impact |
|---------|--------|
| Send message only after upload (or one file at a time) | Viewers see CDN URLs before bytes exist → broken images |
| `updateChannelMessage` changes attachment list | CDN filename changes → mismatch |
| No `presign_finish` | Cannot distinguish "URL reserved" vs "bytes uploaded" |
| Message-wide pending UI | One large file keeps the entire grid spinning |
| Video thumb in same `try` as video upload | Video on CDN but UI spins forever when thumb fails |

---

## Solution

### Core flow

1. **Presign** all files (parallel, max 4) — get CDN URL + presigned MinIO URL; **do not change URLs after the message is sent**.
2. **`sendChannelMessage` once** with full `attachments` + `presign_finish: []` in content JSON.
3. **Upload bytes** to MinIO (parallel, max 4; files ≥ 50MB use multipart with 10MB parts).
4. After each successful upload → append **presign key** (CDN filename **without extension**).
5. **Local:** update `presign_finish` in DB/UI **immediately per file** (sender sees images one by one).
6. **Server:** `updateChannelMessage` (socket-first) pushes `presign_finish` in **batches of 4**, with **force flush** and up to 2 retries at the end.

```mermaid
sequenceDiagram
    participant User
    participant ChatController
    participant API as Mezon API
    participant MinIO
    participant Viewer

    User->>ChatController: Send images + files
    ChatController->>API: Presign CDN URLs (parallel, max 4)
    ChatController->>API: sendChannelMessage<br/>attachments + presign_finish: []
    API-->>Viewer: New message (attachments pending)

    loop Each completed upload
        ChatController->>MinIO: PUT bytes (+ progress)
        ChatController->>ChatController: Local presign_finish += key
        ChatController->>ChatController: Refresh UI per slot
    end

    alt 4 new keys or final forceFlush
        ChatController->>API: updateChannelMessage<br/>presign_finish + hideEditted: true
        API-->>Viewer: messageUpdated
    end
```

### `presign_finish` content shape

```json
{
  "t": "optional caption",
  "presign_finish": ["1749384123_vacation_photo", "1749384456_clip"]
}
```

| Concept | Value |
|---------|-------|
| **Presign key** | Last CDN URL path segment **without extension** |
| Example URL | `https://cdn.example.com/1749384123_photo.webp` |
| Key | `1749384123_photo` |
| **Not** | User's original `attachment.filename`, local URI, full URL |

---

## Implementation details (Android)

### 1. Orchestration — `ChatController.sendAttachmentsIncrementally`

| Phase | Description |
|-------|-------------|
| `presign` | `prepareAndPresignAttachment` — parallel, max 4 |
| `send` | `channelMessageSend` + `PresignFinishContent.injectEmptyPresignFinish` |
| `upload` | `executeBackgroundAttachmentUpload` — parallel, progress keyed by CDN URL |
| `local sync` | `applyLocalPresignFinishSnapshot` — **on each file completion** |
| `server sync` | `maybeSyncPresignFinishToServer` — batch of 4, force flush at end |

**Constants:** `ATTACHMENT_UPLOAD_PARALLELISM = 4`, `PRESIGN_EDIT_BATCH_SIZE = 4`, multipart for files ≥ 50MB.

### 2. Upload — `AttachmentUploader`

- Split **presign** (`presignAttachmentBytes` / `presignAttachmentFromFile`) and **upload** (`executeUploadPlan`).
- Single PUT + multipart; legacy upload APIs kept for other paths (share, etc.).

### 3. Content helper — `PresignFinishContent`

- `presignKey`, `injectEmptyPresignFinish`, `injectPresignFinish`, `parseKeys`, `mergePresignFinishContent`, `isPresignFinishOnlyChange`.

### 4. Sender UI — `ChatMessageCell` + `MessageEntity`

| State | UI (sender) |
|-------|-------------|
| Uploading bytes | Spinner + % on **each slot** |
| Upload done (`markUploadComplete` or key in `presign_finish`) | Load from CDN / skeleton |
| Video, thumb failed | Video placeholder + play button (playback still works) |

- `AttachmentUploadProgressStore` — progress + `markUploadComplete`.
- `NotificationCenter.attachmentUploadProgress` / `attachmentUploadFinished` → refresh grid.
- `messageDidUpdate` with `UPDATE_MASK_ATTACHMENTS` when `presign_finish` changes.

### 5. Viewer UI — `ChatMessageCell` + `MessageEntity`

| State | UI (viewer) |
|-------|-------------|
| Key **not** in `presign_finish` | Static gray placeholder |
| Key **in** `presign_finish`, fetching CDN | Skeleton shimmer |
| Loaded | Image / video |

### 6. Socket / merge / edited label

- `channelUpdate` socket-first, `hideEditted: true` on every presign sync.
- `mergeIncomingAttachmentEntity` — merge `presign_finish`, hide edited on presign-only changes.
- `applyLocalPresignContentUpdate` — clear `updateTimeSeconds` on presign-only updates.

### 7. Video thumbnail

- Presign thumb separately when preparing video.
- `uploadVideoThumbnailIfPresent` — **best-effort** (catch errors, do not fail the video slot).

---

## Key files

| File | Role |
|------|------|
| `ChatController.kt` | Presign → send → upload → local/server `presign_finish` sync |
| `AttachmentUploader.kt` | Presign vs execute upload (PUT / multipart) |
| `PresignFinishContent.kt` | Parse/inject/merge `presign_finish` |
| `AttachmentUploadProgressStore.kt` | Progress + `markUploadComplete` |
| `MessageEntity.kt` | `isPresignAttachmentPending`, `isAttachmentUploadPending` |
| `ChatMessageCell.kt` | Grid placeholder / spinner / skeleton / video placeholder |
| `ChatFragment.kt` | Observe progress + upload finished → `updateVisibleRows` |
| `NotificationCenter.kt` | `attachmentUploadFinished` event |

---

## Test plan

### Sender

- [ ] Send 1 image — reserve → send → upload → % overlay → image appears when done
- [ ] Send 7–10 images + 1 large file — light images appear **per slot**, not blocked by the heavy file
- [ ] Send video — thumb OK → preview; thumb fail → placeholder + play, **no infinite spinner**
- [ ] File ≥ 50MB — multipart + % on file row
- [ ] No "(edited)" after presign sync
- [ ] Retry after network loss mid-upload — no stuck spinner

### Viewer (second account / device)

- [ ] New message: key not in `presign_finish` → static placeholder
- [ ] After `messageUpdated` (batch of 4): skeleton → images appear gradually
- [ ] Video with key → playback works
- [ ] Matches web/iOS behavior (`presign_finish`, `hide_editted`)

### Edge cases

- [ ] One presign failure — message still sends with successful files
- [ ] Server echo does not overwrite newer local keys (`mergePresignFinishContent`)
- [ ] Scroll / reload list — `presign_finish` fingerprint updates correctly
