### PR TITLE
260630-ANDROID-Fix bug send ogp link

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/ChatController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChatController.kt
@@ -1504,15 +1504,16 @@ class ChatController @Inject constructor(
         hashtags: List<com.mezon.mobile.util.HashtagData>? = null,
         emojiMarkers: List<EmojiMarker>? = null,
         ogpMarker: OgpMarker? = null,
+        markdownMarkers: List<MarkdownMarker>? = null,
         topicId: Long = 0L
     ) {
         val mode = channelTypeToStreamMode(channelType)
         val isPublic = !isChannelPrivate
         val cacheKey = messageCacheKey(channelId, topicId)
-        val hasContentExtras = !hashtags.isNullOrEmpty() || !emojiMarkers.isNullOrEmpty() || ogpMarker != null
+        val hasContentExtras = !hashtags.isNullOrEmpty() || !emojiMarkers.isNullOrEmpty() || ogpMarker != null || !markdownMarkers.isNullOrEmpty()
         val wireBase = when {
             text.isBlank() -> PresignFinishContent.emptyOutgoingContent()
-            hasContentExtras -> buildTextContentWithEmojis(text, null, emojiMarkers, null, hashtags, ogpMarker)
+            hasContentExtras -> buildTextContentWithEmojis(text, null, emojiMarkers, markdownMarkers, hashtags, ogpMarker)
             else -> buildTextContent(text)
         }
         val optimisticContent = PresignFinishContent.injectEmptyPresignFinish(

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -4543,15 +4543,7 @@ open class ChatFragment : BaseFragment() {
         val ogpPreview = inputOgpPreviewData
             ?: extractFirstInputUrl(cleanedText)?.let { inputOgpCache[it] }
         val ogpMarker = buildInputOgpMarker(cleanedText, ogpPreview)
-        val filteredMdMarkers = if (ogpMarker == null) mdMarkers else {
-            mdMarkers
-                ?.filterNot {
-                    it.type == "lk" &&
-                        it.s < ogpMarker.e &&
-                        ogpMarker.s < it.e
-                }
-                ?.ifEmpty { null }
-        }
+        val filteredMdMarkers = mdMarkers
 
         val fromTrackers = mentionTrackers.mapNotNull { m ->
             val inTrimmed = mentionOffsetsForTrimmed(rawInput, text, m) ?: return@mapNotNull null
@@ -4611,6 +4603,7 @@ open class ChatFragment : BaseFragment() {
                 hashtags,
                 emojiMarkers,
                 ogpMarker,
+                filteredMdMarkers,
                 topicId = topicId
             )
             clearPendingAttachments()
@@ -5374,12 +5367,13 @@ open class ChatFragment : BaseFragment() {
         val image = p.imageUrl.trim()
         if (title.isEmpty() || (description.isEmpty() && image.isEmpty())) return null
         return OgpMarker(
-            s = start,
-            e = end,
+            s = cleanedText.length,
+            e = cleanedText.length + 1,
             index = start,
             title = title,
             description = description,
-            image = image
+            image = image,
+            url = urlInText
         )
     }
 

--- a/app/src/main/java/com/mezon/mobile/home/clans/settings/InvitePeopleModels.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/settings/InvitePeopleModels.kt
@@ -62,5 +62,5 @@ fun buildInviteLinkContent(
     val description = (memberCountDescription
         ?: preview.channelLabel.ifBlank { preview.clanName }).escapeJson()
     val image = preview.logoUrl.escapeJson()
-    return """{"t":"$escaped","mk":[{"type":"lk","s":0,"e":$end},{"type":"lk_ogp","s":$end,"e":${end + 1},"index":0,"title":"$title","description":"$description","image":"$image"}]}"""
+    return """{"t":"$escaped","mk":[{"type":"lk","s":0,"e":$end},{"type":"lk_ogp","s":$end,"e":${end + 1},"index":0,"title":"$title","description":"$description","image":"$image","url":"$escaped"}]}"""
 }

--- a/app/src/main/java/com/mezon/mobile/util/ContentParser.kt
+++ b/app/src/main/java/com/mezon/mobile/util/ContentParser.kt
@@ -268,7 +268,8 @@ data class OgpMarker(
     val index: Int,
     val title: String,
     val description: String,
-    val image: String
+    val image: String,
+    val url: String
 )
 
 data class HashtagData(
@@ -661,9 +662,15 @@ fun buildTextContentWithEmojis(
                 .replace("\n", "\\n")
                 .replace("\r", "\\r")
                 .replace("\t", "\\t")
+            val escapedUrl = it.url
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t")
             mkEntries.add(
                 "{\"type\":\"lk_ogp\",\"s\":${it.s},\"e\":${it.e},\"index\":${it.index}," +
-                    "\"title\":\"$escapedTitle\",\"description\":\"$escapedDescription\",\"image\":\"$escapedImage\"}"
+                    "\"title\":\"$escapedTitle\",\"description\":\"$escapedDescription\",\"image\":\"$escapedImage\",\"url\":\"$escapedUrl\"}"
             )
         }
         parts.add("\"mk\":[${mkEntries.joinToString(",")}]")


### PR DESCRIPTION
issue: https://github.com/mezonai/mezon-android/issues/289
Root Cause:
The url field was missing in the lk_ogp JSON payload, making the OGP card unclickable on the Web client.
The lk_ogp marker incorrectly occupied the link's text range, and the original lk (link) marker was erroneously filtered out.
The sendMessageWithAttachments function hardcoded null for markdownMarkers, stripping link formatting when sending files.

Solution:
Added the missing url field to the lk_ogp JSON payload.
Stopped filtering out lk markers and moved the lk_ogp marker boundaries to the end of the text to match iOS behavior.
Passed the markdownMarkers parameter into sendMessageWithAttachments to preserve link formatting.

Test Cases:
Send a text message with a URL and verify the OGP card is clickable on the Web client.
Send a text message with a URL and verify the URL text itself is highlighted and clickable on the Web client.
Send a message containing both a URL and an image attachment, and verify the URL text remains highlighted and clickable on the Web client.