### PR TITLE
260624-ANDROID-Fix bug emoji

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/chat/AdvancedMenuView.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/AdvancedMenuView.kt
@@ -186,8 +186,6 @@ class AdvancedMenuView(
                 }
                 if (dragging) {
                     dragTranslation = (ev.rawY - dragStartY).coerceAtLeast(0f)
-                    val child = getChildAt(0)
-                    child?.translationY = dragTranslation
                     delegate?.onDragY(dragTranslation)
                 }
                 return true
@@ -203,11 +201,6 @@ class AdvancedMenuView(
                         delegate?.onAnimateExpand(false)
                     } else {
                         delegate?.onAnimateExpand(true)
-                        child.animate()
-                            .translationY(0f)
-                            .setDuration(200)
-                            .setInterpolator(android.view.animation.DecelerateInterpolator())
-                            .start()
                     }
                 }
                 velocityTracker?.recycle()

--- a/app/src/main/java/com/mezon/mobile/home/chat/AdvancedMenuView.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/AdvancedMenuView.kt
@@ -125,14 +125,24 @@ class AdvancedMenuView(
 
     private fun onFunctionClicked(item: FunctionItem) {
         val del = delegate
+        var dismiss = true
         when (item.id) {
             "location" -> del?.onLocationSelected()
             "files" -> del?.onFilesSelected()
             "buzz" -> del?.onBuzzSelected()
-            "anonymous" -> del?.onAnonymousToggled()
+            "anonymous" -> {
+                del?.onAnonymousToggled()
+                dismiss = false
+            }
             "poll" -> del?.onCreatePollRequested()
             "share_contact" -> del?.onShareContactSelected()
-            else -> android.widget.Toast.makeText(context, R.string.feature_coming_soon, android.widget.Toast.LENGTH_SHORT).show()
+            else -> {
+                android.widget.Toast.makeText(context, R.string.feature_coming_soon, android.widget.Toast.LENGTH_SHORT).show()
+                dismiss = false
+            }
+        }
+        if (dismiss) {
+            del?.onAnimateExpand(false)
         }
     }
 

--- a/app/src/main/java/com/mezon/mobile/home/chat/AdvancedMenuView.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/AdvancedMenuView.kt
@@ -8,17 +8,13 @@ import android.graphics.drawable.Drawable
 import android.text.StaticLayout
 import android.text.TextPaint
 import android.text.TextUtils
-import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import android.widget.LinearLayout
-import android.widget.Toast
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.mezon.mobile.R
 import com.mezon.mobile.core.AndroidUtilities
-import com.mezon.mobile.core.BottomSheet
 import com.mezon.mobile.core.LayoutHelper
 import com.mezon.mobile.core.ThemeColors
 import com.mezon.mobile.ui.cells.MezonIcon
@@ -27,28 +23,33 @@ private const val ITEMS_PER_ROW = 4
 private const val ICON_BG_SIZE = 42
 private const val ICON_SIZE = 24
 
-class AdvancedAttachAlert(
+class AdvancedMenuView(
     context: Context,
     private val theme: ThemeColors,
     private val clanId: Long = 0L,
     private val isAnonymousMode: Boolean = false,
-    /**
-     * Web `FileSelectionButton`: poll hidden only for `CHANNEL_TYPE_DM` (1:1 DM).
-     * Caller must set this from [com.mezon.mobile.home.chat.poll.canCreatePoll] — not from [clanId].
-     */
     private val showCreatePoll: Boolean = false
-) : BottomSheet(context) {
+) : FrameLayout(context) {
 
-    interface AdvancedAttachAlertDelegate {
+    interface AdvancedMenuViewDelegate {
         fun onLocationSelected()
         fun onFilesSelected()
         fun onBuzzSelected()
         fun onAnonymousToggled()
         fun onCreatePollRequested() {}
         fun onShareContactSelected() {}
+        fun onDragY(dy: Float) {}
+        fun onAnimateExpand(expand: Boolean) {}
     }
 
-    var advancedDelegate: AdvancedAttachAlertDelegate? = null
+    var delegate: AdvancedMenuViewDelegate? = null
+    
+    private var dragStartY = 0f
+    private var dragging = false
+    private var dragTranslation = 0f
+    private var velocityTracker: android.view.VelocityTracker? = null
+    private val touchSlop = android.view.ViewConfiguration.get(context).scaledTouchSlop
+    private val dismissVelocity = 1000f
 
     private data class FunctionItem(
         val id: String,
@@ -57,6 +58,20 @@ class AdvancedAttachAlert(
     )
 
     private val functions: List<FunctionItem> = buildFunctions()
+
+    init {
+        setBackgroundColor(theme.getColor(ThemeColors.key_sheetBackground))
+
+        val gridView = RecyclerView(context).apply {
+            layoutManager = GridLayoutManager(context, ITEMS_PER_ROW)
+            adapter = FunctionGridAdapter()
+            overScrollMode = View.OVER_SCROLL_NEVER
+            clipToPadding = false
+            setPadding(LayoutHelper.dp(12f), LayoutHelper.dp(16f), LayoutHelper.dp(12f), LayoutHelper.dp(16f))
+        }
+
+        addView(gridView, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT, android.view.Gravity.CENTER))
+    }
 
     private fun buildFunctions(): List<FunctionItem> {
         val list = ArrayList<FunctionItem>()
@@ -74,7 +89,6 @@ class AdvancedAttachAlert(
             list.add(FunctionItem("ephemeral", R.string.advanced_ephemeral, MezonIcon.ephemeralIconGray))
         }
         list.add(FunctionItem("transfer_funds", R.string.advanced_transfer_funds, MezonIcon.sendMoneyAdvancedIcon))
-        // Poll: non-DM channels only (group DM + clan). Threads/ephemeral still use clanId above.
         if (showCreatePoll) {
             list.add(FunctionItem("poll", R.string.advanced_poll, MezonIcon.pollIconGray))
         }
@@ -82,28 +96,6 @@ class AdvancedAttachAlert(
             list.add(FunctionItem("share_contact", R.string.advanced_share_contact, MezonIcon.shareContactIconGray))
         }
         return list
-    }
-
-    override fun onCreate(savedInstanceState: android.os.Bundle?) {
-        super.onCreate(savedInstanceState)
-        fixNavigationBar()
-
-        val gridView = RecyclerView(context).apply {
-            layoutManager = GridLayoutManager(context, ITEMS_PER_ROW)
-            adapter = FunctionGridAdapter()
-            overScrollMode = View.OVER_SCROLL_NEVER
-            clipToPadding = false
-            setPadding(LayoutHelper.dp(12f), LayoutHelper.dp(16f), LayoutHelper.dp(12f), LayoutHelper.dp(16f))
-        }
-
-        val contentFrame = FrameLayout(context)
-        contentFrame.addView(gridView, FrameLayout.LayoutParams(
-            FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.WRAP_CONTENT
-        ))
-
-        contentLayout?.addView(contentFrame, LinearLayout.LayoutParams(
-            LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT
-        ))
     }
 
     private inner class FunctionGridAdapter : RecyclerView.Adapter<FunctionGridAdapter.Holder>() {
@@ -132,24 +124,88 @@ class AdvancedAttachAlert(
     }
 
     private fun onFunctionClicked(item: FunctionItem) {
-        val delegate = advancedDelegate
-        dismiss()
+        val del = delegate
         when (item.id) {
-            "location" -> delegate?.onLocationSelected()
-            "files" -> delegate?.onFilesSelected()
-            "buzz" -> delegate?.onBuzzSelected()
-            "anonymous" -> delegate?.onAnonymousToggled()
-            "poll" -> delegate?.onCreatePollRequested()
-            "share_contact" -> delegate?.onShareContactSelected()
-            else -> Toast.makeText(context, R.string.feature_coming_soon, Toast.LENGTH_SHORT).show()
+            "location" -> del?.onLocationSelected()
+            "files" -> del?.onFilesSelected()
+            "buzz" -> del?.onBuzzSelected()
+            "anonymous" -> del?.onAnonymousToggled()
+            "poll" -> del?.onCreatePollRequested()
+            "share_contact" -> del?.onShareContactSelected()
+            else -> android.widget.Toast.makeText(context, R.string.feature_coming_soon, android.widget.Toast.LENGTH_SHORT).show()
         }
     }
 
-    override fun dismiss() {
-        super.dismiss()
-        if (isDismissed()) {
-            advancedDelegate = null
+    override fun onInterceptTouchEvent(ev: android.view.MotionEvent): Boolean {
+        if (ev.actionMasked == android.view.MotionEvent.ACTION_DOWN) {
+            dragStartY = ev.rawY
+            dragging = false
+            velocityTracker?.recycle()
+            velocityTracker = android.view.VelocityTracker.obtain()
+            velocityTracker?.addMovement(ev)
+        } else if (ev.actionMasked == android.view.MotionEvent.ACTION_MOVE) {
+            velocityTracker?.addMovement(ev)
+            val dy = ev.rawY - dragStartY
+            if (!dragging && dy > touchSlop) {
+                val grid = getChildAt(0) as? RecyclerView
+                if (grid == null || !grid.canScrollVertically(-1)) {
+                    dragging = true
+                    dragStartY = ev.rawY
+                    return true
+                }
+            }
         }
+        return super.onInterceptTouchEvent(ev)
+    }
+
+    override fun onTouchEvent(ev: android.view.MotionEvent): Boolean {
+        velocityTracker?.addMovement(ev)
+        when (ev.actionMasked) {
+            android.view.MotionEvent.ACTION_DOWN -> {
+                dragStartY = ev.rawY
+                return true
+            }
+            android.view.MotionEvent.ACTION_MOVE -> {
+                val dy = ev.rawY - dragStartY
+                if (!dragging && dy > touchSlop) {
+                    val grid = getChildAt(0) as? RecyclerView
+                    if (grid == null || !grid.canScrollVertically(-1)) {
+                        dragging = true
+                        dragStartY = ev.rawY
+                    }
+                }
+                if (dragging) {
+                    dragTranslation = (ev.rawY - dragStartY).coerceAtLeast(0f)
+                    val child = getChildAt(0)
+                    child?.translationY = dragTranslation
+                    delegate?.onDragY(dragTranslation)
+                }
+                return true
+            }
+            android.view.MotionEvent.ACTION_UP, android.view.MotionEvent.ACTION_CANCEL -> {
+                if (dragging) {
+                    dragging = false
+                    velocityTracker?.computeCurrentVelocity(1000)
+                    val vy = velocityTracker?.yVelocity ?: 0f
+                    val child = getChildAt(0) ?: return true
+                    val h = child.height.toFloat()
+                    if (vy > dismissVelocity || dragTranslation > h * 0.4f) {
+                        delegate?.onAnimateExpand(false)
+                    } else {
+                        delegate?.onAnimateExpand(true)
+                        child.animate()
+                            .translationY(0f)
+                            .setDuration(200)
+                            .setInterpolator(android.view.animation.DecelerateInterpolator())
+                            .start()
+                    }
+                }
+                velocityTracker?.recycle()
+                velocityTracker = null
+                return true
+            }
+        }
+        return super.onTouchEvent(ev)
     }
 }
 
@@ -184,7 +240,7 @@ private class FunctionCell(context: Context, private val theme: ThemeColors) : V
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        val w = MeasureSpec.getSize(widthMeasureSpec)
+        val w = View.MeasureSpec.getSize(widthMeasureSpec)
         setMeasuredDimension(w, LayoutHelper.dp(100f))
         buildLayout()
     }

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -1420,7 +1420,13 @@ open class ChatFragment : BaseFragment() {
 
         val chatActionBar = ActionBarView(context, themeColors).apply {
             setBackClickListener {
-                finishFragment()
+                if (emojiViewVisible) {
+                    hideEmojiView()
+                } else if (advancedMenuViewVisible) {
+                    hideAdvancedMenuView()
+                } else {
+                    finishFragment()
+                }
             }
             setTitleOnClickListener {
                 val channelEntity = channelController.findChannelById(channelId)

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -4905,9 +4905,8 @@ open class ChatFragment : BaseFragment() {
     private fun showAdvancedFunctionMenu() {
         dismissPasteImagePopup()
         if (!ensureCanSendMessageOrNotify()) return
-        
         if (advancedMenuViewVisible) {
-            openKeyboardFromEmoji()
+            hideAdvancedMenuView()
             return
         }
 

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -279,6 +279,7 @@ open class ChatFragment : BaseFragment() {
     private var anonymousIndicator: ImageView? = null
     private var emojiView: EmojiView? = null
     private var emojiViewVisible = false
+    private var emojiExpandAnimator: android.animation.ValueAnimator? = null
     private var advancedMenuView: AdvancedMenuView? = null
     private var advancedMenuViewVisible = false
     private var previousKeyboardHeight = 0
@@ -2620,6 +2621,8 @@ open class ChatFragment : BaseFragment() {
     }
 
     private fun hideEmojiView(animated: Boolean = true, resetPadding: Boolean = true) {
+        emojiExpandAnimator?.cancel()
+        emojiExpandAnimator = null
         dismissPasteImagePopup()
         emojiSearchExpanded = false
         searchKeyboardWasVisible = false
@@ -2842,7 +2845,9 @@ open class ChatFragment : BaseFragment() {
                     val startHeight = emojiView?.layoutParams?.height ?: panelHeight
                     val targetHeight = if (expand) sizeNotifierRoot.height else panelHeight
                     
+                    emojiExpandAnimator?.cancel()
                     val anim = android.animation.ValueAnimator.ofInt(startHeight, targetHeight)
+                    emojiExpandAnimator = anim
                     anim.addUpdateListener {
                         val h = it.animatedValue as Int
                         emojiView?.layoutParams = FrameLayout.LayoutParams(
@@ -2871,6 +2876,8 @@ open class ChatFragment : BaseFragment() {
     }
 
     override fun onFragmentDestroy() {
+        emojiExpandAnimator?.cancel()
+        emojiExpandAnimator = null
         activePhotoViewer?.setOnDismissListener(null)
         activePhotoViewer?.dismiss()
         activePhotoViewer = null

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -279,6 +279,9 @@ open class ChatFragment : BaseFragment() {
     private var anonymousIndicator: ImageView? = null
     private var emojiView: EmojiView? = null
     private var emojiViewVisible = false
+    private var advancedMenuView: AdvancedMenuView? = null
+    private var advancedMenuViewVisible = false
+    private var previousKeyboardHeight = 0
     private var emojiPadding = 0
     private var emojiSearchExpanded = false
     private var searchKeyboardWasVisible = false
@@ -1417,11 +1420,7 @@ open class ChatFragment : BaseFragment() {
 
         val chatActionBar = ActionBarView(context, themeColors).apply {
             setBackClickListener {
-                if (emojiViewVisible) {
-                    hideEmojiView()
-                } else {
-                    finishFragment()
-                }
+                finishFragment()
             }
             setTitleOnClickListener {
                 val channelEntity = channelController.findChannelById(channelId)
@@ -2322,8 +2321,11 @@ open class ChatFragment : BaseFragment() {
 
         sizeNotifierRoot.setDelegate(object : SizeNotifierFrameLayout.SizeNotifierFrameLayoutDelegate {
             override fun onSizeChanged(keyboardHeight: Int, isWidthGreater: Boolean) {
-                if (emojiSearchExpanded) {
-                    if (keyboardHeight > LayoutHelper.dp(50f)) {
+                val isKeyboardOpening = keyboardHeight > previousKeyboardHeight
+                previousKeyboardHeight = keyboardHeight
+                
+                if (emojiSearchExpanded || searchKeyboardWasVisible) {
+                    if (isKeyboardOpening && keyboardHeight > LayoutHelper.dp(50f)) {
                         SharedConfig.saveKeyboardHeight(keyboardHeight, isWidthGreater)
                         searchKeyboardWasVisible = true
                     }
@@ -2332,7 +2334,7 @@ open class ChatFragment : BaseFragment() {
                     }
                     return
                 }
-                if (keyboardHeight > LayoutHelper.dp(50f)) {
+                if (isKeyboardOpening && keyboardHeight > LayoutHelper.dp(50f)) {
                     SharedConfig.saveKeyboardHeight(keyboardHeight, isWidthGreater)
                     if (waitingForKeyboardOpen) {
                         waitingForKeyboardOpen = false
@@ -2341,8 +2343,11 @@ open class ChatFragment : BaseFragment() {
                     if (emojiViewVisible) {
                         dismissEmojiSilently()
                     }
+                    if (advancedMenuViewVisible) {
+                        dismissAdvancedMenuSilently()
+                    }
                 }
-                if (keyboardHeight <= LayoutHelper.dp(20f) && !emojiViewVisible && emojiPadding != 0) {
+                if (keyboardHeight <= LayoutHelper.dp(20f) && !emojiViewVisible && !advancedMenuViewVisible && emojiPadding != 0) {
                     emojiPadding = 0
                     sizeNotifierRoot.setEmojiKeyboardHeight(0)
                     sizeNotifierRoot.requestLayout()
@@ -2500,12 +2505,21 @@ open class ChatFragment : BaseFragment() {
             hideEmojiView()
             return false
         }
+        if (advancedMenuViewVisible) {
+            hideAdvancedMenuView()
+            return false
+        }
         return super.onBackPressed()
     }
 
     private fun showEmojiView() {
         dismissPasteImagePopup()
         if (emojiView == null) createEmojiView()
+        
+        if (advancedMenuViewVisible) {
+            hideAdvancedMenuView(animated = false, resetPadding = false)
+        }
+        
         val ev = emojiView!!
         ev.animate().cancel()
         ev.translationY = 0f
@@ -2543,8 +2557,18 @@ open class ChatFragment : BaseFragment() {
     private fun openKeyboardFromEmoji() {
         updateEmojiButtonIcon(showingEmoji = false)
         AndroidUtilities.cancelRunOnUIThread(showKeyboardFromEmojiRunnable)
-        if (emojiViewVisible) {
-            AndroidUtilities.runOnUIThread(showKeyboardFromEmojiRunnable, 200)
+        if (emojiViewVisible || advancedMenuViewVisible) {
+            if (searchKeyboardWasVisible) {
+                searchKeyboardWasVisible = false
+                emojiSearchExpanded = false
+                inputField.requestFocus()
+                waitingForKeyboardOpen = false
+                AndroidUtilities.showKeyboard(inputField)
+                if (emojiViewVisible) dismissEmojiSilently()
+                if (advancedMenuViewVisible) dismissAdvancedMenuSilently()
+            } else {
+                AndroidUtilities.runOnUIThread(showKeyboardFromEmojiRunnable, 200)
+            }
         } else {
             showKeyboardFromEmojiRunnable.run()
         }
@@ -2561,7 +2585,35 @@ open class ChatFragment : BaseFragment() {
         updateEmojiButtonIcon(showingEmoji = false)
     }
 
-    private fun hideEmojiView(animated: Boolean = true) {
+    private fun dismissAdvancedMenuSilently() {
+        advancedMenuViewVisible = false
+        advancedMenuView?.visibility = View.GONE
+        emojiPadding = 0
+        sizeNotifierRoot.setEmojiKeyboardHeight(0)
+    }
+
+    private fun hideAdvancedMenuView(animated: Boolean = true, resetPadding: Boolean = true) {
+        advancedMenuViewVisible = false
+        val amv = advancedMenuView ?: return
+        if (animated) {
+            amv.animate()
+                .translationY(amv.height.toFloat())
+                .setDuration(250)
+                .setInterpolator(android.view.animation.DecelerateInterpolator())
+                .withEndAction { amv.visibility = View.GONE }
+                .start()
+        } else {
+            amv.animate().cancel()
+            amv.visibility = View.GONE
+        }
+        if (resetPadding) {
+            emojiPadding = 0
+            sizeNotifierRoot.setEmojiKeyboardHeight(0)
+            sizeNotifierRoot.requestLayout()
+        }
+    }
+
+    private fun hideEmojiView(animated: Boolean = true, resetPadding: Boolean = true) {
         dismissPasteImagePopup()
         emojiSearchExpanded = false
         searchKeyboardWasVisible = false
@@ -2569,9 +2621,11 @@ open class ChatFragment : BaseFragment() {
         emojiViewVisible = false
         emojiView?.clearSearchFocus()
 
-        emojiPadding = 0
-        sizeNotifierRoot.setEmojiKeyboardHeight(0)
-        sizeNotifierRoot.requestLayout()
+        if (resetPadding) {
+            emojiPadding = 0
+            sizeNotifierRoot.setEmojiKeyboardHeight(0)
+            sizeNotifierRoot.requestLayout()
+        }
         updateEmojiButtonIcon(showingEmoji = false)
 
         val ev = emojiView ?: return
@@ -2624,7 +2678,7 @@ open class ChatFragment : BaseFragment() {
     }
 
     private fun collapseEmojiSearch() {
-        if (!emojiSearchExpanded) return
+        if (!emojiSearchExpanded && !searchKeyboardWasVisible) return
         emojiSearchExpanded = false
         searchKeyboardWasVisible = false
         sizeNotifierRoot.isSearchExpanded = false
@@ -2688,6 +2742,10 @@ open class ChatFragment : BaseFragment() {
                         android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
                     )
                     inputField.setSelection(cursor + insertText.length)
+                    
+                    if (emojiSearchExpanded) {
+                        collapseEmojiSearch()
+                    }
                 }
 
                 override fun onStickerSelected(sticker: StickerItem, isAudio: Boolean) {
@@ -2732,6 +2790,72 @@ open class ChatFragment : BaseFragment() {
 
                 override fun onDismissRequested() {
                     hideEmojiView(animated = false)
+                }
+
+                override fun onExpandRequested() {
+                    expandEmojiSearch()
+                }
+
+                override fun isExpanded(): Boolean {
+                    return emojiSearchExpanded
+                }
+
+                override fun onDragY(dy: Float, dragFromExpanded: Boolean) {
+                    val panelHeight = SharedConfig.getEmojiPanelHeight()
+                    if (dragFromExpanded) {
+                        if (dy > 0) {
+                            emojiSearchExpanded = false
+                            sizeNotifierRoot.isSearchExpanded = false
+                            emojiView?.clearSearchFocus()
+                            AndroidUtilities.hideKeyboard(emojiView)
+                            val targetHeight = (sizeNotifierRoot.height - dy).toInt().coerceAtLeast(panelHeight)
+                            emojiView?.layoutParams = FrameLayout.LayoutParams(
+                                FrameLayout.LayoutParams.MATCH_PARENT, targetHeight, Gravity.BOTTOM
+                            )
+                            sizeNotifierRoot.setEmojiKeyboardHeight(targetHeight)
+                            sizeNotifierRoot.requestLayout()
+                        }
+                        return
+                    }
+
+                    if (dy < 0) {
+                        val targetHeight = (panelHeight - dy).toInt().coerceAtMost(sizeNotifierRoot.height)
+                        if (emojiView?.layoutParams?.height != targetHeight) {
+                            emojiView?.layoutParams = FrameLayout.LayoutParams(
+                                FrameLayout.LayoutParams.MATCH_PARENT, targetHeight, Gravity.BOTTOM
+                            )
+                            sizeNotifierRoot.setEmojiKeyboardHeight(targetHeight)
+                            sizeNotifierRoot.requestLayout()
+                        }
+                    }
+                }
+
+                override fun onAnimateExpand(expand: Boolean) {
+                    if (emojiSearchExpanded) return
+                    val panelHeight = SharedConfig.getEmojiPanelHeight()
+                    val startHeight = emojiView?.layoutParams?.height ?: panelHeight
+                    val targetHeight = if (expand) sizeNotifierRoot.height else panelHeight
+                    
+                    val anim = android.animation.ValueAnimator.ofInt(startHeight, targetHeight)
+                    anim.addUpdateListener {
+                        val h = it.animatedValue as Int
+                        emojiView?.layoutParams = FrameLayout.LayoutParams(
+                            FrameLayout.LayoutParams.MATCH_PARENT, h, Gravity.BOTTOM
+                        )
+                        sizeNotifierRoot.setEmojiKeyboardHeight(h)
+                        sizeNotifierRoot.requestLayout()
+                    }
+                    anim.addListener(object : android.animation.AnimatorListenerAdapter() {
+                        override fun onAnimationEnd(animation: android.animation.Animator) {
+                            if (expand) {
+                                expandEmojiSearch()
+                            } else {
+                                emojiPadding = panelHeight
+                            }
+                        }
+                    })
+                    anim.duration = 200
+                    anim.start()
                 }
             }
         }
@@ -2796,6 +2920,7 @@ open class ChatFragment : BaseFragment() {
         chatAdjustPanHelper?.onDetach()
         chatAdjustPanHelper = null
         emojiView = null
+        advancedMenuView = null
         emojiObjPicked.clear()
         buzzMediaPlayer?.release()
         buzzMediaPlayer = null
@@ -3490,7 +3615,7 @@ open class ChatFragment : BaseFragment() {
                 null
             }
             if (merged == null) return@launch
-            withContext(Dispatchers.Main) {
+            withContext(mainDispatcher) {
                 val cur = messagesDict.get(messageId) ?: return@withContext
                 if (!cur.isPollMessage) return@withContext
                 val uid = currentUserIdLong()
@@ -4180,6 +4305,8 @@ open class ChatFragment : BaseFragment() {
                     -1 -> {
                         if (emojiViewVisible) {
                             hideEmojiView()
+                        } else if (advancedMenuViewVisible) {
+                            hideAdvancedMenuView()
                         } else {
                             finishFragment()
                         }
@@ -4765,43 +4892,94 @@ open class ChatFragment : BaseFragment() {
     private fun showAdvancedFunctionMenu() {
         dismissPasteImagePopup()
         if (!ensureCanSendMessageOrNotify()) return
-        val ctx = getContext() ?: return
-        val isAnon = anonymousController.isAnonymous(clanId)
-        val alert = AdvancedAttachAlert(
-            ctx,
-            themeColors,
-            clanId,
-            isAnon,
-            showCreatePoll = canCreatePoll(channelType)
-        )
-        alert.advancedDelegate = object : AdvancedAttachAlert.AdvancedAttachAlertDelegate {
-            override fun onLocationSelected() {
-                if (!ensureCanSendMessageOrNotify()) return
-                requestLocationAndSend()
-            }
-            override fun onFilesSelected() {
-                if (!ensureCanSendMessageOrNotify()) return
-                launchDocumentPicker()
-            }
-            override fun onBuzzSelected() {
-                if (!ensureCanSendMessageOrNotify()) return
-                showBuzzConfirmDialog()
-            }
-            override fun onAnonymousToggled() {
-                anonymousController.toggleAnonymous(clanId)
-            }
-            override fun onCreatePollRequested() {
-                openCreatePollScreen()
-            }
-            override fun onShareContactSelected() {
-                if (!ensureCanSendMessageOrNotify()) return
-                presentFragment(
-                    ShareContactFragment.newInstance(channelId, clanId, channelType, resolveChannelPrivate())
-                )
-            }
+        
+        if (advancedMenuViewVisible) {
+            openKeyboardFromEmoji()
+            return
         }
-        alert.setDrawNavigationBar(true)
-        alert.show()
+
+        if (advancedMenuView == null) {
+            val ctx = getContext() ?: return
+            val isAnon = anonymousController.isAnonymous(clanId)
+            advancedMenuView = AdvancedMenuView(
+                ctx,
+                themeColors,
+                clanId,
+                isAnon,
+                showCreatePoll = canCreatePoll(channelType)
+            ).apply {
+                delegate = object : AdvancedMenuView.AdvancedMenuViewDelegate {
+                    override fun onLocationSelected() {
+                        if (!ensureCanSendMessageOrNotify()) return
+                        requestLocationAndSend()
+                    }
+                    override fun onFilesSelected() {
+                        if (!ensureCanSendMessageOrNotify()) return
+                        launchDocumentPicker()
+                    }
+                    override fun onBuzzSelected() {
+                        if (!ensureCanSendMessageOrNotify()) return
+                        showBuzzConfirmDialog()
+                    }
+                    override fun onAnonymousToggled() {
+                        anonymousController.toggleAnonymous(clanId)
+                    }
+                    override fun onCreatePollRequested() {
+                        openCreatePollScreen()
+                    }
+                    override fun onShareContactSelected() {
+                        if (!ensureCanSendMessageOrNotify()) return
+                        presentFragment(
+                            com.mezon.mobile.home.chat.ShareContactFragment.newInstance(channelId, clanId, channelType, resolveChannelPrivate())
+                        )
+                    }
+                    override fun onDragY(dy: Float) {
+                        advancedMenuView?.translationY = dy
+                    }
+                    override fun onAnimateExpand(expand: Boolean) {
+                        if (!expand) {
+                            hideAdvancedMenuView(animated = true)
+                        } else {
+                            advancedMenuView?.animate()
+                                ?.translationY(0f)
+                                ?.setDuration(250)
+                                ?.setInterpolator(android.view.animation.DecelerateInterpolator())
+                                ?.start()
+                        }
+                    }
+                }
+                visibility = View.GONE
+            }
+            rootView.addView(advancedMenuView, FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, 0, android.view.Gravity.BOTTOM))
+        }
+
+        val amv = advancedMenuView!!
+        amv.animate().cancel()
+        amv.translationY = 0f
+        amv.visibility = View.VISIBLE
+        advancedMenuViewVisible = true
+
+        val panelHeight = com.mezon.mobile.core.SharedConfig.getEmojiPanelHeight()
+        amv.layoutParams = FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT, panelHeight, android.view.Gravity.BOTTOM
+        )
+        
+        emojiPadding = panelHeight
+        sizeNotifierRoot.setEmojiKeyboardHeight(panelHeight)
+        sizeNotifierRoot.requestLayout()
+
+        amv.translationY = panelHeight.toFloat()
+        amv.animate()
+            .translationY(0f)
+            .setDuration(250)
+            .setInterpolator(android.view.animation.DecelerateInterpolator())
+            .start()
+
+        if (emojiViewVisible) {
+            hideEmojiView(animated = false, resetPadding = false)
+        } else {
+            AndroidUtilities.hideKeyboard(inputField)
+        }
     }
 
     private fun launchDocumentPicker() {

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
@@ -355,10 +355,10 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
     private var reactionChipBounds: ArrayList<RectF> = ArrayList()
     private var reactionChipBoundsCount: Int = 0
     private var reactionIsMyFlags: BooleanArray = BooleanArray(0)
+    private var reactionEmojiDrawables: Array<android.graphics.drawable.Drawable?> = emptyArray()
     private var reactionRowHeight = 0
     private var reactionRowContentWidth = 0f
     private val reactionChipRect = RectF()
-    private var reactionEmojiBitmaps: Array<android.graphics.Bitmap?> = emptyArray()
     private var reactionEmojiCancellables: Array<MezonImageLoader.Cancellable?> = emptyArray()
     private var reactionBitmapLoadToken = 0
     private val reactionAddBounds = RectF()
@@ -395,6 +395,13 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         ogpImage.onAttachedToWindow()
         linkInviteBlock.onAttachedToWindow()
         embedMessage.onAttachedToWindow()
+
+        reactionEmojiDrawables.forEach {
+            if (it is android.graphics.drawable.AnimatedImageDrawable) {
+                it.start()
+            }
+            it?.callback = this
+        }
         pendingMessage?.let { msg ->
             pendingMessage = null
             update(0, msg)
@@ -410,6 +417,13 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         ogpImage.onDetachedFromWindow()
         linkInviteBlock.onDetachedFromWindow()
         embedMessage.onDetachedFromWindow()
+        
+        reactionEmojiDrawables.forEach {
+            if (it is android.graphics.drawable.AnimatedImageDrawable) {
+                it.stop()
+            }
+            it?.callback = null
+        }
         topicButtonLayout.cancelAvatarLoad()
         avatarCancellable?.cancel()
         avatarCancellable = null
@@ -3671,7 +3685,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             reactionCountLayouts = emptyArray()
             reactionChipBoundsCount = 0
             reactionIsMyFlags = BooleanArray(0)
-            reactionEmojiBitmaps = emptyArray()
+            reactionEmojiDrawables = emptyArray()
             reactionEmojiCancellables = emptyArray()
             reactionRowHeight = 0
             reactionRowContentWidth = 0f
@@ -3684,7 +3698,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             reactionCountLayouts = emptyArray()
             reactionChipBoundsCount = 0
             reactionIsMyFlags = BooleanArray(0)
-            reactionEmojiBitmaps = emptyArray()
+            reactionEmojiDrawables = emptyArray()
             reactionEmojiCancellables = emptyArray()
             reactionRowHeight = 0
             reactionRowContentWidth = 0f
@@ -3705,7 +3719,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         reactionCountLayouts = countLayouts
 
         val loadToken = ++reactionBitmapLoadToken
-        val bitmaps = Array<android.graphics.Bitmap?>(groups.size) { null }
+        val drawables = Array<android.graphics.drawable.Drawable?>(groups.size) { null }
         val cancellables = Array<MezonImageLoader.Cancellable?>(groups.size) { null }
         val loader = MezonImageLoader.getInstance(context)
         var pendingLoads = 0
@@ -3717,28 +3731,34 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
 
         for (i in groups.indices) {
             val url = getEmojiUrl(groups[i].emojiId.toString()) ?: continue
-            val cached = loader.getBitmapFromMemory(url, REACTION_EMOJI_SIZE, REACTION_EMOJI_SIZE)
-            if (cached != null) {
-                bitmaps[i] = cached
+            val cachedBmp = loader.getBitmapFromMemory(url, REACTION_EMOJI_SIZE, REACTION_EMOJI_SIZE)
+            if (cachedBmp != null) {
+                val cached = android.graphics.drawable.BitmapDrawable(context.resources, cachedBmp)
+                drawables[i] = cached
+                cached.callback = this
                 continue
             }
             pendingLoads++
             val idx = i
             fun startLoad(loadUrl: String, isRetry: Boolean) {
-                cancellables[idx] = loader.load(loadUrl, REACTION_EMOJI_SIZE, REACTION_EMOJI_SIZE,
-                    onSuccess = { bmp ->
-                        if (loadToken != reactionBitmapLoadToken) return@load
-                        bitmaps[idx] = bmp
-                        reactionEmojiBitmaps = bitmaps
+                cancellables[idx] = loader.loadDrawable(loadUrl, REACTION_EMOJI_SIZE, REACTION_EMOJI_SIZE,
+                    onSuccess = { d ->
+                        if (loadToken != reactionBitmapLoadToken) return@loadDrawable
+                        drawables[idx] = d
+                        d.callback = this@ChatMessageCell
+                        if (d is android.graphics.drawable.AnimatedImageDrawable && attachedToWindow) {
+                            d.start()
+                        }
+                        reactionEmojiDrawables = drawables
                         finishOneLoad()
                     },
                     onError = {
-                        if (loadToken != reactionBitmapLoadToken) return@load
+                        if (loadToken != reactionBitmapLoadToken) return@loadDrawable
                         if (!isRetry) {
                             val direct = getEmojiDirectUrl(groups[idx].emojiId.toString())
                             if (direct != null && direct != loadUrl) {
                                 startLoad(direct, true)
-                                return@load
+                                return@loadDrawable
                             }
                         }
                         finishOneLoad()
@@ -3747,7 +3767,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             }
             startLoad(url, false)
         }
-        reactionEmojiBitmaps = bitmaps
+        reactionEmojiDrawables = drawables
         reactionEmojiCancellables = cancellables
 
         var x = 0f
@@ -3812,10 +3832,25 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
 
             val emojiX = chipX + REACTION_CHIP_PAD
             val emojiY = chipY + (REACTION_CHIP_H - REACTION_EMOJI_SIZE) / 2f
-            val bmp = reactionEmojiBitmaps.getOrNull(i)
-            if (bmp != null && !bmp.isRecycled) {
-                tmpRect.set(emojiX, emojiY, emojiX + REACTION_EMOJI_SIZE, emojiY + REACTION_EMOJI_SIZE)
-                canvas.drawBitmap(bmp, null, tmpRect, null)
+            val d = reactionEmojiDrawables.getOrNull(i)
+            if (d != null) {
+                val iw = d.intrinsicWidth.toFloat()
+                val ih = d.intrinsicHeight.toFloat()
+                var dw = REACTION_EMOJI_SIZE.toFloat()
+                var dh = REACTION_EMOJI_SIZE.toFloat()
+                if (iw > 0 && ih > 0) {
+                    val ratio = iw / ih
+                    dw = if (ratio > 1f) REACTION_EMOJI_SIZE.toFloat() else (REACTION_EMOJI_SIZE * ratio)
+                    dh = if (ratio < 1f) REACTION_EMOJI_SIZE.toFloat() else (REACTION_EMOJI_SIZE / ratio)
+                }
+                val dx = emojiX + (REACTION_EMOJI_SIZE - dw) / 2f
+                val dy = emojiY + (REACTION_EMOJI_SIZE - dh) / 2f
+
+                canvas.save()
+                canvas.translate(dx, dy)
+                d.setBounds(0, 0, dw.toInt(), dh.toInt())
+                d.draw(canvas)
+                canvas.restore()
             } else {
                 tmpRect.set(emojiX, emojiY, emojiX + REACTION_EMOJI_SIZE, emojiY + REACTION_EMOJI_SIZE)
                 REACTION_BG_PAINT.color = EMOJI_PLACEHOLDER_COLOR

--- a/app/src/main/java/com/mezon/mobile/home/chat/EmojiController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/EmojiController.kt
@@ -141,7 +141,7 @@ class EmojiController @Inject constructor(
     fun searchEmojis(query: String): List<EmojiItem> {
         val lower = query.lowercase()
         return synchronized(this) {
-            emojis.filter { it.shortname.lowercase().contains(lower) }
+            emojis.filter { it.shortname.lowercase().contains(lower) }.distinctBy { it.id }
         }
     }
 

--- a/app/src/main/java/com/mezon/mobile/home/chat/EmojiSpan.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/EmojiSpan.kt
@@ -32,8 +32,13 @@ class EmojiSpan(
         override fun invalidateDrawable(who: Drawable) {
             viewRef.get()?.invalidate()
         }
-        override fun scheduleDrawable(who: Drawable, what: Runnable, w: Long) {}
-        override fun unscheduleDrawable(who: Drawable, what: Runnable) {}
+        override fun scheduleDrawable(who: Drawable, what: Runnable, w: Long) {
+            val delay = w - android.os.SystemClock.uptimeMillis()
+            viewRef.get()?.postDelayed(what, maxOf(0L, delay))
+        }
+        override fun unscheduleDrawable(who: Drawable, what: Runnable) {
+            viewRef.get()?.removeCallbacks(what)
+        }
     }
 
     override fun getSize(

--- a/app/src/main/java/com/mezon/mobile/home/chat/EmojiSpan.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/EmojiSpan.kt
@@ -1,9 +1,10 @@
 package com.mezon.mobile.home.chat
 
-import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.RectF
+import android.graphics.drawable.AnimatedImageDrawable
+import android.graphics.drawable.Drawable
 import android.text.style.ReplacementSpan
 import android.view.View
 import com.mezon.mobile.core.LayoutHelper
@@ -11,21 +12,29 @@ import com.mezon.mobile.util.getEmojiDirectUrl
 import com.mezon.mobile.util.getEmojiUrl
 import java.lang.ref.WeakReference
 
-private val EMOJI_SIZE = LayoutHelper.dp(20)
 private val PLACEHOLDER_RADIUS = LayoutHelper.dp(4).toFloat()
 private const val PLACEHOLDER_COLOR = 0x1A000000
 
 class EmojiSpan(
     private val emojiId: String,
-    viewRef: WeakReference<View>
+    viewRef: WeakReference<View>,
+    private val size: Int = LayoutHelper.dp(20)
 ) : ReplacementSpan() {
 
     private val viewRef = viewRef
     @Volatile
-    private var bitmap: Bitmap? = null
+    private var drawable: Drawable? = null
     @Volatile
     private var loadStarted = false
     private var cancellable: MezonImageLoader.Cancellable? = null
+
+    private val drawableCallback = object : Drawable.Callback {
+        override fun invalidateDrawable(who: Drawable) {
+            viewRef.get()?.invalidate()
+        }
+        override fun scheduleDrawable(who: Drawable, what: Runnable, w: Long) {}
+        override fun unscheduleDrawable(who: Drawable, what: Runnable) {}
+    }
 
     override fun getSize(
         paint: Paint,
@@ -33,7 +42,19 @@ class EmojiSpan(
         start: Int,
         end: Int,
         fm: Paint.FontMetricsInt?
-    ): Int = EMOJI_SIZE
+    ): Int {
+        if (fm != null) {
+            val h = paint.fontMetricsInt.descent - paint.fontMetricsInt.ascent
+            if (h < size) {
+                val diff = (size - h) / 2
+                fm.ascent = paint.fontMetricsInt.ascent - diff
+                fm.descent = paint.fontMetricsInt.descent + diff
+                fm.top = fm.ascent
+                fm.bottom = fm.descent
+            }
+        }
+        return size
+    }
 
     override fun draw(
         canvas: Canvas,
@@ -46,15 +67,41 @@ class EmojiSpan(
         bottom: Int,
         paint: Paint
     ) {
-        val bmp = bitmap
-        if (bmp != null && !bmp.isRecycled) {
-            tmpRect.set(x, top.toFloat(), x + EMOJI_SIZE, bottom.toFloat())
-            canvas.drawBitmap(bmp, null, tmpRect, null)
+        val h = bottom - top
+        val cy = top + h / 2f
+        val topF = cy - size / 2f
+        val bottomF = cy + size / 2f
+
+        val d = drawable
+        if (d != null) {
+            if (d.callback != drawableCallback) {
+                d.callback = drawableCallback
+                if (d is AnimatedImageDrawable) {
+                    d.start()
+                }
+            }
+            val iw = d.intrinsicWidth.toFloat()
+            val ih = d.intrinsicHeight.toFloat()
+            var dw = size
+            var dh = size
+            if (iw > 0 && ih > 0) {
+                val ratio = iw / ih
+                dw = if (ratio > 1f) size else (size * ratio).toInt()
+                dh = if (ratio < 1f) size else (size / ratio).toInt()
+            }
+            val dx = x + (size - dw) / 2f
+            val dy = topF + (size - dh) / 2f
+
+            canvas.save()
+            canvas.translate(dx, dy)
+            d.setBounds(0, 0, dw, dh)
+            d.draw(canvas)
+            canvas.restore()
             return
         }
 
         if (loadStarted) {
-            drawPlaceholder(canvas, x, top, bottom)
+            drawPlaceholder(canvas, x, topF.toInt(), bottomF.toInt())
             return
         }
 
@@ -62,20 +109,22 @@ class EmojiSpan(
         val view = viewRef.get() ?: return
         val loader = MezonImageLoader.getInstance(view.context)
 
-        val cached = loader.getBitmapFromMemory(url, EMOJI_SIZE, EMOJI_SIZE)
-        if (cached != null) {
-            bitmap = cached
-            tmpRect.set(x, top.toFloat(), x + EMOJI_SIZE, bottom.toFloat())
-            canvas.drawBitmap(cached, null, tmpRect, null)
-            return
-        }
-        drawPlaceholder(canvas, x, top, bottom)
+        drawPlaceholder(canvas, x, topF.toInt(), bottomF.toInt())
         loadStarted = true
-        cancellable = loader.load(
-            url, EMOJI_SIZE, EMOJI_SIZE,
+        
+        fun applyDrawable(loaded: Drawable) {
+            drawable = loaded
+            loaded.callback = drawableCallback
+            if (loaded is AnimatedImageDrawable) {
+                loaded.start()
+            }
+            viewRef.get()?.invalidate()
+        }
+
+        cancellable = loader.loadDrawable(
+            url, size, size,
             onSuccess = { loaded ->
-                bitmap = loaded
-                viewRef.get()?.invalidate()
+                applyDrawable(loaded)
             },
             onError = outerErr@{
                 val direct = getEmojiDirectUrl(emojiId) ?: run {
@@ -86,11 +135,10 @@ class EmojiSpan(
                     viewRef.get()?.invalidate()
                     return@outerErr
                 }
-                cancellable = loader.load(
-                    direct, EMOJI_SIZE, EMOJI_SIZE,
-                    onSuccess = { bmp2 ->
-                        bitmap = bmp2
-                        viewRef.get()?.invalidate()
+                cancellable = loader.loadDrawable(
+                    direct, size, size,
+                    onSuccess = { d2 ->
+                        applyDrawable(d2)
                     },
                     onError = { viewRef.get()?.invalidate() }
                 )
@@ -100,19 +148,23 @@ class EmojiSpan(
 
     private fun drawPlaceholder(canvas: Canvas, x: Float, top: Int, bottom: Int) {
         placeholderPaint.color = PLACEHOLDER_COLOR
-        placeholderRect.set(x, top.toFloat(), x + EMOJI_SIZE, bottom.toFloat())
-        canvas.drawRoundRect(placeholderRect, PLACEHOLDER_RADIUS, PLACEHOLDER_RADIUS, placeholderPaint)
+        tmpRect.set(x, top.toFloat(), x + size, bottom.toFloat())
+        canvas.drawRoundRect(tmpRect, PLACEHOLDER_RADIUS, PLACEHOLDER_RADIUS, placeholderPaint)
     }
 
     fun cancelLoad() {
         cancellable?.cancel()
         cancellable = null
         loadStarted = false
+        val d = drawable
+        if (d is AnimatedImageDrawable) {
+            d.stop()
+        }
+        d?.callback = null
     }
 
     companion object {
         private val placeholderPaint = Paint(Paint.ANTI_ALIAS_FLAG)
-        private val placeholderRect = RectF()
         private val tmpRect = RectF()
     }
 }

--- a/app/src/main/java/com/mezon/mobile/home/chat/MezonImageLoader.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/MezonImageLoader.kt
@@ -473,7 +473,17 @@ class MezonImageLoader private constructor(context: Context) {
                                 }
                             }
                         } else {
-                            decoder.setTargetSize(reqWidth, reqHeight)
+                            val w = info.size.width
+                            val h = info.size.height
+                            if (w > 0 && h > 0) {
+                                val scale = kotlin.math.min(reqWidth.toFloat() / w, reqHeight.toFloat() / h)
+                                decoder.setTargetSize(
+                                    (w * scale).toInt().coerceAtLeast(1),
+                                    (h * scale).toInt().coerceAtLeast(1)
+                                )
+                            } else {
+                                decoder.setTargetSize(reqWidth, reqHeight)
+                            }
                         }
                     }
                     dispatchSuccess(cacheKey, drawable)

--- a/app/src/main/java/com/mezon/mobile/home/chat/ReactionDetailBottomSheet.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ReactionDetailBottomSheet.kt
@@ -152,9 +152,12 @@ class ReactionDetailBottomSheet(
             val emojiSize = LayoutHelper.dp(24)
             if (url != null) {
                 fun loadTabEmoji(loadUrl: String, isRetry: Boolean) {
-                    loader.load(loadUrl, emojiSize, emojiSize,
-                        onSuccess = { bmp ->
-                            emojiIv.setImageBitmap(bmp)
+                    loader.loadDrawable(loadUrl, emojiSize, emojiSize,
+                        onSuccess = { drawable ->
+                            emojiIv.setImageDrawable(drawable)
+                            if (drawable is android.graphics.drawable.AnimatedImageDrawable) {
+                                drawable.start()
+                            }
                         },
                         onError = {
                             if (!isRetry) {

--- a/app/src/main/java/com/mezon/mobile/home/chat/UserProfileBottomSheet.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/UserProfileBottomSheet.kt
@@ -26,6 +26,8 @@ import com.mezon.mobile.ui.cells.MezonIcon
 import com.mezon.mobile.ui.theme.ThemeMode
 import com.mezon.mobile.util.ColorUtilities
 import com.mezon.mobile.util.avatarImgproxyUrl
+import com.mezon.mobile.di.FragmentEntryPoint
+import dagger.hilt.android.EntryPointAccessors
 
 
 class UserProfileBottomSheet(
@@ -52,8 +54,6 @@ class UserProfileBottomSheet(
     }
 
     data class VoiceParticipantExtras(
-        val showHeaderActions: Boolean,
-        val onFriendClick: () -> Unit,
         val onTransferClick: () -> Unit = {},
         val canManageVoiceUser: Boolean,
         val showMuteAction: Boolean,
@@ -234,14 +234,10 @@ class UserProfileBottomSheet(
             FrameLayout.LayoutParams.MATCH_PARENT, LayoutHelper.dp(120)
         ))
 
-        voiceParticipantExtras?.takeIf { it.showHeaderActions }?.let { ex ->
-            addHeaderFriendButton(container, textColor, ex.onFriendClick)
-        }
-
         if (!isOwnProfile && !isWebhook && userId != 0L) {
             addHeaderTransferButton(
                 container = container,
-                marginEndDp = if (voiceParticipantExtras?.showHeaderActions == true) 50 else 10,
+                marginEndDp = 10,
                 onClick = {
                     dismiss()
                     val l = listener
@@ -280,37 +276,6 @@ class UserProfileBottomSheet(
         )
 
         return container
-    }
-
-    private fun addHeaderFriendButton(
-        container: FrameLayout,
-        iconTint: Int,
-        onClick: () -> Unit
-    ) {
-        val friendBtn = ImageView(context).apply {
-            scaleType = ImageView.ScaleType.CENTER_INSIDE
-            setImageDrawable(MezonIcon.userPlusIcon.getDrawable(context).apply {
-                colorFilter = PorterDuffColorFilter(iconTint, PorterDuff.Mode.SRC_IN)
-            })
-            background = GradientDrawable().apply {
-                shape = GradientDrawable.OVAL
-                setColor(theme.serverRailBg)
-            }
-            setPadding(LayoutHelper.dp(6), LayoutHelper.dp(6), LayoutHelper.dp(6), LayoutHelper.dp(6))
-            isClickable = true
-            isFocusable = true
-            setOnClickListener {
-                dismiss()
-                onClick()
-            }
-        }
-        container.addView(
-            friendBtn,
-            FrameLayout.LayoutParams(LayoutHelper.dp(32), LayoutHelper.dp(32), Gravity.TOP or Gravity.END).apply {
-                topMargin = LayoutHelper.dp(10)
-                marginEnd = LayoutHelper.dp(10)
-            }
-        )
     }
 
     private fun addHeaderTransferButton(
@@ -405,7 +370,7 @@ class UserProfileBottomSheet(
             ))
         }
 
-        if (voiceParticipantExtras == null && userId != 0L) {
+        if (userId != 0L) {
             val actionsRow = LinearLayout(context).apply {
                 orientation = LinearLayout.HORIZONTAL
             }
@@ -439,16 +404,23 @@ class UserProfileBottomSheet(
                     LinearLayout.LayoutParams.WRAP_CONTENT
                 ).apply { rightMargin = LayoutHelper.dp(14) })
 
-                actionsRow.addView(buildActionButton(
-                    context.getString(R.string.user_profile_add_friend),
-                    R.drawable.ic_user_plus_icon,
-                    0xFF42A869.toInt()  // baseColor.green
-                ) {
-                    dismiss()
-                    val l = listener
-                    if (l != null) l.onAddFriend(userId)
-                    else Toast.makeText(context, R.string.feature_coming_soon, Toast.LENGTH_SHORT).show()
-                })
+                val entryPoint = EntryPointAccessors.fromApplication(context.applicationContext, FragmentEntryPoint::class.java)
+                val friendController = entryPoint.friendController()
+                
+                if (friendController.findFriendByUserId(userId) == null) {
+                    var addFriendBtn: LinearLayout? = null
+                    addFriendBtn = buildActionButton(
+                        context.getString(R.string.user_profile_add_friend),
+                        R.drawable.ic_user_plus_icon,
+                        0xFF42A869.toInt()  // baseColor.green
+                    ) {
+                        addFriendBtn?.visibility = View.GONE
+                        val l = listener
+                        if (l != null) l.onAddFriend(userId)
+                        else Toast.makeText(context, R.string.feature_coming_soon, Toast.LENGTH_SHORT).show()
+                    }
+                    actionsRow.addView(addFriendBtn)
+                }
             }
 
             card.addView(actionsRow, LinearLayout.LayoutParams(

--- a/app/src/main/java/com/mezon/mobile/home/chat/emoji/EmojiCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/emoji/EmojiCell.kt
@@ -139,24 +139,48 @@ class EmojiCell(context: Context, private val themeColors: ThemeColors) : BaseCe
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        setMeasuredDimension(CELL_SIZE, CELL_SIZE)
+        val specMode = MeasureSpec.getMode(widthMeasureSpec)
+        val w = if (specMode == MeasureSpec.EXACTLY) MeasureSpec.getSize(widthMeasureSpec) else CELL_SIZE
+        setMeasuredDimension(w, w)
     }
 
     override fun onDraw(canvas: Canvas) {
-        val left = (measuredWidth - IMAGE_SIZE) / 2
-        val top = (measuredHeight - IMAGE_SIZE) / 2
-
         val d = animDrawable
+        val bmp = bitmap
+        
+        var imgW = IMAGE_SIZE
+        var imgH = IMAGE_SIZE
+        
+        if (d != null) {
+            val iw = d.intrinsicWidth.toFloat()
+            val ih = d.intrinsicHeight.toFloat()
+            if (iw > 0 && ih > 0) {
+                val ratio = iw / ih
+                imgW = if (ratio > 1f) IMAGE_SIZE else (IMAGE_SIZE * ratio).toInt()
+                imgH = if (ratio < 1f) IMAGE_SIZE else (IMAGE_SIZE / ratio).toInt()
+            }
+        } else if (bmp != null) {
+            val iw = bmp.width.toFloat()
+            val ih = bmp.height.toFloat()
+            if (iw > 0 && ih > 0) {
+                val ratio = iw / ih
+                imgW = if (ratio > 1f) IMAGE_SIZE else (IMAGE_SIZE * ratio).toInt()
+                imgH = if (ratio < 1f) IMAGE_SIZE else (IMAGE_SIZE / ratio).toInt()
+            }
+        }
+
+        val left = (measuredWidth - imgW) / 2
+        val top = (measuredHeight - imgH) / 2
+
         if (d != null) {
             canvas.save()
             canvas.translate(left.toFloat(), top.toFloat())
-            d.setBounds(0, 0, IMAGE_SIZE, IMAGE_SIZE)
+            d.setBounds(0, 0, imgW, imgH)
             d.draw(canvas)
             canvas.restore()
-        } else {
-            val bmp = bitmap ?: return
+        } else if (bmp != null) {
             srcRect.set(0, 0, bmp.width, bmp.height)
-            dstRect.set(left, top, left + IMAGE_SIZE, top + IMAGE_SIZE)
+            dstRect.set(left, top, left + imgW, top + imgH)
             canvas.drawBitmap(bmp, srcRect, dstRect, bitmapPaint)
         }
 
@@ -167,8 +191,8 @@ class EmojiCell(context: Context, private val themeColors: ThemeColors) : BaseCe
                     lockDrawable = it
                 }
             }
-            val lx = left + IMAGE_SIZE - LOCK_SIZE - LOCK_PAD
-            val ly = top + IMAGE_SIZE - LOCK_SIZE - LOCK_PAD
+            val lx = left + imgW - LOCK_SIZE - LOCK_PAD
+            val ly = top + imgH - LOCK_SIZE - LOCK_PAD
             ld.setBounds(lx, ly, lx + LOCK_SIZE, ly + LOCK_SIZE)
             ld.draw(canvas)
         }
@@ -180,6 +204,20 @@ class EmojiCell(context: Context, private val themeColors: ThemeColors) : BaseCe
             d.stop()
         }
         d?.callback = null
+    }
+
+    private fun restartAnimation() {
+        val d = animDrawable ?: return
+        d.callback = drawableCallback
+        if (d is android.graphics.drawable.AnimatedImageDrawable && !d.isRunning) {
+            d.start()
+        }
+        invalidate()
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        restartAnimation()
     }
 
     override fun onDetachedFromWindow() {

--- a/app/src/main/java/com/mezon/mobile/home/chat/emoji/EmojiView.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/emoji/EmojiView.kt
@@ -56,6 +56,10 @@ class EmojiView(
         fun onBackspace()
         fun onSearchFocusChanged(focused: Boolean) {}
         fun onDismissRequested() {}
+        fun onExpandRequested() {}
+        fun onDragY(dy: Float, dragFromExpanded: Boolean = false) {}
+        fun onAnimateExpand(expand: Boolean) {}
+        fun isExpanded(): Boolean = false
     }
 
     var delegate: EmojiViewDelegate? = null
@@ -73,6 +77,11 @@ class EmojiView(
     private val contentContainer: FrameLayout
     private val backspaceButton: ImageView
 
+    private var dragStartY = 0f
+    private var dragging = false
+    private var dragTranslation = 0f
+    private var dragStartedExpanded = false
+    private var velocityTracker: VelocityTracker? = null
     private var emojiGrid: RecyclerListView? = null
     private var stickerGrid: RecyclerListView? = null
     private var gifGrid: RecyclerListView? = null
@@ -97,10 +106,6 @@ class EmojiView(
         }
     }
 
-    private var velocityTracker: VelocityTracker? = null
-    private var dragging = false
-    private var dragStartY = 0f
-    private var dragTranslation = 0f
     private val touchSlop = ViewConfiguration.get(context).scaledTouchSlop
     private val dismissVelocity = LayoutHelper.dp(800f).toFloat()
 
@@ -359,10 +364,10 @@ class EmojiView(
                         delegate?.onGifSelected(gif.gifUrl)
                     }
                     gifGrid = RecyclerListView(context).apply {
-                        layoutManager = GridLayoutManager(context, 2)
+                        layoutManager = androidx.recyclerview.widget.StaggeredGridLayoutManager(2, androidx.recyclerview.widget.StaggeredGridLayoutManager.VERTICAL)
                         adapter = gifAdapter
-                        setHasFixedSize(true)
-                        (itemAnimator as? SimpleItemAnimator)?.supportsChangeAnimations = false
+                        setHasFixedSize(false)
+                        (itemAnimator as? androidx.recyclerview.widget.SimpleItemAnimator)?.supportsChangeAnimations = false
                         overScrollMode = OVER_SCROLL_NEVER
                         addItemDecoration(GifSpacingDecoration(gifSpacing))
                         setPadding(gifSpacing, gifSpacing, gifSpacing, gifSpacing)
@@ -478,12 +483,22 @@ class EmojiView(
 
     val isSearchFocused: Boolean get() = searchField.hasFocus()
 
+    private fun getActiveRecyclerView(): androidx.recyclerview.widget.RecyclerView? {
+        return when (currentTab) {
+            TAB_EMOJI -> emojiGrid
+            TAB_GIF -> if (gifSearchActive) gifGrid else gifCategoryGrid
+            TAB_STICKER -> stickerGrid
+            else -> null
+        }
+    }
+
     override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
         when (ev.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
                 dragStartY = ev.rawY
                 dragTranslation = 0f
                 dragging = false
+                dragStartedExpanded = delegate?.isExpanded() ?: false
                 velocityTracker?.recycle()
                 velocityTracker = VelocityTracker.obtain()
                 velocityTracker?.addMovement(ev)
@@ -492,10 +507,27 @@ class EmojiView(
             MotionEvent.ACTION_MOVE -> {
                 velocityTracker?.addMovement(ev)
                 val dy = ev.rawY - dragStartY
-                if (!dragging && dy > touchSlop && ev.y < DRAG_HANDLE_HEIGHT + tabBar.height) {
-                    dragging = true
-                    dragStartY = ev.rawY
-                    return true
+                if (!dragging && Math.abs(dy) > touchSlop) {
+                    var shouldIntercept = false
+                    if (dy > 0) {
+                        if (ev.y < DRAG_HANDLE_HEIGHT + tabBar.height) {
+                            shouldIntercept = true
+                        } else {
+                            val rv = getActiveRecyclerView()
+                            if (rv == null || !rv.canScrollVertically(-1)) {
+                                shouldIntercept = true
+                            }
+                        }
+                    } else {
+                        if (!dragStartedExpanded) {
+                            shouldIntercept = true
+                        }
+                    }
+                    if (shouldIntercept) {
+                        dragging = true
+                        dragStartY = ev.rawY
+                        return true
+                    }
                 }
             }
         }
@@ -507,18 +539,30 @@ class EmojiView(
         when (ev.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
                 dragStartY = ev.rawY
+                dragStartedExpanded = delegate?.isExpanded() ?: false
                 return true
             }
             MotionEvent.ACTION_MOVE -> {
-                val dy = (ev.rawY - dragStartY).coerceAtLeast(0f)
-                if (!dragging && dy > touchSlop) {
+                val dy = ev.rawY - dragStartY
+                if (!dragging && Math.abs(dy) > touchSlop) {
                     dragging = true
                     dragStartY = ev.rawY
                 }
                 if (dragging) {
-                    dragTranslation = (ev.rawY - dragStartY).coerceAtLeast(0f)
+                    dragTranslation = ev.rawY - dragStartY
                     val child = getChildAt(0)
-                    child?.translationY = dragTranslation
+                    if (dragTranslation > 0) {
+                        if (dragStartedExpanded) {
+                            child?.translationY = 0f
+                            delegate?.onDragY(dragTranslation, true)
+                        } else {
+                            child?.translationY = dragTranslation
+                            delegate?.onDragY(0f, false)
+                        }
+                    } else {
+                        child?.translationY = 0f
+                        delegate?.onDragY(dragTranslation, dragStartedExpanded)
+                    }
                 }
                 return true
             }
@@ -529,10 +573,26 @@ class EmojiView(
                     val vy = velocityTracker?.yVelocity ?: 0f
                     val child = getChildAt(0) ?: return true
                     val h = child.height.toFloat()
-                    if (vy > dismissVelocity || dragTranslation > h * 0.4f) {
-                        animateSlide(child, dragTranslation, h, dismiss = true)
+                    if (dragTranslation > 0) {
+                        if (dragStartedExpanded || child.translationY == 0f) {
+                            if (vy > dismissVelocity || dragTranslation > h * 0.2f) {
+                                delegate?.onAnimateExpand(false)
+                            } else {
+                                delegate?.onAnimateExpand(true)
+                            }
+                        } else {
+                            if (vy > dismissVelocity || dragTranslation > h * 0.4f) {
+                                animateSlide(child, dragTranslation, h, dismiss = true)
+                            } else {
+                                animateSlide(child, dragTranslation, 0f, dismiss = false)
+                            }
+                        }
                     } else {
-                        animateSlide(child, dragTranslation, 0f, dismiss = false)
+                        if (vy < -dismissVelocity || dragTranslation < -h * 0.2f) {
+                            delegate?.onAnimateExpand(true)
+                        } else {
+                            delegate?.onAnimateExpand(false)
+                        }
                     }
                 }
                 velocityTracker?.recycle()

--- a/app/src/main/java/com/mezon/mobile/home/chat/emoji/EmojiView.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/emoji/EmojiView.kt
@@ -366,7 +366,7 @@ class EmojiView(
                     gifGrid = RecyclerListView(context).apply {
                         layoutManager = androidx.recyclerview.widget.StaggeredGridLayoutManager(2, androidx.recyclerview.widget.StaggeredGridLayoutManager.VERTICAL)
                         adapter = gifAdapter
-                        setHasFixedSize(false)
+                        setHasFixedSize(true)
                         (itemAnimator as? androidx.recyclerview.widget.SimpleItemAnimator)?.supportsChangeAnimations = false
                         overScrollMode = OVER_SCROLL_NEVER
                         addItemDecoration(GifSpacingDecoration(gifSpacing))

--- a/app/src/main/java/com/mezon/mobile/home/chat/emoji/GifCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/emoji/GifCell.kt
@@ -48,8 +48,13 @@ class GifCell(context: Context, private val themeColors: ThemeColors) : View(con
         gif = item
 
         val reqW = if (measuredWidth > 0) measuredWidth else LayoutHelper.dp(170f)
+        var reqH = CELL_HEIGHT
+        if (item.width > 0 && item.height > 0) {
+            reqH = (reqW * item.height.toFloat() / item.width.toFloat()).toInt()
+        }
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && !SharedConfig.deviceIsLow()) {
-            cancellable = loader.loadDrawable(item.thumbnailUrl, reqW, CELL_HEIGHT,
+            cancellable = loader.loadDrawable(item.thumbnailUrl, reqW, reqH,
                 onSuccess = { d ->
                     animDrawable = d
                     d.callback = drawableCallback
@@ -57,11 +62,12 @@ class GifCell(context: Context, private val themeColors: ThemeColors) : View(con
                     invalidate()
                 })
         } else {
-            cancellable = loader.load(item.thumbnailUrl, reqW, CELL_HEIGHT, onSuccess = { bmp ->
+            cancellable = loader.load(item.thumbnailUrl, reqW, reqH, onSuccess = { bmp ->
                 animDrawable = android.graphics.drawable.BitmapDrawable(resources, bmp)
                 invalidate()
             })
         }
+        requestLayout()
         invalidate()
     }
 
@@ -72,7 +78,12 @@ class GifCell(context: Context, private val themeColors: ThemeColors) : View(con
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         val width = MeasureSpec.getSize(widthMeasureSpec)
-        setMeasuredDimension(width, CELL_HEIGHT)
+        var height = CELL_HEIGHT
+        val g = gif
+        if (g != null && g.width > 0 && g.height > 0) {
+            height = (width * g.height.toFloat() / g.width.toFloat()).toInt()
+        }
+        setMeasuredDimension(width, height)
     }
 
     override fun onDraw(canvas: Canvas) {

--- a/app/src/main/java/com/mezon/mobile/home/chat/emoji/GifCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/emoji/GifCell.kt
@@ -45,6 +45,7 @@ class GifCell(context: Context, private val themeColors: ThemeColors) : View(con
         stopAnimation()
         cancellable?.cancel()
         animDrawable = null
+        val oldGif = gif
         gif = item
 
         val reqW = if (measuredWidth > 0) measuredWidth else LayoutHelper.dp(170f)
@@ -67,7 +68,10 @@ class GifCell(context: Context, private val themeColors: ThemeColors) : View(con
                 invalidate()
             })
         }
-        requestLayout()
+        
+        if (oldGif == null || oldGif.width != item.width || oldGif.height != item.height) {
+            requestLayout()
+        }
         invalidate()
     }
 

--- a/app/src/main/java/com/mezon/mobile/home/chat/input/InputSuggestionsController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/input/InputSuggestionsController.kt
@@ -140,6 +140,7 @@ object InputSuggestionsController {
         val sLower = keyword.trim().lowercase()
         val filtered = emojis.asSequence()
             .filter { it.shortname.lowercase().contains(sLower) }
+            .distinctBy { it.id }
             .take(20)
             .toList()
         return filtered.map { InputSuggestionItem.Emoji(it) }

--- a/app/src/main/java/com/mezon/mobile/home/friends/FriendController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/friends/FriendController.kt
@@ -329,6 +329,9 @@ class FriendController @Inject constructor(
     fun isUserBlocked(userId: Long): Boolean =
         _blockedUsers.value.any { it.user.id == userId }
 
+    fun isFriend(userId: Long): Boolean =
+        _friends.value.any { it.user.id == userId }
+
     fun cleanup() {
         _blockedUsers.value = emptyList()
         _friends.value = emptyList()

--- a/app/src/main/java/com/mezon/mobile/home/voice/VoiceRoomFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/voice/VoiceRoomFragment.kt
@@ -38,7 +38,12 @@ import com.mezon.mobile.home.clans.CHANNEL_TYPE_VOICE
 import com.mezon.mobile.home.clans.ChannelController
 import com.mezon.mobile.home.clans.ClansController
 import com.mezon.mobile.home.clans.PermissionPolicy
+import com.mezon.mobile.home.DialogsController
+import com.mezon.mobile.home.friends.FriendController
+import com.mezon.mobile.network.CHANNEL_TYPE_DM
 import com.mezon.mobile.home.profile.UserController
+import com.mezon.mobile.ui.MezonToast
+import com.mezon.mobile.ui.cells.ToastOverlay
 import com.mezon.mobile.ui.cells.MezonIcon
 import io.livekit.android.AudioOptions
 import io.livekit.android.LiveKit
@@ -98,6 +103,8 @@ class VoiceRoomFragment : BaseFragment() {
     private lateinit var memberResolver: MemberResolver
     private lateinit var emojiController: EmojiController
     private lateinit var userController: UserController
+    private lateinit var dialogsController: DialogsController
+    private lateinit var friendController: FriendController
     private lateinit var permissionPolicy: PermissionPolicy
     private var channelId: Long = 0L
     private var clanId: Long = 0L
@@ -290,6 +297,8 @@ class VoiceRoomFragment : BaseFragment() {
         memberResolver = entryPoint.memberResolver()
         emojiController = entryPoint.emojiController()
         userController = entryPoint.userController()
+        dialogsController = entryPoint.dialogsController()
+        friendController = entryPoint.friendController()
         permissionPolicy = entryPoint.permissionPolicy()
     }
 
@@ -1457,12 +1466,40 @@ class VoiceRoomFragment : BaseFragment() {
                         }.ifBlank { participantSubline }.ifBlank { displayName }
                         openProfileTransferFunds(userId, transferUsername)
                     }
+
+                    override fun onSendMessage(userId: Long) {
+                        fragmentScope.launch {
+                            val dmId = withContext(Dispatchers.IO) { dialogsController.getOrCreateDm(userId) }
+                            withContext(Dispatchers.Main) {
+                                if (dmId != 0L) {
+                                    getMainActivity()?.openChat(dmId, displayName.ifBlank { participantSubline }, 0L, CHANNEL_TYPE_DM)
+                                    dismissOverlay()
+                                } else {
+                                    MezonToast.show(this@VoiceRoomFragment, ToastOverlay.ToastType.ERROR, getString(R.string.contact_shared_error))
+                                }
+                            }
+                        }
+                    }
+
+                    override fun onVoiceCall(userId: Long) {
+                        MezonToast.show(this@VoiceRoomFragment, ToastOverlay.ToastType.ERROR, getString(R.string.cannot_start_voice_call_while_in_room))
+                    }
+
+                    override fun onAddFriend(userId: Long) {
+                        if (userId == 0L || userId == userController.userId) return
+                        if (friendController.isUserBlocked(userId)) {
+                            MezonToast.show(this@VoiceRoomFragment, ToastOverlay.ToastType.ERROR, getString(R.string.friend_unblock_first))
+                            return
+                        }
+                        val username = participantSubline.ifBlank { displayName }
+                        friendController.sendFriendRequest(userId, username) { success ->
+                            if (success) {
+                                MezonToast.show(this@VoiceRoomFragment, ToastOverlay.ToastType.SUCCESS, getString(R.string.friend_request_sent_success, username))
+                            }
+                        }
+                    }
                 },
                 voiceParticipantExtras = UserProfileBottomSheet.VoiceParticipantExtras(
-                    showHeaderActions = showHeaderActions,
-                    onFriendClick = {
-                        showAddFriendBottomSheet()
-                    },
                     canManageVoiceUser = canManageVoiceUser,
                     showMuteAction = showMuteAction,
                     onMuteAction = { showMuteParticipantConfirm(identity, displayName) },

--- a/app/src/main/java/com/mezon/mobile/home/voice/VoiceRoomFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/voice/VoiceRoomFragment.kt
@@ -41,7 +41,6 @@ import com.mezon.mobile.home.clans.ChannelController
 import com.mezon.mobile.home.clans.ClansController
 import com.mezon.mobile.home.clans.PermissionPolicy
 import com.mezon.mobile.home.DialogsController
-import com.mezon.mobile.home.friends.FriendController
 import com.mezon.mobile.network.CHANNEL_TYPE_DM
 import com.mezon.mobile.home.profile.UserController
 import com.mezon.mobile.ui.MezonToast
@@ -108,7 +107,6 @@ class VoiceRoomFragment : BaseFragment() {
     private lateinit var dialogsController: DialogsController
     private lateinit var friendController: FriendController
     private lateinit var permissionPolicy: PermissionPolicy
-    private lateinit var friendController: FriendController
     private var channelId: Long = 0L
     private var clanId: Long = 0L
     private var channelLabel: String = ""
@@ -303,7 +301,6 @@ class VoiceRoomFragment : BaseFragment() {
         dialogsController = entryPoint.dialogsController()
         friendController = entryPoint.friendController()
         permissionPolicy = entryPoint.permissionPolicy()
-        friendController = entryPoint.friendController()
     }
 
     override fun onFragmentCreate(): Boolean {
@@ -1484,24 +1481,6 @@ class VoiceRoomFragment : BaseFragment() {
                                 } else {
                                     MezonToast.show(this@VoiceRoomFragment, ToastOverlay.ToastType.ERROR, getString(R.string.contact_shared_error))
                                 }
-                            }
-                        }
-                    }
-
-                    override fun onVoiceCall(userId: Long) {
-                        MezonToast.show(this@VoiceRoomFragment, ToastOverlay.ToastType.ERROR, getString(R.string.cannot_start_voice_call_while_in_room))
-                    }
-
-                    override fun onAddFriend(userId: Long) {
-                        if (userId == 0L || userId == userController.userId) return
-                        if (friendController.isUserBlocked(userId)) {
-                            MezonToast.show(this@VoiceRoomFragment, ToastOverlay.ToastType.ERROR, getString(R.string.friend_unblock_first))
-                            return
-                        }
-                        val username = participantSubline.ifBlank { displayName }
-                        friendController.sendFriendRequest(userId, username) { success ->
-                            if (success) {
-                                MezonToast.show(this@VoiceRoomFragment, ToastOverlay.ToastType.SUCCESS, getString(R.string.friend_request_sent_success, username))
                             }
                         }
                     }

--- a/app/src/main/java/com/mezon/mobile/ui/cells/InputSuggestionCell.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/cells/InputSuggestionCell.kt
@@ -146,8 +146,23 @@ class InputSuggestionCell(
                 val ix = slotLeft + (SLOT - iconSize) / 2
                 val iy = slotTop + (SLOT - iconSize) / 2
                 leadingDrawable?.let { d ->
-                    d.setBounds(ix, iy, ix + iconSize, iy + iconSize)
+                    val iw = d.intrinsicWidth.toFloat()
+                    val ih = d.intrinsicHeight.toFloat()
+                    var dw = iconSize
+                    var dh = iconSize
+                    if (iw > 0 && ih > 0) {
+                        val ratio = iw / ih
+                        dw = if (ratio > 1f) iconSize else (iconSize * ratio).toInt()
+                        dh = if (ratio < 1f) iconSize else (iconSize / ratio).toInt()
+                    }
+                    val dx = ix + (iconSize - dw) / 2f
+                    val dy = iy + (iconSize - dh) / 2f
+
+                    canvas.save()
+                    canvas.translate(dx, dy)
+                    d.setBounds(0, 0, dw, dh)
                     d.draw(canvas)
+                    canvas.restore()
                 }
             }
             LEADING_BITMAP -> {
@@ -259,7 +274,7 @@ class InputSuggestionCell(
             leadingDrawable = MezonIcon.shieldUserIcon.getDrawable(context).apply {
                 colorFilter = PorterDuffColorFilter(color, PorterDuff.Mode.SRC_IN)
             }
-            loadLeadingBitmap(role.iconUrl, 20)
+            loadLeadingDrawable(role.iconUrl, 20)
         }
     }
 
@@ -283,13 +298,13 @@ class InputSuggestionCell(
     private fun configureEmoji(emoji: EmojiItem) {
         cancelImage()
         showLeadingSlot = true
-        leadingMode = LEADING_BITMAP
+        leadingMode = LEADING_ICON
         setLeadingEffectiveDp(22)
         leadingDrawable = null
         namePaint.color = theme.onSurface
         subPaint.color = theme.textDisabled
         val url = emoji.src.ifBlank { getEmojiUrl(emoji.id) ?: "" }
-        if (url.isNotBlank()) loadLeadingBitmap(url, 22)
+        if (url.isNotBlank()) loadLeadingDrawable(url, 22)
     }
 
     private fun refreshTextColors() {
@@ -322,24 +337,23 @@ class InputSuggestionCell(
         })
     }
 
-    private fun loadLeadingBitmap(url: String, effectiveDp: Int) {
+    private fun loadLeadingDrawable(url: String, effectiveDp: Int) {
         if (url.isBlank()) return
         val size = LayoutHelper.dp(effectiveDp.toFloat())
         currentImageUrl = url
         val loader = MezonImageLoader.getInstance(context)
-        val cached = loader.getBitmapFromMemory(url, size, size)
-        if (cached != null) {
-            leadingBitmap = cached
-            leadingMode = LEADING_BITMAP
-            invalidate()
-            return
-        }
-        imageDisposable = loader.load(url, size, size, onSuccess = { bmp ->
+        imageDisposable = loader.loadDrawable(url, size, size, onSuccess = { drawable ->
             if (currentImageUrl == url) {
-                leadingBitmap = bmp
-                leadingMode = LEADING_BITMAP
+                leadingDrawable = drawable
+                drawable.callback = this@InputSuggestionCell
+                if (drawable is android.graphics.drawable.AnimatedImageDrawable) {
+                    drawable.start()
+                }
+                leadingMode = LEADING_ICON
                 invalidate()
             }
+        }, onError = {
+            // fallback logic can be added here if needed
         })
     }
 
@@ -350,6 +364,12 @@ class InputSuggestionCell(
         imageDisposable?.cancel()
         imageDisposable = null
         leadingBitmap = null
+        val d = leadingDrawable
+        if (d is android.graphics.drawable.AnimatedImageDrawable) {
+            d.stop()
+        }
+        d?.callback = null
+        leadingDrawable = null
         currentImageUrl = null
     }
 

--- a/app/src/main/java/com/mezon/mobile/util/MessageContentParser.kt
+++ b/app/src/main/java/com/mezon/mobile/util/MessageContentParser.kt
@@ -349,20 +349,25 @@ fun parseContentToSpannable(
 
     elements.sortBy { it.s }
     
+    val UNICODE_EMOJI_REGEX = Regex("^(?:[\\p{So}\\p{Sk}\\u200D\\uFE0F\\s]|\\d\\uFE0F\\u20E3|[#*]\\uFE0F\\u20E3)+$")
     val isOnlyEmoji = run {
-        if (elements.isEmpty()) return@run false
-        var hasEmoji = false
+        var hasElementEmoji = false
+        var allElementsAreEmoji = true
         var textIndex = 0
         for (el in elements) {
-            if (el.kind != "e") return@run false
-            hasEmoji = true
+            if (el.kind != "e") {
+                allElementsAreEmoji = false
+                break
+            }
+            hasElementEmoji = true
             val plainText = text.substring(textIndex, el.s.coerceIn(textIndex, text.length))
-            if (plainText.trim().isNotEmpty()) return@run false
+            if (plainText.trim().isNotEmpty() && !UNICODE_EMOJI_REGEX.matches(plainText.trim())) return@run false
             textIndex = el.e.coerceAtLeast(textIndex).coerceAtMost(text.length)
         }
+        if (!allElementsAreEmoji) return@run false
         val remainingText = text.substring(textIndex, text.length)
-        if (remainingText.trim().isNotEmpty()) return@run false
-        hasEmoji
+        if (remainingText.trim().isNotEmpty() && !UNICODE_EMOJI_REGEX.matches(remainingText.trim())) return@run false
+        hasElementEmoji || (text.isNotBlank() && UNICODE_EMOJI_REGEX.matches(text.trim()))
     }
     
     val emojiSize = if (isOnlyEmoji) LayoutHelper.dp(48) else LayoutHelper.dp(20)

--- a/app/src/main/java/com/mezon/mobile/util/MessageContentParser.kt
+++ b/app/src/main/java/com/mezon/mobile/util/MessageContentParser.kt
@@ -348,6 +348,25 @@ fun parseContentToSpannable(
     }
 
     elements.sortBy { it.s }
+    
+    val isOnlyEmoji = run {
+        if (elements.isEmpty()) return@run false
+        var hasEmoji = false
+        var textIndex = 0
+        for (el in elements) {
+            if (el.kind != "e") return@run false
+            hasEmoji = true
+            val plainText = text.substring(textIndex, el.s.coerceIn(textIndex, text.length))
+            if (plainText.trim().isNotEmpty()) return@run false
+            textIndex = el.e.coerceAtLeast(textIndex).coerceAtMost(text.length)
+        }
+        val remainingText = text.substring(textIndex, text.length)
+        if (remainingText.trim().isNotEmpty()) return@run false
+        hasEmoji
+    }
+    
+    val emojiSize = if (isOnlyEmoji) LayoutHelper.dp(48) else LayoutHelper.dp(20)
+
     var last = 0
     val viewRef = view?.let { java.lang.ref.WeakReference(it) }
     val richPlainMarkdown = isEmbedOrComponentsPayload(content)
@@ -423,7 +442,7 @@ fun parseContentToSpannable(
             "e" -> {
                 if (viewRef != null && el.emojiid != null) {
                     sb.append("\uFFFC")
-                    sb.setExclusiveSpan(EmojiSpan(el.emojiid, viewRef), spanStart, sb.length)
+                    sb.setExclusiveSpan(EmojiSpan(el.emojiid, viewRef, emojiSize), spanStart, sb.length)
                 } else {
                     sb.append(segText)
                     sb.setExclusiveSpan(ForegroundColorSpan(linkColor), spanStart, sb.length)

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,8 +6,8 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
-kotlin.daemon.jvmargs=-Xmx2048m
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
+kotlin.daemon.jvmargs=-Xmx4096m
 # Run independent project tasks in parallel and enable the local build cache
 # configured in settings.gradle.kts.
 org.gradle.parallel=true


### PR DESCRIPTION
issue: https://github.com/mezonai/mezon-android/issues/45
1. Distorted Emojis in Text Spans & Suggestions
Root Cause: Bounding boxes for emojis were hardcoded to fixed squares, causing non-square emojis to stretch and distort.
Solution: Applied FIT_CENTER logic to dynamically scale and center emojis while preserving their original aspect ratios.
Test Case: Type :dog: to trigger suggestions. Verify the emoji renders without stretching in both the suggestion list and the input field.
2. GIF List Cropping & Padding Issues
Root Cause: GIFs were rendered inside a standard GridLayoutManager with a fixed height (100dp), forcing them to be either cropped (CENTER_CROP) or padded with black borders (FIT_CENTER).
Solution: Migrated the GIF list to StaggeredGridLayoutManager and updated GifCell to calculate its height dynamically based on the GIF's intrinsic aspect ratio.
Test Case: Open the GIF panel. Verify that GIFs are arranged in a staggered grid, displaying fully without any black borders or cropped edges.
3. Fullscreen Emoji Panel Not Collapsing
Root Cause: The onEmojiSelected callback lacked the logic to revert the emoji panel's fullscreen search state.
Solution: Added a check to call collapseEmojiSearch() upon emoji selection if the panel is currently expanded.
Test Case: Expand the emoji panel by tapping the search bar. Select an emoji. Verify the emoji is inserted and the panel automatically collapses to its default height.