### PR TITLE
260629-ANDROID-Fix bug edit msg UI

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/ChatController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChatController.kt
@@ -2545,6 +2545,32 @@ class ChatController @Inject constructor(
         return incoming
     }
 
+    private fun preserveJsonKeys(baseContent: String, newContent: String, keys: List<String>): String {
+        if (baseContent.isBlank() || newContent.isBlank()) return newContent
+        if (!baseContent.startsWith("{") || !newContent.startsWith("{")) return newContent
+        var merged = newContent
+        try {
+            var appendText = ""
+            val baseJson = org.json.JSONObject(baseContent)
+            for (key in keys) {
+                if (baseContent.contains("\"$key\"") && !merged.contains("\"$key\"")) {
+                    if (baseJson.has(key)) {
+                        appendText += ",\"$key\":" + baseJson.get(key).toString()
+                    }
+                }
+            }
+            if (appendText.isNotEmpty()) {
+                val lastBraceIndex = merged.lastIndexOf('}')
+                if (lastBraceIndex != -1) {
+                    merged = merged.substring(0, lastBraceIndex) + appendText + merged.substring(lastBraceIndex)
+                }
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+        return merged
+    }
+
     private fun mergeIncomingAttachmentEntity(
         existing: MessageEntity?,
         incoming: MessageEntity,
@@ -2561,7 +2587,8 @@ class ChatController @Inject constructor(
             existingCount > incomingCount ||
             (expectedTotal > incomingCount && hasAnyLocalAttachmentUrl(existing))
         )
-        val mergedContent = PresignFinishContent.mergePresignFinishContent(base.content, incoming.content)
+        var mergedContent = PresignFinishContent.mergePresignFinishContent(base.content, incoming.content)
+        mergedContent = preserveJsonKeys(base.content, mergedContent, listOf("references", "mentions"))
         val presignOnly = PresignFinishContent.isPresignFinishOnlyChange(mergedContent, base.content)
         val resolvedContent = when {
             forceContentReplace && incoming.content.isNotBlank() -> mergedContent
@@ -2672,10 +2699,13 @@ class ChatController @Inject constructor(
         } else {
             buildTextContent(newText)
         }
-        val content = if (existingMessage != null && isShareContactMessage(existingMessage.code, existingMessage.content)) {
+        var content = if (existingMessage != null && isShareContactMessage(existingMessage.code, existingMessage.content)) {
             mergeShareContactEmbedIntoContent(baseContent, existingMessage.content)
         } else {
             baseContent
+        }
+        if (existingMessage != null) {
+            content = preserveJsonKeys(existingMessage.content, content, listOf("references", "mentions"))
         }
         val protoMentions = resolvedMentions?.map { m ->
             messageMention {

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -4501,6 +4501,13 @@ open class ChatFragment : BaseFragment() {
         val rawInput = inputField.text?.toString() ?: ""
         val text = rawInput.trim()
         val editMsg = editingMessage
+        if (editMsg != null) {
+            val oldText = com.mezon.mobile.util.restoreInputFromContent(editMsg.content).rawText.trim()
+            if (text == oldText) {
+                clearEditState()
+                return
+            }
+        }
         val preservingShareContactEmbed = editMsg != null &&
             isShareContactMessage(editMsg.code, editMsg.content)
         if (text.isBlank() && pendingAttachments.isEmpty() && !preservingShareContactEmbed) return

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
@@ -1396,14 +1396,10 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
                 .build()
         } else null
 
-        val editedText = EDITED_TEXT
-        editedLayout = if (drawEdited) {
-            StaticLayout.Builder.obtain(editedText, 0, editedText.length, currentTimePaint, LayoutHelper.dp(60).coerceAtLeast(1))
-                .setMaxLines(1)
-                .build()
-        } else null
+        val editedText = context.getString(R.string.message_edited)
+        editedLayout = null
 
-        val timeStr = if (drawEdited) "$editedText  $timeText" else timeText
+        val timeStr = timeText
         timeLayout = if (isCombined) null else {
             StaticLayout.Builder.obtain(timeStr, 0, timeStr.length, currentTimePaint, textWidth.coerceAtLeast(1))
                 .setMaxLines(1)
@@ -1427,12 +1423,14 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             shareContactLayout.clear()
         }
         val hasEmbedPayload = !hasCallLogCard && !hasShareContactCard && isEmbedOrComponentsPayload(msg.content)
-        val hasText = !hasCallLogCard && !msg.isPollMessage &&
+        val hasActualText = !hasCallLogCard && !msg.isPollMessage &&
             parsedContent.isNotBlank() && parsedContent != "[file]" && parsedContent != "[embed]" &&
             parsedContent != "[Contact]" &&
             (!hasEmbedPayload || hasExplicitTextBody)
+        val hasText = hasActualText || drawEdited
         contentLayout = if (hasText) {
-            val content = msg.content
+            val contentToParse = if (hasActualText) msg.content else ""
+            val parsedToParse = if (hasActualText) parsedContent else ""
             val linkColor = theme.blurple
             val mentionColors = MentionColors(
                 theme.textLink,
@@ -1440,10 +1438,35 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
                 theme.textRoleLink,
                 theme.darkMossGreen
             )
-            val charSeq: CharSequence = if (isRawMessage(content)) {
-                buildPlainTextWithHeadings(parsedContent, theme)
+            var charSeq: CharSequence = if (isRawMessage(contentToParse)) {
+                buildPlainTextWithHeadings(parsedToParse, theme)
             } else {
-                parseContentToSpannable(content, linkColor, this, mentionColors, theme)
+                parseContentToSpannable(contentToParse, linkColor, this, mentionColors, theme)
+            }
+            if (drawEdited) {
+                val ssb = android.text.SpannableStringBuilder(charSeq)
+                if (ssb.isNotEmpty()) ssb.append("  ")
+                val start = ssb.length
+                ssb.append(editedText)
+                ssb.setSpan(
+                    android.text.style.ForegroundColorSpan(theme.textDisabled),
+                    start,
+                    ssb.length,
+                    android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                )
+                ssb.setSpan(
+                    android.text.style.RelativeSizeSpan(0.70f),
+                    start,
+                    ssb.length,
+                    android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                )
+                ssb.setSpan(
+                    android.text.style.StyleSpan(android.graphics.Typeface.ITALIC),
+                    start,
+                    ssb.length,
+                    android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+                )
+                charSeq = ssb
             }
             val layoutTargetW = textWidth.coerceAtLeast(1)
             val contentLayoutW =
@@ -3000,7 +3023,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
                 timeLayout?.let { time ->
                     val timeX = (contentLeft + cachedSenderW + TIME_GAP_LEFT).toFloat()
                         .coerceAtMost((width - TIME_GAP_RIGHT).toFloat())
-                    val timeY = yOff + sender.height - time.height
+                    val timeY = yOff + sender.getLineBaseline(0) - time.getLineBaseline(0)
                     canvas.save()
                     canvas.translate(timeX, timeY)
                     time.draw(canvas)
@@ -3062,7 +3085,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             timeLayout?.let { time ->
                 val timeX = (contentLeft + cachedSenderW + TIME_GAP_LEFT).toFloat()
                         .coerceAtMost((width - TIME_GAP_RIGHT).toFloat())
-                val timeY = yOff + sender.height - time.height 
+                val timeY = yOff + sender.getLineBaseline(0) - time.getLineBaseline(0)
                 canvas.save()
                 canvas.translate(timeX, timeY)
                 time.draw(canvas)
@@ -4724,7 +4747,6 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         }
 
         private const val FORWARD_TEXT = "Forwarded"
-        private const val EDITED_TEXT = "(edited)"
         private const val ERROR_TEXT = "Unable to send message"
 
         private val REFERENCE_SENDER_CLAN_NICK_REGEX = Regex("\"message_sender_clan_nick\"\\s*:\\s*\"([^\"]*?)\"")

--- a/app/src/main/java/com/mezon/mobile/home/friends/FriendController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/friends/FriendController.kt
@@ -21,12 +21,18 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import android.os.SystemClock
 import android.util.Log
+import android.widget.Toast
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import com.mezon.mobile.R
+import com.mezon.mobile.home.notifications.toNotificationEntity
 import javax.inject.Inject
 import javax.inject.Singleton
 
 private const val FRIEND_LOG = "FriendController"
 private const val FRIEND_RELATIONS_FOREGROUND_THROTTLE_MS = 30_000L
 private const val FRIEND_RELATIONS_NOTIFICATION_DEBOUNCE_MS = 5_000L
+private const val NOTIFICATION_CODE_FRIEND_ACCEPT = -3
 
 @Singleton
 class FriendController @Inject constructor(
@@ -36,6 +42,7 @@ class FriendController @Inject constructor(
     private val dispatcher: SocketEventDispatcher,
     private val notificationCenter: NotificationCenter,
     private val cacheTracker: ApiCacheTracker,
+    @ApplicationContext private val appContext: Context,
     @ApplicationScope private val appScope: CoroutineScope,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) {
@@ -78,8 +85,21 @@ class FriendController @Inject constructor(
         dispatcher.notifications.collect { notification ->
             val subject = notification.subject.lowercase()
             val content = notification.content.toStringUtf8().lowercase()
-            val hasFriendSignal = notificationSuggestsFriendRelationRefresh(subject, content)
+            val hasFriendSignal = notificationSuggestsFriendRelationRefresh(subject, content) || notification.code == NOTIFICATION_CODE_FRIEND_ACCEPT
             if (hasFriendSignal) {
+                if (notification.code == NOTIFICATION_CODE_FRIEND_ACCEPT) {
+                    val name = notification.toNotificationEntity().senderName.ifEmpty { "Someone" }
+                    withContext(Dispatchers.Main) {
+                        val activity = com.mezon.mobile.MainActivity.instance ?: return@withContext
+                        activity.drawerLayoutContainer.post {
+                            com.mezon.mobile.ui.cells.ToastOverlay(activity, activity.themeColors).show(
+                                activity.drawerLayoutContainer,
+                                com.mezon.mobile.ui.cells.ToastOverlay.ToastType.INFO,
+                                appContext.getString(R.string.friend_request_accepted, name)
+                            )
+                        }
+                    }
+                }
                 val now = SystemClock.elapsedRealtime()
                 val shouldRefresh = synchronized(friendRelationsForegroundThrottleLock) {
                     val last = lastFriendRelationsNotificationRefreshElapsedMs

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -35,6 +35,7 @@
     <string name="common_members">Thành viên</string>
     <string name="common_friend">Bạn bè</string>
     <string name="common_add_friend">Thêm bạn</string>
+    <string name="friend_request_accepted">%1$s đã chấp nhận lời mời kết bạn của bạn</string>
     <string name="common_online">Trực tuyến</string>
     <string name="common_offline">Ngoại tuyến</string>
     <string name="common_copy">Sao chép</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="common_members">Members</string>
     <string name="common_friend">Friend</string>
     <string name="common_add_friend">Add friend</string>
+    <string name="friend_request_accepted">%1$s accepted your friend request</string>
     <string name="common_online">Online</string>
     <string name="common_offline">Offline</string>
     <string name="common_copy">Copy</string>


### PR DESCRIPTION
issue: https://github.com/mezonai/mezon/issues/13404
result: 
<img width="210" height="143" alt="image" src="https://github.com/user-attachments/assets/b87a650e-7ed8-43b6-894f-687c5eca6e56" />

Root Cause
Data Loss: Optimistic UI updates wiped references and mentions JSON fields, breaking reply headers and mentions.
UI Misalignment: Sender name and time were aligned by layout heights instead of text baselines.
Redundant API Calls: Edits containing only leading/trailing spaces triggered unnecessary network requests.
Hardcoded Tag: The (edited) label was hardcoded and its style didn't match the web client.
Solution
Preserve Data: Explicitly retained references and mentions fields during local message payload updates.
Fix Alignment: Aligned sender name and timestamp using getLineBaseline(0).
Optimize Network: Added early return to skip API calls if the trimmed text remains unchanged.
Refine UI: Localized the "edited" text and applied italicized, muted styling to match the web.
Test Cases
TC1: Verify reply headers and mentions remain intact after editing a message.
TC2: Verify the sender name and timestamp in the message header are horizontally aligned by their baselines.
TC3: Verify submitting an edit with only extra spaces closes the edit state without making an API call.
TC4: Verify the "edited" tag is properly localized and displayed in a small, muted, italic font.