### PR TITLE
fix(chat): render multiline code fences as one block

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
@@ -1397,21 +1397,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             val layout = StaticLayout.Builder.obtain(charSeq, 0, charSeq.length, currentContentPaint, contentLayoutW)
                 .setLineSpacing(LayoutHelper.dpf(2f), 1f)
                 .build()
-            val spannedText = charSeq as? Spanned
-            if (spannedText != null) {
-                val codeFenceSpans = spannedText.getSpans(0, spannedText.length, CodeFenceSpan::class.java)
-                for (span in codeFenceSpans) {
-                    val spanStart = spannedText.getSpanStart(span)
-                    val spanEnd = spannedText.getSpanEnd(span)
-                    val firstContent = (spanStart until spanEnd).firstOrNull { spannedText[it] != '\n' } ?: spanStart
-                    val lastContent = (spanEnd - 1 downTo spanStart).firstOrNull { spannedText[it] != '\n' }
-                        ?: (spanEnd - 1).coerceAtLeast(spanStart)
-                    val a = firstContent.coerceAtMost(lastContent)
-                    val b = lastContent.coerceAtLeast(firstContent)
-                    span.spanFirstLine = layout.getLineForOffset(a)
-                    span.spanLastLine = layout.getLineForOffset(b)
-                }
-            }
+            (charSeq as? Spanned)?.let { CodeFenceSpan.bindLineBounds(it, layout) }
             layout
         } else null
 

--- a/app/src/main/java/com/mezon/mobile/home/chat/CodeFenceSpan.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/CodeFenceSpan.kt
@@ -2,7 +2,11 @@ package com.mezon.mobile.home.chat
 
 import android.graphics.Canvas
 import android.graphics.Paint
+import android.graphics.Path
 import android.graphics.RectF
+import android.text.Layout
+import android.text.Spanned
+import android.text.StaticLayout
 import android.text.style.LeadingMarginSpan
 import android.text.style.LineBackgroundSpan
 import com.mezon.mobile.core.LayoutHelper
