### PR TITLE
fix(chat): show topic voice after create and group owner crown

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/ChatController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChatController.kt
@@ -211,10 +211,21 @@ class ChatController @Inject constructor(
 
     fun getActivePendingAttachmentMessages(cacheKey: Long): List<MessageEntity> = synchronized(this) {
         val result = ArrayList<MessageEntity>()
+        val seenTempIds = HashSet<Long>()
         for (i in 0 until attachmentJobsByTempId.size()) {
             if (attachmentJobsByTempId.valueAt(i).cacheKey != cacheKey) continue
-            val entity = pendingAttachmentEntityByTempId.get(attachmentJobsByTempId.keyAt(i)) ?: continue
+            val tempId = attachmentJobsByTempId.keyAt(i)
+            val entity = pendingAttachmentEntityByTempId.get(tempId) ?: continue
             result.add(entity)
+            seenTempIds.add(tempId)
+        }
+        for (i in 0 until pendingAttachmentEntityByTempId.size()) {
+            val tempId = pendingAttachmentEntityByTempId.keyAt(i)
+            if (seenTempIds.contains(tempId)) continue
+            val entity = pendingAttachmentEntityByTempId.valueAt(i)
+            if (entity.channelId == cacheKey && entity.isSending) {
+                result.add(entity)
+            }
         }
         result
     }
@@ -1472,12 +1483,22 @@ class ChatController @Inject constructor(
             sendState = MessageEntity.SEND_STATE_SENDING,
             topicId = topicId
         )
+        synchronized(this) {
+            pendingAttachmentEntityByTempId.put(tempId, optimistic)
+            if (attachmentJobsByTempId.get(tempId) == null) {
+                attachmentJobsByTempId.put(
+                    tempId,
+                    IncrementalAttachmentJob(
+                        tempId = tempId,
+                        cacheKey = cacheKey,
+                        totalCount = attachments.size,
+                    )
+                )
+            }
+        }
         notificationCenter.postNotificationOnMainThread(
             NotificationCenter.didReceiveNewMessages, cacheKey, optimistic
         )
-        synchronized(this) {
-            pendingAttachmentEntityByTempId.put(tempId, optimistic)
-        }
 
         appScope.launch(ioDispatcher) {
             try {
@@ -1646,13 +1667,13 @@ class ChatController @Inject constructor(
             return
         }
 
-        val job = IncrementalAttachmentJob(
-            tempId = params.tempId,
-            cacheKey = params.cacheKey,
-            totalCount = params.allItems.size,
-        )
-        synchronized(this) {
-            attachmentJobsByTempId.put(params.tempId, job)
+        val job = synchronized(this) {
+            attachmentJobsByTempId.get(params.tempId)
+                ?: IncrementalAttachmentJob(
+                    tempId = params.tempId,
+                    cacheKey = params.cacheKey,
+                    totalCount = params.allItems.size,
+                ).also { attachmentJobsByTempId.put(params.tempId, it) }
         }
 
         val cdnBaseUrl = BuildConfig.MEZON_BASE_IMG_URL

--- a/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/ChannelInfoFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/ChannelInfoFragment.kt
@@ -38,6 +38,7 @@ import com.mezon.mobile.home.MemberResolver
 import com.mezon.mobile.home.UserClanController
 import com.mezon.mobile.home.clans.ChannelController
 import com.mezon.mobile.home.clans.ChannelPermissionController
+import com.mezon.mobile.home.clans.ClansController
 import com.mezon.mobile.home.clans.PermissionPolicy
 
 import com.mezon.mobile.home.clans.CHANNEL_TYPE_APP
@@ -114,6 +115,7 @@ class ChannelInfoFragment : BaseFragment() {
     private lateinit var chatController: ChatController
     private lateinit var channelController: ChannelController
     private lateinit var channelPermissionController: ChannelPermissionController
+    private lateinit var clansController: ClansController
     private lateinit var permissionPolicy: PermissionPolicy
     private var settingsActionGap: View? = null
     private var settingsActionView: View? = null
@@ -259,6 +261,7 @@ class ChannelInfoFragment : BaseFragment() {
         chatController = entryPoint.chatController()
         channelController = entryPoint.channelController()
         channelPermissionController = entryPoint.channelPermissionController()
+        clansController = entryPoint.clansController()
         permissionPolicy = entryPoint.permissionPolicy()
         channelFilesController = entryPoint.channelFilesController()
         channelGalleryController = entryPoint.channelGalleryController()
@@ -580,7 +583,7 @@ class ChannelInfoFragment : BaseFragment() {
             ))
         }
 
-        memberListAdapter = MemberListAdapter(themeColors, isDm, 0L)
+        memberListAdapter = MemberListAdapter(themeColors, isDm, resolveMemberListOwnerId())
 
         membersRecyclerView = RecyclerListView(context).apply {
             layoutManager = LinearLayoutManager(context)
@@ -930,8 +933,20 @@ class ChannelInfoFragment : BaseFragment() {
     }
 
     private fun reloadMembers() {
+        memberListAdapter?.updateCreatorId(resolveMemberListOwnerId())
         val members = memberResolver.resolveChannelMembers(clanId, channelId, channelType)
         memberListAdapter?.setData(members)
+    }
+
+    private fun resolveMemberListOwnerId(): Long {
+        return when {
+            channelType == CHANNEL_TYPE_GROUP ->
+                dialogsController.getDialog(channelId)?.groupCreatorId ?: 0L
+            channelType == CHANNEL_TYPE_DM -> 0L
+            clanId != 0L ->
+                clansController.clans.value.firstOrNull { it.clanId == clanId }?.creatorId ?: 0L
+            else -> 0L
+        }
     }
 
     private fun triggerMemberLoad() {

--- a/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/MemberListAdapter.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/MemberListAdapter.kt
@@ -19,8 +19,10 @@ import kotlinx.coroutines.withContext
 class MemberListAdapter(
     private val theme: ThemeColors,
     private val isDm: Boolean,
-    private val creatorId: Long
+    creatorId: Long
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+    private var creatorId = creatorId
 
     private val rows = ArrayList<Any>()
     private var allMembers = ArrayList<ClanMember>()
@@ -40,6 +42,12 @@ class MemberListAdapter(
     fun setFilter(query: String) {
         filterQuery = query.trim().lowercase()
         rebuildRows()
+    }
+
+    fun updateCreatorId(id: Long) {
+        if (creatorId == id) return
+        creatorId = id
+        notifyDataSetChanged()
     }
 
     private fun rebuildRows() {
@@ -130,7 +138,11 @@ class MemberListAdapter(
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (val item = rows[position]) {
             is SectionHeader -> (holder.itemView as TextView).text = item.title
-            is ClanMember -> (holder.itemView as MemberCell).update(0, item)
+            is ClanMember -> {
+                val cell = holder.itemView as MemberCell
+                cell.setCreatorId(creatorId)
+                cell.update(0, item)
+            }
         }
     }
 

--- a/app/src/main/java/com/mezon/mobile/home/chat/thread/CreateThreadFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/thread/CreateThreadFragment.kt
@@ -203,6 +203,15 @@ class CreateThreadFragment : BaseFragment() {
 
     private data class PendingStickerSend(val url: String, val filetype: String, val filename: String?)
 
+    private data class TopicComposerPayload(
+        val rawInput: String,
+        val attachments: ArrayList<AttachmentPickerItem>,
+        val sticker: PendingStickerSend?,
+        val mentions: List<MentionData>,
+        val hashtags: List<HashtagData>,
+        val emojiEntries: LinkedHashMap<String, String>
+    )
+
     private val mainHandler = android.os.Handler(android.os.Looper.getMainLooper())
     private var voiceRecorder: VoiceRecorder? = null
     private var voiceOverlay: VoiceRecordingOverlay? = null
@@ -1780,10 +1789,10 @@ class CreateThreadFragment : BaseFragment() {
         return m.copy(startOffset = s - leading, endOffset = e - leading)
     }
 
-    private fun buildEmojiMarkers(text: String): List<com.mezon.mobile.util.EmojiMarker>? {
-        if (emojiObjPicked.isEmpty()) return null
+    private fun buildEmojiMarkers(text: String, emojiSource: Map<String, String> = emojiObjPicked): List<com.mezon.mobile.util.EmojiMarker>? {
+        if (emojiSource.isEmpty()) return null
         val markers = ArrayList<com.mezon.mobile.util.EmojiMarker>()
-        for ((shortname, emojiId) in emojiObjPicked) {
+        for ((shortname, emojiId) in emojiSource) {
             var searchFrom = 0
             while (true) {
                 val idx = text.indexOf(shortname, searchFrom)
@@ -1868,14 +1877,15 @@ class CreateThreadFragment : BaseFragment() {
         }
     }
 
-    private fun sendComposerToTopic(topicId: Long) {
-        val rawInput = composerField.text?.toString() ?: ""
+    private fun sendComposerToTopic(topicId: Long, payload: TopicComposerPayload? = null) {
+        val captured = payload ?: captureTopicComposerPayload() ?: return
+        val rawInput = captured.rawInput
         val text = rawInput.trim()
         val ctx = getContext() ?: return
         val parentType = parentChannelType()
         val parentPrivate = channelController.findChannelById(parentChannelId, clanId)?.isPrivate == true
-        if (text.isBlank() && pendingAttachments.isEmpty()) {
-            pendingStickerSend?.let { st ->
+        if (text.isBlank() && captured.attachments.isEmpty()) {
+            captured.sticker?.let { st ->
                 chatController.sendDirectAttachment(
                     parentChannelId,
                     clanId,
@@ -1887,15 +1897,16 @@ class CreateThreadFragment : BaseFragment() {
                     null,
                     topicId = topicId
                 )
+            }
+            if (payload == null) {
                 pendingStickerSend = null
-                return
             }
             return
         }
         val mdResult = parseMarkdownAndStrip(text)
         val cleanedText = mdResult.cleanedText
         val mdMarkers = mdResult.markers.ifEmpty { null }
-        val fromTrackers = mentionTrackers.mapNotNull { m ->
+        val fromTrackers = captured.mentions.mapNotNull { m ->
             val inTrimmed = mentionOffsetsForTrimmed(rawInput, text, m) ?: return@mapNotNull null
             val s = mdResult.adjustOffset(inTrimmed.startOffset)
             val e = mdResult.adjustOffset(inTrimmed.endOffset)
@@ -1905,7 +1916,7 @@ class CreateThreadFragment : BaseFragment() {
         }
         val mergedMentions = mergeAtHereMentionsFromText(cleanedText, fromTrackers)
         val mentions = mergedMentions.ifEmpty { null }
-        val hashtagsFromTrackers = hashtagTrackers.mapNotNull { h ->
+        val hashtagsFromTrackers = captured.hashtags.mapNotNull { h ->
             val inTrimmed = hashtagOffsetsForTrimmed(rawInput, h) ?: return@mapNotNull null
             val s = mdResult.adjustOffset(inTrimmed.startOffset)
             val e = mdResult.adjustOffset(inTrimmed.endOffset)
@@ -1914,15 +1925,15 @@ class CreateThreadFragment : BaseFragment() {
             HashtagData(inTrimmed.channelId, s, e, inTrimmed.clanId)
         }
         val hashtags = hashtagsFromTrackers.ifEmpty { null }
-        val emojiMarkers = buildEmojiMarkers(cleanedText)
-        if (pendingAttachments.isNotEmpty()) {
+        val emojiMarkers = buildEmojiMarkers(cleanedText, captured.emojiEntries)
+        if (captured.attachments.isNotEmpty()) {
             chatController.sendMessageWithAttachments(
                 parentChannelId,
                 clanId,
                 parentType,
                 parentPrivate,
                 cleanedText,
-                ArrayList(pendingAttachments),
+                captured.attachments,
                 ctx.contentResolver,
                 null,
                 mentions,
@@ -1930,8 +1941,6 @@ class CreateThreadFragment : BaseFragment() {
                 emojiMarkers,
                 topicId = topicId
             )
-            pendingAttachments.clear()
-            updateAttachmentPreview()
         } else {
             chatController.sendMessage(
                 parentChannelId,
@@ -1948,12 +1957,17 @@ class CreateThreadFragment : BaseFragment() {
                 topicId = topicId
             )
         }
-        composerField.text?.clear()
-        emojiObjPicked.clear()
-        mentionTrackers.clear()
-        hashtagTrackers.clear()
-        updateSendButtonState()
-        pendingStickerSend?.let { st ->
+        if (payload == null) {
+            composerField.text?.clear()
+            emojiObjPicked.clear()
+            mentionTrackers.clear()
+            hashtagTrackers.clear()
+            pendingAttachments.clear()
+            updateAttachmentPreview()
+            updateSendButtonState()
+            pendingStickerSend = null
+        }
+        captured.sticker?.let { st ->
             chatController.sendDirectAttachment(
                 parentChannelId,
                 clanId,
@@ -1965,8 +1979,23 @@ class CreateThreadFragment : BaseFragment() {
                 null,
                 topicId = topicId
             )
-            pendingStickerSend = null
         }
+    }
+
+    private fun captureTopicComposerPayload(): TopicComposerPayload? {
+        val rawInput = composerField.text?.toString() ?: ""
+        val text = rawInput.trim()
+        val hasAttachments = pendingAttachments.isNotEmpty()
+        val hasSticker = pendingStickerSend != null
+        if (text.isBlank() && !hasAttachments && !hasSticker) return null
+        return TopicComposerPayload(
+            rawInput = rawInput,
+            attachments = ArrayList(pendingAttachments),
+            sticker = pendingStickerSend,
+            mentions = ArrayList(mentionTrackers),
+            hashtags = ArrayList(hashtagTrackers),
+            emojiEntries = LinkedHashMap(emojiObjPicked)
+        )
     }
 
     private fun refreshNameError() {
@@ -2047,11 +2076,23 @@ class CreateThreadFragment : BaseFragment() {
                         )
                     } ?: throw IllegalStateException("create topic failed")
                     val topicRootMessageId = createdTopic.messageId.takeIf { it != 0L } ?: seedMessageId
+                    val composerPayload = captureTopicComposerPayload()
                     withContext(mainDispatcher) {
                         submitProgress?.visibility = View.GONE
                         isSubmitting = false
                         sendButton?.isEnabled = true
                         attachButton?.isEnabled = true
+                        if (composerPayload != null) {
+                            sendComposerToTopic(createdTopic.id, composerPayload)
+                            composerField.text?.clear()
+                            emojiObjPicked.clear()
+                            mentionTrackers.clear()
+                            hashtagTrackers.clear()
+                            pendingAttachments.clear()
+                            pendingStickerSend = null
+                            updateAttachmentPreview()
+                            updateSendButtonState()
+                        }
                         presentFragment(
                             TopicFragment.newInstance(
                                 topicId = createdTopic.id,
@@ -2063,7 +2104,6 @@ class CreateThreadFragment : BaseFragment() {
                             ),
                             removeLast = true
                         )
-                        sendComposerToTopic(createdTopic.id)
                     }
                     return@launch
                 }


### PR DESCRIPTION
Capture composer payload before topic navigation so voice recordings are not dropped, register pending attachment jobs earlier for topic load, and pass group creator id to member list for owner crown icon.