### PR TITLE
260630-ANDROID-Remove permission create topic

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/chat/thread/CreateThreadFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/thread/CreateThreadFragment.kt
@@ -2024,7 +2024,7 @@ class CreateThreadFragment : BaseFragment() {
     private fun canCreateThreadForCurrentFlow(): Boolean {
         if (fromTopicFlow && anonymousController.isAnonymous(clanId)) return false
         return if (fromTopicFlow) {
-            permissionPolicy.canCreateThreadFromMessage(parentChannelId, clanId)
+            true
         } else {
             permissionPolicy.canCreateThreadFromThreadList(parentChannelId, clanId)
         }


### PR DESCRIPTION
issue: https://github.com/mezonai/mezon-android/issues/292
Root Cause: The CreateThreadFragment incorrectly enforced strict thread creation permissions (MANAGE_THREAD and MANAGE_CHANNEL) during the topic creation flow.
Solution: Bypassed the permission check in canCreateThreadForCurrentFlow when fromTopicFlow is true, allowing any authenticated role to create a topic while keeping the thread permissions intact.
Test Cases:
Verify that a standard user without any special management roles can successfully create a topic.
