### PR TITLE
260626-ANDROID-Update role UI

### DIFF
--- a/app/src/main/java/com/mezon/mobile/data/db/RoleCacheDao.kt
+++ b/app/src/main/java/com/mezon/mobile/data/db/RoleCacheDao.kt
@@ -31,6 +31,7 @@ internal data class ClanRoleExtraPayload(
     val permissionSlugs: List<String>,
     val rolePermissions: List<RolePermissionInfoRow>,
     val channelIds: List<Long>,
+    val orderRole: Int = 0,
 )
 
 @Entity(tableName = "clan_role_list_meta")
@@ -114,6 +115,7 @@ internal fun ClanRole.toCacheEntity(): ClanRoleCacheEntity {
             )
         },
         channelIds = channelIds,
+        orderRole = orderRole,
     )
     return ClanRoleCacheEntity(
         clanId = clanId,
@@ -154,6 +156,7 @@ internal fun ClanRoleCacheEntity.toClanRole(): ClanRole? = try {
         },
         roleChannelActive = roleChannelActive,
         channelIds = p.channelIds,
+        orderRole = p.orderRole,
     )
 } catch (_: Exception) {
     null

--- a/app/src/main/java/com/mezon/mobile/home/chat/UserProfileBottomSheet.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/UserProfileBottomSheet.kt
@@ -562,14 +562,34 @@ class UserProfileBottomSheet(
             }
         }
         val color = if (role.color != 0) role.color else Color.parseColor("#99aab5")
+        val hasIcon = role.iconUrl.isNotBlank()
+
         row.addView(View(context).apply {
             background = GradientDrawable().apply {
                 shape = GradientDrawable.OVAL
                 setColor(color)
             }
         }, LinearLayout.LayoutParams(LayoutHelper.dp(10), LayoutHelper.dp(10)).apply {
-            marginEnd = LayoutHelper.dp(10)
+            marginEnd = if (hasIcon) LayoutHelper.dp(6) else LayoutHelper.dp(8)
         })