@@ -14,8 +18,11 @@ class CodeFenceSpan(
 ) : LineBackgroundSpan, LeadingMarginSpan {
 
     private val rect = RectF()
+    private val cornerRadii = FloatArray(8)
+    private val bgPath = Path()
     private val bgPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
     private val radius = LayoutHelper.dp(4).toFloat()
+    private val lineGapBridge = LayoutHelper.dpf(2f)
     private val containerInsetH = LayoutHelper.dp(4)
     private val innerTextPadH = LayoutHelper.dp(12)
 
@@ -23,6 +30,40 @@ class CodeFenceSpan(
 
     companion object {
         fun layoutExtraHorizontalShrink(): Int = LayoutHelper.dp(4) * 2
+
+        fun layoutWidthForText(charSeq: CharSequence, baseWidth: Int): Int {
+            val spanned = charSeq as? Spanned ?: return baseWidth
+            if (spanned.getSpans(0, spanned.length, CodeFenceSpan::class.java).isEmpty()) return baseWidth
+            return (baseWidth - layoutExtraHorizontalShrink()).coerceAtLeast(1)
+        }
+
+        fun bindLineBounds(spanned: Spanned, layout: Layout) {
+            for (span in spanned.getSpans(0, spanned.length, CodeFenceSpan::class.java)) {
+                val spanStart = spanned.getSpanStart(span)
+                val spanEnd = spanned.getSpanEnd(span)
+                val firstContent = (spanStart until spanEnd).firstOrNull { spanned[it] != '\n' } ?: spanStart
+                val lastContent = (spanEnd - 1 downTo spanStart).firstOrNull { spanned[it] != '\n' }
+                    ?: (spanEnd - 1).coerceAtLeast(spanStart)
+                val a = firstContent.coerceAtMost(lastContent)
+                val b = lastContent.coerceAtLeast(firstContent)
+                span.spanFirstLine = layout.getLineForOffset(a)
+                span.spanLastLine = layout.getLineForOffset(b)
+            }
+        }
+
+        fun buildRichStaticLayout(
+            charSeq: CharSequence,
+            paint: android.text.TextPaint,
+            baseWidth: Int,
+            configure: StaticLayout.Builder.() -> Unit = {},
+        ): StaticLayout {
+            val layoutW = layoutWidthForText(charSeq, baseWidth)
+            val layout = StaticLayout.Builder.obtain(charSeq, 0, charSeq.length, paint, layoutW)
+                .apply(configure)
+                .build()
+            (charSeq as? Spanned)?.let { bindLineBounds(it, layout) }
+            return layout
+        }
     }
 
     override fun drawLeadingMargin(
@@ -40,20 +81,41 @@ class CodeFenceSpan(
         text: CharSequence, start: Int, end: Int,
         lineNumber: Int
     ) {
+        if (spanFirstLine >= 0 && lineNumber < spanFirstLine) return
+        if (spanLastLine >= 0 && lineNumber > spanLastLine) return
         bgPaint.color = bgColor
-        val isFirst = lineNumber == spanFirstLine || spanFirstLine < 0
-        val isLast = lineNumber == spanLastLine || spanLastLine < 0
-        val t = top.toFloat()
-        val b = bottom.toFloat()
+        val isFirst = spanFirstLine >= 0 && lineNumber == spanFirstLine
+        val isLast = spanLastLine >= 0 && lineNumber == spanLastLine
+        var t = top.toFloat()
+        var b = bottom.toFloat()
+        if (!isFirst) t -= lineGapBridge
+        if (!isLast) b += lineGapBridge
         val inset = containerInsetH.toFloat()
         val l = left + inset
         val r = right - inset
         if (l >= r) return
         rect.set(l, t, r, b)
-        if (isFirst || isLast) {
-            canvas.drawRoundRect(rect, radius, radius, bgPaint)
-        } else {
-            canvas.drawRect(rect, bgPaint)
+        when {
+            isFirst && isLast -> canvas.drawRoundRect(rect, radius, radius, bgPaint)
+            isFirst -> drawPartialRoundRect(canvas, roundTop = true, roundBottom = false)
+            isLast -> drawPartialRoundRect(canvas, roundTop = false, roundBottom = true)
+            else -> canvas.drawRect(rect, bgPaint)
         }
+    }
+
+    private fun drawPartialRoundRect(canvas: Canvas, roundTop: Boolean, roundBottom: Boolean) {
+        val topR = if (roundTop) radius else 0f
+        val bottomR = if (roundBottom) radius else 0f
+        cornerRadii[0] = topR
+        cornerRadii[1] = topR
+        cornerRadii[2] = topR
+        cornerRadii[3] = topR
+        cornerRadii[4] = bottomR
+        cornerRadii[5] = bottomR
+        cornerRadii[6] = bottomR
+        cornerRadii[7] = bottomR
+        bgPath.reset()
+        bgPath.addRoundRect(rect, cornerRadii, Path.Direction.CW)
+        canvas.drawPath(bgPath, bgPaint)
     }
 }

--- a/app/src/main/java/com/mezon/mobile/home/messages/EmbedMessage.kt
+++ b/app/src/main/java/com/mezon/mobile/home/messages/EmbedMessage.kt
@@ -13,6 +13,7 @@ import android.text.style.ForegroundColorSpan
 import android.view.View
 import com.mezon.mobile.core.LayoutHelper
 import com.mezon.mobile.core.ThemeColors
+import com.mezon.mobile.home.chat.CodeFenceSpan
 import com.mezon.mobile.home.chat.ImageReceiver
 import com.mezon.mobile.home.chat.ShimmerEffect
 import com.mezon.mobile.ui.theme.ThemeMode
@@ -461,47 +462,47 @@ class EmbedMessageRenderer(
 
         val authorLayout = if (d.authorName.isNotEmpty()) {
             val rich = formatEmbedRichText(d.authorName, th)
-            StaticLayout.Builder.obtain(rich, 0, rich.length, AUTHOR_PAINT, authorTextW)
-                .setMaxLines(3)
-                .setEllipsize(TextUtils.TruncateAt.END)
-                .setLineSpacing(LayoutHelper.dpf(2f), 1f)
-                .build()
+            CodeFenceSpan.buildRichStaticLayout(rich, AUTHOR_PAINT, authorTextW) {
+                setMaxLines(3)
+                setEllipsize(TextUtils.TruncateAt.END)
+                setLineSpacing(LayoutHelper.dpf(2f), 1f)
+            }
         } else null
 
         val titlePaint = if (d.url.isNotEmpty()) TITLE_LINK_PAINT else TITLE_PAINT
         val titleLayout = if (d.title.isNotEmpty()) {
             val rich = formatEmbedRichText(d.title, th)
-            StaticLayout.Builder.obtain(rich, 0, rich.length, titlePaint, leftColumnW)
-                .setMaxLines(12)
-                .setEllipsize(TextUtils.TruncateAt.END)
-                .setLineSpacing(LayoutHelper.dpf(2f), 1f)
-                .build()
+            CodeFenceSpan.buildRichStaticLayout(rich, titlePaint, leftColumnW) {
+                setMaxLines(12)
+                setEllipsize(TextUtils.TruncateAt.END)
+                setLineSpacing(LayoutHelper.dpf(2f), 1f)
+            }
         } else null
 
         val descLayout = if (d.description.isNotEmpty()) {
             val rich = formatEmbedRichText(d.description, th)
-            StaticLayout.Builder.obtain(rich, 0, rich.length, DESC_PAINT, leftColumnW)
-                .setMaxLines(32)
-                .setEllipsize(TextUtils.TruncateAt.END)
-                .setLineSpacing(LayoutHelper.dpf(2f), 1f)
-                .build()
+            CodeFenceSpan.buildRichStaticLayout(rich, DESC_PAINT, leftColumnW) {
+                setMaxLines(32)
+                setEllipsize(TextUtils.TruncateAt.END)
+                setLineSpacing(LayoutHelper.dpf(2f), 1f)
+            }
         } else null
 
         val fieldLayouts = d.fields.map { field ->
             val nameLay = embedFieldNameWithRequired(field, th)?.let { rich ->
-                StaticLayout.Builder.obtain(rich, 0, rich.length, FIELD_NAME_PAINT, leftColumnW)
-                    .setMaxLines(4)
-                    .setEllipsize(TextUtils.TruncateAt.END)
-                    .setLineSpacing(LayoutHelper.dpf(2f), 1f)
-                    .build()
+                CodeFenceSpan.buildRichStaticLayout(rich, FIELD_NAME_PAINT, leftColumnW) {
+                    setMaxLines(4)
+                    setEllipsize(TextUtils.TruncateAt.END)
+                    setLineSpacing(LayoutHelper.dpf(2f), 1f)
+                }
             }
             val valLay = if (field.value.isNotEmpty()) {
                 val rich = formatEmbedRichText(field.value, th)
-                StaticLayout.Builder.obtain(rich, 0, rich.length, FIELD_VALUE_PAINT, leftColumnW)
-                    .setMaxLines(16)
-                    .setEllipsize(TextUtils.TruncateAt.END)
-                    .setLineSpacing(LayoutHelper.dpf(2f), 1f)
-                    .build()
+                CodeFenceSpan.buildRichStaticLayout(rich, FIELD_VALUE_PAINT, leftColumnW) {
+                    setMaxLines(16)
+                    setEllipsize(TextUtils.TruncateAt.END)
+                    setLineSpacing(LayoutHelper.dpf(2f), 1f)
+                }
             } else null
             nameLay to valLay
         }
@@ -525,11 +526,11 @@ class EmbedMessageRenderer(
         } else contentW
         val footerLayout = if (footerStr.isNotEmpty()) {
             val rich = formatEmbedRichText(footerStr, th)
-            StaticLayout.Builder.obtain(rich, 0, rich.length, FOOTER_PAINT, footerTextW)
-                .setMaxLines(3)
-                .setEllipsize(TextUtils.TruncateAt.END)
-                .setLineSpacing(LayoutHelper.dpf(2f), 1f)
-                .build()
+            CodeFenceSpan.buildRichStaticLayout(rich, FOOTER_PAINT, footerTextW) {
+                setMaxLines(3)
+                setEllipsize(TextUtils.TruncateAt.END)
+                setLineSpacing(LayoutHelper.dpf(2f), 1f)
+            }
         } else null
 
         val animationSpecsInOrder = d.fields.mapNotNull { f ->
@@ -668,12 +669,12 @@ class EmbedMessageRenderer(
             for (btn in row.buttons) {
                 val innerW = (maxW - BUTTON_PAD_H * 2).toInt().coerceAtLeast(1)
                 val rich = formatEmbedRichText(btn.label, theme())
-                val labelLayout = StaticLayout.Builder.obtain(rich, 0, rich.length, BUTTON_LABEL_PAINT, innerW)
-                    .setMaxLines(2)
-                    .setEllipsize(TextUtils.TruncateAt.END)
-                    .setLineSpacing(LayoutHelper.dpf(1f), 1f)
-                    .setIncludePad(false)
-                    .build()
+                val labelLayout = CodeFenceSpan.buildRichStaticLayout(rich, BUTTON_LABEL_PAINT, innerW) {
+                    setMaxLines(2)
+                    setEllipsize(TextUtils.TruncateAt.END)
+                    setLineSpacing(LayoutHelper.dpf(1f), 1f)
+                    setIncludePad(false)
+                }
                 var textW = 0f
                 for (li in 0 until labelLayout.lineCount) {
                     textW = max(textW, labelLayout.getLineWidth(li))
@@ -1036,20 +1037,20 @@ class EmbedMessageRenderer(
         if (o.label.isNotEmpty()) {
             val raw = if (o.description.isNotEmpty()) "${o.label}\n${o.description}" else o.label.ifEmpty { o.value }
             val rich = formatEmbedRichText(raw, th)
-            val lay = StaticLayout.Builder.obtain(rich, 0, rich.length, FIELD_NAME_PAINT, colW)
-                .setMaxLines(12)
-                .setEllipsize(TextUtils.TruncateAt.END)
-                .setLineSpacing(LayoutHelper.dpf(2f), 1f)
-                .build()
+            val lay = CodeFenceSpan.buildRichStaticLayout(rich, FIELD_NAME_PAINT, colW) {
+                setMaxLines(12)
+                setEllipsize(TextUtils.TruncateAt.END)
+                setLineSpacing(LayoutHelper.dpf(2f), 1f)
+            }
             h += lay.height
         }
         if (o.description.isNotEmpty() && o.label.isEmpty()) {
             val rich = formatEmbedRichText(o.description, th)
-            val lay = StaticLayout.Builder.obtain(rich, 0, rich.length, FIELD_VALUE_PAINT, colW)
-                .setMaxLines(12)
-                .setEllipsize(TextUtils.TruncateAt.END)
-                .setLineSpacing(LayoutHelper.dpf(2f), 1f)
-                .build()
+            val lay = CodeFenceSpan.buildRichStaticLayout(rich, FIELD_VALUE_PAINT, colW) {
+                setMaxLines(12)
+                setEllipsize(TextUtils.TruncateAt.END)
+                setLineSpacing(LayoutHelper.dpf(2f), 1f)
+            }
             h += lay.height
         }
         h += RADIO_CONTROL_ROW_H

--- a/app/src/main/java/com/mezon/mobile/util/MessageContentParser.kt
+++ b/app/src/main/java/com/mezon/mobile/util/MessageContentParser.kt
@@ -191,17 +191,16 @@ private val EMBED_INLINE_ITALIC_UNDERSCORE_REGEX = Regex("(?<!_)_([^_\n]+)_(?!_)
 
 private fun appendCodeFenceBlock(sb: SpannableStringBuilder, innerRaw: String, theme: ThemeColors) {
     val inner = stripMarkdownFenceLanguage(innerRaw)
+    if (inner.isEmpty()) return
+    if (sb.isNotEmpty() && sb.last() != '\n') sb.append('\n')
     val start = sb.length
-    sb.append('\n')
     sb.append(inner)
-    sb.append('\n')
     val end = sb.length
-    if (end > start) {
-        sb.setExclusiveSpan(TypefaceSpan("monospace"), start, end)
-        sb.setExclusiveSpan(RelativeSizeSpan(0.875f), start, end)
-        sb.setExclusiveSpan(ForegroundColorSpan(theme.codeInlineText), start, end)
-        sb.setExclusiveSpan(CodeFenceSpan(theme.codeFenceBg), start, end)
-    }
+    sb.setExclusiveSpan(TypefaceSpan("monospace"), start, end)
+    sb.setExclusiveSpan(RelativeSizeSpan(0.875f), start, end)
+    sb.setExclusiveSpan(ForegroundColorSpan(theme.codeInlineText), start, end)
+    sb.setExclusiveSpan(CodeFenceSpan(theme.codeFenceBg), start, end)
+    sb.append('\n')
 }
 
 private fun appendEmbedPlainMultiline(sb: SpannableStringBuilder, plain: String, theme: ThemeColors) {
@@ -455,17 +454,17 @@ fun parseContentToSpannable(
                         .removeSurrounding("```")
                         .replace(CODE_BLOCK_EDGE_REGEX, "")
                         .trim()
-                    if (sb.isNotEmpty() && sb.last() != '\n') sb.append("\n")
-                    val fenceStart = sb.length
-                    sb.append('\n')
-                    sb.append(stripped)
-                    sb.append('\n')
-                    val fenceEnd = sb.length
-                    sb.append("\n")
-                    sb.setExclusiveSpan(TypefaceSpan("monospace"), fenceStart, fenceEnd)
-                    sb.setExclusiveSpan(RelativeSizeSpan(0.875f), fenceStart, fenceEnd)
-                    sb.setExclusiveSpan(ForegroundColorSpan(theme.codeInlineText), fenceStart, fenceEnd)
-                    sb.setExclusiveSpan(CodeFenceSpan(theme.codeFenceBg), fenceStart, fenceEnd)
+                    if (stripped.isNotEmpty()) {
+                        if (sb.isNotEmpty() && sb.last() != '\n') sb.append("\n")
+                        val fenceStart = sb.length
+                        sb.append(stripped)
+                        val fenceEnd = sb.length
+                        sb.setExclusiveSpan(TypefaceSpan("monospace"), fenceStart, fenceEnd)
+                        sb.setExclusiveSpan(RelativeSizeSpan(0.875f), fenceStart, fenceEnd)
+                        sb.setExclusiveSpan(ForegroundColorSpan(theme.codeInlineText), fenceStart, fenceEnd)
+                        sb.setExclusiveSpan(CodeFenceSpan(theme.codeFenceBg), fenceStart, fenceEnd)
+                        sb.append("\n")
+                    }
                 }
                 "lk", "vk", "lk_yt", "lk_fb", "lk_tt" -> {
                     val linkStartInText = (clampedS - schemeMergeLen).coerceAtLeast(0)


### PR DESCRIPTION
Bind line bounds for embed markdown and trim newline padding inside CodeFenceSpan so fenced blocks draw seamlessly.