### PR TITLE
fix(chat): prevent ViewPager swipe while photo is zoomed

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/chat/PhotoViewer.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/PhotoViewer.kt
@@ -17,8 +17,10 @@ import android.os.Build
 import android.os.Environment
 import android.util.TypedValue
 import android.view.Gravity
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewParent
 import android.view.ViewOutlineProvider
 import android.view.Window
 import android.view.WindowManager
@@ -44,6 +46,7 @@ import java.util.Locale
 private const val LOADING_SHOW_DELAY_MS = 300L
 private const val MIN_LOADING_VISIBLE_MS = 300L
 private const val LOADING_FADE_MS = 150L
+private const val VIEWPAGER_SWIPE_SCALE_EPSILON = 1.02f
 
 class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Black_NoTitleBar_Fullscreen) {
 
@@ -69,7 +72,21 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
         window?.addFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
         window?.setBackgroundDrawable(backgroundDrawable)
 
-        val root = FrameLayout(context)
+        val root = object : FrameLayout(context) {
+            override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+                when (ev.actionMasked) {
+                    MotionEvent.ACTION_POINTER_DOWN -> {
+                        viewPager.isUserInputEnabled = false
+                        setAncestorsDisallowIntercept(viewPager, true)
+                    }
+                    MotionEvent.ACTION_UP -> {
+                        if (ev.pointerCount <= 1) syncViewPagerSwipeWithCurrentPhoto()
+                    }
+                    MotionEvent.ACTION_CANCEL -> syncViewPagerSwipeWithCurrentPhoto()
+                }
+                return super.dispatchTouchEvent(ev)
+            }
+        }
 
         viewPager = ViewPager2(context).apply {
             offscreenPageLimit = 1
@@ -170,8 +187,40 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
                 updateCounter()
                 onCurrentUrlChanged?.invoke(currentUrl)
                 maybeNotifyOldestEdge(position)
+                syncViewPagerSwipeWithCurrentPhoto()
             }
         })
+    }
+
+    private fun syncViewPagerSwipeWithCurrentPhoto() {
+        viewPager.isUserInputEnabled = urls.size > 1 &&
+            (photoViewAt(currentIndex)?.scale ?: 1f) <= VIEWPAGER_SWIPE_SCALE_EPSILON
+    }
+
+    private fun updateViewPagerSwipeForScale(scale: Float) {
+        viewPager.isUserInputEnabled = urls.size > 1 && scale <= VIEWPAGER_SWIPE_SCALE_EPSILON
+    }
+
+    private fun photoViewAt(position: Int): PhotoView? {
+        val rv = viewPager.getChildAt(0) as? RecyclerView ?: return null
+        val holder = rv.findViewHolderForAdapterPosition(position) as? PhotoPagerAdapter.ViewHolder
+        return holder?.photoView
+    }
+
+    private fun setAncestorsDisallowIntercept(view: View, disallow: Boolean) {
+        var parent: ViewParent? = view.parent
+        while (parent != null) {
+            parent.requestDisallowInterceptTouchEvent(disallow)
+            parent = parent.parent
+        }
+    }
+
+    private fun wirePhotoViewGestures(photoView: PhotoView) {
+        photoView.setOnScaleChangeListener { _, _, _ ->
+            val scale = photoView.scale
+            updateViewPagerSwipeForScale(scale)
+            setAncestorsDisallowIntercept(viewPager, scale > VIEWPAGER_SWIPE_SCALE_EPSILON)
+        }
     }
 
     private fun maybeNotifyOldestEdge(position: Int) {
@@ -204,6 +253,7 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
         oldestEdgeBaselinePosition = -1
         viewPager.adapter = PhotoPagerAdapter(thumbBitmap.takeIf { singleShowsThumb })
         viewPager.setCurrentItem(currentIndex, false)
+        viewPager.isUserInputEnabled = urls.size > 1
 
         updateCounter()
         backgroundDrawable.alpha = 0
@@ -294,6 +344,7 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
             photoView.setImageDrawable(null)
             photoView.getAttacher().update()
             photoView.setScale(1f, false)
+            updateViewPagerSwipeForScale(1f)
         }
 
         private fun applyLoadedDrawable(holder: ViewHolder, drawable: Drawable) {
@@ -324,9 +375,9 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
                     FrameLayout.LayoutParams.MATCH_PARENT
                 )
                 setBackgroundColor(Color.BLACK)
-                maximumScale = 4f
-                mediumScale = 2f
-                minimumScale = 0.5f
+                maximumScale = 5f
+                mediumScale = 2.5f
+                minimumScale = 1f
                 setOnSingleFlingListener { _, _, velocityX, velocityY ->
                     val absX = kotlin.math.abs(velocityX)
                     val absY = kotlin.math.abs(velocityY)
@@ -342,6 +393,8 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
             val progress = ProgressBar(ctx).apply {
                 isIndeterminate = true
                 indeterminateTintList = android.content.res.ColorStateList.valueOf(Color.WHITE)
+                isClickable = false
+                isFocusable = false
                 val size = LayoutHelper.dp(48)
                 layoutParams = FrameLayout.LayoutParams(size, size, Gravity.CENTER)
                 visibility = View.GONE
@@ -355,6 +408,7 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
                 addView(photoView)
                 addView(progress)
             }
+            wirePhotoViewGestures(photoView)
             return ViewHolder(container, photoView, progress)
         }
 


### PR DESCRIPTION
Disable horizontal paging when pinch-zoom exceeds baseline, sync swipe on scale change, and tighten PhotoView scale limits.