### PR TITLE
260619-ANDROID-Update sync text avatar 

### DIFF
--- a/app/src/main/java/com/mezon/mobile/core/AvatarDrawable.kt
+++ b/app/src/main/java/com/mezon/mobile/core/AvatarDrawable.kt
@@ -130,7 +130,7 @@ class AvatarDrawable : Drawable() {
     }
 
     private fun getAvatarSymbols(username: String): String {
-        val upper = avatarPlaceholderChar(username) ?: return "?"
+        val upper = avatarPlaceholderChar(username) ?: return ""
         return upper.toString()
     }
 

--- a/app/src/main/java/com/mezon/mobile/home/call/CallAvatarView.kt
+++ b/app/src/main/java/com/mezon/mobile/home/call/CallAvatarView.kt
@@ -65,7 +65,7 @@ class CallAvatarView(
 
     fun setData(name: String, username: String, avatarUrl: String?) {
         peerName = name
-        avatarDrawable.setInfo(0L, username)
+        avatarDrawable.setInfo(0L, username.ifEmpty { name })
         if (currentAvatarUrl != avatarUrl) {
             currentAvatarUrl = avatarUrl
             cancellable?.cancel()

--- a/app/src/main/java/com/mezon/mobile/home/call/CallingOverlay.kt
+++ b/app/src/main/java/com/mezon/mobile/home/call/CallingOverlay.kt
@@ -121,7 +121,7 @@ class CallingOverlay(context: Context) : FrameLayout(context) {
 
     fun setCallerInfo(name: String, username: String, avatarUrl: String?) {
         nameTv.text = name
-        avatarView.setInfo(0L, username)
+        avatarView.setInfo(0L, username.ifEmpty { name })
         avatarView.setImageUrl(avatarUrl)
     }
 

--- a/app/src/main/java/com/mezon/mobile/home/call/IncomingCallActivity.kt
+++ b/app/src/main/java/com/mezon/mobile/home/call/IncomingCallActivity.kt
@@ -512,7 +512,7 @@ class IncomingCallActivity : Activity(), NotificationCenter.NotificationCenterDe
         nameView?.text = callerName
         statusView?.text = "Incoming voice call..."
         titleView?.text = "Incoming Call"
-        ringingAvatarView?.setInfo(0L, callerUsername)
+        ringingAvatarView?.setInfo(0L, callerUsername.ifEmpty { callerName })
         ringingAvatarView?.setImageUrl(callerAvatar)
     }
 

--- a/app/src/main/java/com/mezon/mobile/home/clans/ClanEventDetailFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ClanEventDetailFragment.kt
@@ -696,8 +696,7 @@ class ClanEventDetailFragment : BaseFragment() {
                 AvatarView(context).apply {
                     setSizeDp(40)
                     setRoundRadius(20f)
-                    val name = memberDisplayName(member)
-                    setInfo(userId, name)
+                    setInfo(userId, member?.username ?: "")
                     val avatar = memberAvatarUrl(member)
                     if (avatar.isNotEmpty()) setImageUrl(avatarImgproxyUrl(avatar, LayoutHelper.dp(40)))
                 },

--- a/app/src/main/java/com/mezon/mobile/home/messages/DirectMessage.kt
+++ b/app/src/main/java/com/mezon/mobile/home/messages/DirectMessage.kt
@@ -78,8 +78,8 @@ data class DirectMessage(
 ) {
     fun avatarPlaceholderKey(): String = when (type) {
         CHANNEL_TYPE_GROUP -> displayName.ifEmpty { label }
-        CHANNEL_TYPE_DM -> label.ifEmpty { username }
-        else -> displayName.ifEmpty { label }.ifEmpty { username }
+        CHANNEL_TYPE_DM -> username
+        else -> username.ifEmpty { displayName.ifEmpty { label } }
     }
 }
 

--- a/app/src/main/java/com/mezon/mobile/home/messages/DmMenuBottomSheet.kt
+++ b/app/src/main/java/com/mezon/mobile/home/messages/DmMenuBottomSheet.kt
@@ -98,7 +98,7 @@ class DmMenuBottomSheet(
             AvatarView(context).apply {
                 setSizeDp(60)
                 setRoundRadius(if (dm.type == CHANNEL_TYPE_GROUP) 10f else 30f)
-                setInfo(dm.channelId, displayName)
+                setInfo(dm.channelId, dm.avatarPlaceholderKey())
                 setImageUrl(dm.avatarUrl.ifBlank { "" })
             },
             FrameLayout.LayoutParams(LayoutHelper.dp(60), LayoutHelper.dp(60))

--- a/app/src/main/java/com/mezon/mobile/home/messages/FriendPickerAdapter.kt
+++ b/app/src/main/java/com/mezon/mobile/home/messages/FriendPickerAdapter.kt
@@ -393,7 +393,7 @@ private class FriendPickerCell(
         } else {
             fallbackAvatar.visibility = View.GONE
             avatarView.visibility = View.VISIBLE
-            avatarView.setInfo(user.id, displayName)
+            avatarView.setInfo(user.id, user.username)
             avatarView.setImageUrl(user.avatarUrl)
         }
         titleView.text = displayName


### PR DESCRIPTION
issue: https://github.com/mezonai/mezon/issues/13335
result:
<img width="414" height="830" alt="image" src="https://github.com/user-attachments/assets/43da00fe-c687-434a-8f11-fe25831b421b" />
<img width="371" height="146" alt="image" src="https://github.com/user-attachments/assets/e0b7528a-8fe8-4c9d-a274-8351222de42f" />
<img width="424" height="789" alt="image" src="https://github.com/user-attachments/assets/8c1073b1-4b37-4363-b4ad-9a3e7de6dd61" />
root cause: empty fallback caller name
test cases: check text avatar, outgoing call, ingoing call
solution: add caller name to fallback