### PR TITLE
260630-ANDROID-Fix bug of list image

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/ChannelMediaGalleryAdapter.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/ChannelMediaGalleryAdapter.kt
@@ -215,6 +215,7 @@ internal class ChannelMediaGalleryAdapter(
             BackupImageView(ctx).apply {
                 setRoundRadius(LayoutHelper.dp(10f))
                 setOmitEmptyPlaceholder(true)
+                setAspectFill(true)
             }
         root.addView(thumb, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT))
 

--- a/app/src/main/java/com/mezon/mobile/ui/cells/BackupImageView.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/cells/BackupImageView.kt
@@ -23,6 +23,7 @@ class BackupImageView(context: Context) : View(context) {
     private var decodeWidth = -1
     private var decodeHeight = -1
     private var aspectFit = false
+    private var aspectFill = false
     private var roundRadius = 0
     private var roundRadiusTL = 0
     private var roundRadiusTR = 0
@@ -75,6 +76,11 @@ class BackupImageView(context: Context) : View(context) {
 
     fun setAspectFit(value: Boolean) {
         aspectFit = value
+        invalidate()
+    }
+
+    fun setAspectFill(value: Boolean) {
+        aspectFill = value
         invalidate()
     }
 
@@ -183,22 +189,48 @@ class BackupImageView(context: Context) : View(context) {
         }
         val d = loadedDrawable
         if (d != null) {
-            val drawW = if (decodeWidth > 0 && decodeHeight > 0) {
-                if (aspectFit) {
-                    val scale = min(width.toFloat() / decodeWidth, height.toFloat() / decodeHeight)
-                    (decodeWidth * scale).toInt()
+            val drawW: Int
+            val drawH: Int
+            val drawX: Int
+            val drawY: Int
+
+            val iW = d.intrinsicWidth
+            val iH = d.intrinsicHeight
+
+            if (aspectFill && iW > 0 && iH > 0) {
+                val scale = kotlin.math.max(width.toFloat() / iW, height.toFloat() / iH)
+                drawW = (iW * scale).toInt()
+                drawH = (iH * scale).toInt()
+                drawX = (width - drawW) / 2
+                drawY = (height - drawH) / 2
+            } else {
+                drawW = if (decodeWidth > 0 && decodeHeight > 0) {
+                    if (aspectFit) {
+                        val scale = kotlin.math.min(width.toFloat() / decodeWidth, height.toFloat() / decodeHeight)
+                        (decodeWidth * scale).toInt()
+                    } else width
                 } else width
-            } else width
-            val drawH = if (decodeWidth > 0 && decodeHeight > 0) {
-                if (aspectFit) {
-                    val scale = min(width.toFloat() / decodeWidth, height.toFloat() / decodeHeight)
-                    (decodeHeight * scale).toInt()
+                
+                drawH = if (decodeWidth > 0 && decodeHeight > 0) {
+                    if (aspectFit) {
+                        val scale = kotlin.math.min(width.toFloat() / decodeWidth, height.toFloat() / decodeHeight)
+                        (decodeHeight * scale).toInt()
+                    } else height
                 } else height
-            } else height
-            val drawX = if (decodeWidth > 0 && decodeHeight > 0 && aspectFit) (width - drawW) / 2 else 0
-            val drawY = if (decodeWidth > 0 && decodeHeight > 0 && aspectFit) (height - drawH) / 2 else 0
+                
+                drawX = if (decodeWidth > 0 && decodeHeight > 0 && aspectFit) (width - drawW) / 2 else 0
+                drawY = if (decodeWidth > 0 && decodeHeight > 0 && aspectFit) (height - drawH) / 2 else 0
+            }
+
+            if (!hasRoundClip && aspectFill) {
+                canvas.save()
+                canvas.clipRect(0, 0, width, height)
+            }
             d.setBounds(drawX, drawY, drawX + drawW, drawY + drawH)
             d.draw(canvas)
+            if (!hasRoundClip && aspectFill) {
+                canvas.restore()
+            }
         } else if (!omitEmptyPlaceholder) {
             avatarDrawable.setBounds(0, 0, width, height)
             avatarDrawable.draw(canvas)


### PR DESCRIPTION
issue: https://github.com/mezonai/mezon/issues/13406
Root Cause: By default, BackupImageView on Android stretches non-square images to exactly match its bounds without maintaining the aspect ratio, causing media gallery thumbnails to appear distorted.

Solution: Introduced an aspectFill flag to BackupImageView to correctly scale and center-crop images (matching the iOS .fill behavior), and enabled this flag specifically for the media gallery thumbnails.

Test Cases:
Verify that images in the DM media gallery are displayed as perfect squares without any vertical or horizontal stretching.
Verify that images in the Channel media gallery maintain their original proportions while completely filling the thumbnail cell via center-crop.
Verify that Thread media gallery thumbnails are cropped properly and do not bleed outside their visual boundaries.
Verify that other components using BackupImageView (such as user avatars and chat message bubbles) remain completely unaffected.