+
+        if (hasIcon) {
+            val iconView = ImageView(context).apply {
+                scaleType = ImageView.ScaleType.FIT_CENTER
+            }
+            row.addView(iconView, LinearLayout.LayoutParams(LayoutHelper.dp(14), LayoutHelper.dp(14)).apply {
+                marginEnd = LayoutHelper.dp(6)
+            })
+            val loader = MezonImageLoader.getInstance(context)
+            loader.getBitmapFromMemory(role.iconUrl, LayoutHelper.dp(14), LayoutHelper.dp(14))?.let { bmp ->
+                iconView.setImageBitmap(bmp)
+            } ?: run {
+                loader.load(role.iconUrl, LayoutHelper.dp(14), LayoutHelper.dp(14), onSuccess = { bmp ->
+                    iconView.setImageBitmap(bmp)
+                })
+            }
+        }
+
         row.addView(TextView(context).apply {
             text = role.title
             setTextColor(textStrongColor)

--- a/app/src/main/java/com/mezon/mobile/home/clans/ClanRole.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ClanRole.kt
@@ -2,6 +2,7 @@ package com.mezon.mobile.home.clans
 
 import com.mezon.mezon.api.Permission
 import com.mezon.mezon.api.Role
+import com.mezon.mobile.util.absoluteResourceUrl
 
 data class RolePermissionInfo(
     val permissionId: Long,
@@ -25,6 +26,7 @@ data class ClanRole(
     val rolePermissions: List<RolePermissionInfo>,
     val roleChannelActive: Int,
     val channelIds: List<Long>,
+    val orderRole: Int,
 )
 
 data class PermissionCatalogEntry(
@@ -62,7 +64,7 @@ fun mapProtoRoleToClanRole(proto: Role): ClanRole {
         title = proto.title,
         color = colorInt,
         colorHexRaw = rawColor,
-        iconUrl = proto.roleIcon,
+        iconUrl = absoluteResourceUrl(proto.roleIcon),
         slug = proto.slug,
         permissionSlugs = activeSlugs,
         maxLevelPermission = proto.maxLevelPermission,
@@ -70,6 +72,7 @@ fun mapProtoRoleToClanRole(proto: Role): ClanRole {
         rolePermissions = rolePerms,
         roleChannelActive = proto.roleChannelActive,
         channelIds = proto.channelIdsList.toList(),
+        orderRole = proto.orderRole,
     )
 }
 

--- a/app/src/main/java/com/mezon/mobile/home/clans/RoleController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/RoleController.kt
@@ -136,9 +136,9 @@ class RoleController @Inject constructor(
             rolesByClan[clanId]?.forEach { rolesById[it.roleId] = it }
         }
         val result = ArrayList<MemberProfileRoleChip>(roleIds.size)
-        for (roleId in roleIds) {
-            val role = rolesById[roleId] ?: continue
-            if (role.isEveryoneRole()) continue
+        val validRoles = roleIds.mapNotNull { rolesById[it] }.filterNot { it.isEveryoneRole() }
+        val sortedRoles = validRoles.sortedBy { it.orderRole }
+        for (role in sortedRoles) {
             result.add(
                 MemberProfileRoleChip(
                     roleId = role.roleId,
@@ -316,15 +316,8 @@ class RoleController @Inject constructor(
             for (role in allRoles) {
                 byId[role.roleId] = role
             }
-            if (clanCreatorId != 0L) {
-                val top = allRoles.maxByOrNull { it.maxLevelPermission }
-                if (top != null) {
-                    byUser.put(clanCreatorId, UserDisplayRole(top.color, top.iconUrl))
-                }
-            }
             for (member in members) {
                 if (member.userId == 0L) continue
-                if (clanCreatorId != 0L && member.userId == clanCreatorId) continue
                 byUser.put(member.userId, computeDisplayRoleForMember(member, byId))
             }
         }
@@ -370,23 +363,24 @@ class RoleController @Inject constructor(
         rolesById: Map<Long, ClanRole>
     ): UserDisplayRole {
         if (member.roleIds.isEmpty()) return UserDisplayRole(0, "")
-        var bestLevel = -1
+        var bestOrder = Int.MAX_VALUE
         var bestRole: ClanRole? = null
         for (rid in member.roleIds) {
             val role = rolesById[rid] ?: continue
-            if (role.maxLevelPermission > bestLevel) {
-                bestLevel = role.maxLevelPermission
+            if (role.orderRole < bestOrder) {
+                bestOrder = role.orderRole
                 bestRole = role
             }
         }
         if (bestRole == null) return UserDisplayRole(0, "")
         var iconUrl = bestRole.iconUrl
         if (iconUrl.isBlank()) {
+            var bestIconOrder = Int.MAX_VALUE
             for (rid in member.roleIds) {
                 val role = rolesById[rid] ?: continue
-                if (role.iconUrl.isNotBlank()) {
+                if (role.iconUrl.isNotBlank() && role.orderRole < bestIconOrder) {
+                    bestIconOrder = role.orderRole
                     iconUrl = role.iconUrl
-                    break
                 }
             }
         }

--- a/app/src/main/java/com/mezon/mobile/home/messages/DirectMessage.kt
+++ b/app/src/main/java/com/mezon/mobile/home/messages/DirectMessage.kt
@@ -48,7 +48,13 @@ fun ChannelDescription.resolveOtherParticipantIndex(currentUserId: Long): Int {
 fun ChannelDescription.resolveParticipantFallbackIndex(currentUserId: Long): Int {
     val other = resolveOtherParticipantIndex(currentUserId)
     if (other >= 0) return other
-    if (userIdsCount == 0 && (usernamesCount > 0 || displayNamesCount > 0 || avatarsCount > 0)) {
+    if (userIdsCount > 0) {
+        for (i in 0 until userIdsCount) {
+            if (getUserIds(i) == currentUserId) return i
+        }
+        return 0
+    }
+    if (usernamesCount > 0 || displayNamesCount > 0 || avatarsCount > 0) {
         return 0
     }
     return -1


### PR DESCRIPTION
root causes: incorrect logic (check max permission)
solution:  replace logic check max permission -> order 
test cases: 
Verify that a normal member's display name color in the chat list matches their assigned role with the highest priority (smallest orderRole value).
Verify that the clan creator's display name color is correctly calculated based on their assigned roles' orderRole, instead of being forced to the maximum permission level.
Verify that a member's role icon in the chat list displays correctly and falls back to lower priority roles if the top priority role lacks an icon.
Verify that the short profile bottom sheet displays all assigned roles with their correct background colors.