### PR TITLE
260701-ANDROID-Implement camera for list attachment

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/chat/CameraPermissionPrompt.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/CameraPermissionPrompt.kt
@@ -1,0 +1,25 @@
+package com.mezon.mobile.home.chat
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import com.mezon.mobile.R
+import com.mezon.mobile.core.AlertsCreator
+
+object CameraPermissionPrompt {
+    fun show(context: Context) {
+        AlertsCreator.createConfirmDialog(
+            context,
+            context.getString(R.string.camera_permission_denied_title),
+            context.getString(R.string.camera_permission_denied_message),
+            confirmText = context.getString(R.string.common_open_settings),
+            cancelText = context.getString(R.string.common_cancel)
+        ) {
+            val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                data = Uri.fromParts("package", context.packageName, null)
+            }
+            runCatching { context.startActivity(intent) }
+        }.show()
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/home/chat/CameraPhotoCapture.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/CameraPhotoCapture.kt
@@ -1,0 +1,58 @@
+package com.mezon.mobile.home.chat
+
+import android.content.ClipData
+import android.content.Context
+import android.content.Intent
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.provider.MediaStore
+import androidx.core.content.FileProvider
+import java.io.File
+import java.util.UUID
+
+data class CameraPhotoCapture(
+    val file: File,
+    val uri: Uri,
+    val intent: Intent
+) {
+    fun toAttachment(): AttachmentPickerItem? {
+        if (!file.isFile || file.length() <= 0L) return null
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(file.absolutePath, bounds)
+        return AttachmentPickerItem(
+            id = uri.hashCode().toLong(),
+            uri = uri,
+            path = uri.toString(),
+            filename = file.name,
+            mimeType = "image/jpeg",
+            width = bounds.outWidth.coerceAtLeast(0),
+            height = bounds.outHeight.coerceAtLeast(0),
+            size = file.length(),
+            duration = 0,
+            isVideo = false
+        )
+    }
+
+    fun discard() {
+        file.delete()
+    }
+
+    companion object {
+        fun create(context: Context): CameraPhotoCapture? {
+            val directory = File(context.cacheDir, "camera").apply { mkdirs() }
+            val file = File(directory, "camera-${UUID.randomUUID()}.jpg")
+            if (!file.createNewFile()) return null
+            val uri = FileProvider.getUriForFile(
+                context,
+                "${context.packageName}.fileprovider",
+                file
+            )
+            val intent = Intent(MediaStore.ACTION_IMAGE_CAPTURE).apply {
+                putExtra(MediaStore.EXTRA_OUTPUT, uri)
+                clipData = ClipData.newRawUri("camera-photo", uri)
+                addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION or Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            return CameraPhotoCapture(file, uri, intent)
+        }
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/home/chat/CameraPhotoReviewDialog.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/CameraPhotoReviewDialog.kt
@@ -1,0 +1,128 @@
+package com.mezon.mobile.home.chat
+
+import android.app.Dialog
+import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.view.Gravity
+import android.view.ViewGroup
+import android.view.Window
+import android.view.WindowManager
+import android.widget.FrameLayout
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import com.mezon.mobile.R
+import com.mezon.mobile.core.LayoutHelper
+
+class CameraPhotoReviewDialog(
+    context: Context,
+    capture: CameraPhotoCapture,
+    private val onRetake: () -> Boolean,
+    private val onUsePhoto: () -> Unit,
+    private val onCancelReview: () -> Unit
+) : Dialog(context, android.R.style.Theme_Black_NoTitleBar_Fullscreen) {
+
+    private var actionHandled = false
+    private var imageRequest: MezonImageLoader.Cancellable? = null
+    private val rootView: FrameLayout
+
+    init {
+        requestWindowFeature(Window.FEATURE_NO_TITLE)
+        window?.apply {
+            setWindowAnimations(0)
+            setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+            setBackgroundDrawable(ColorDrawable(Color.BLACK))
+            statusBarColor = Color.BLACK
+            navigationBarColor = Color.BLACK
+            addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+        }
+
+        rootView = FrameLayout(context).apply { setBackgroundColor(Color.BLACK) }
+        val photo = ImageView(context).apply {
+            scaleType = ImageView.ScaleType.FIT_CENTER
+            setBackgroundColor(Color.BLACK)
+            contentDescription = context.getString(R.string.camera_photo_preview)
+        }
+        rootView.addView(
+            photo,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT
+            ).apply { bottomMargin = LayoutHelper.dp(88f) }
+        )
+
+        val actions = LinearLayout(context).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            setPadding(LayoutHelper.dp(16f), 0, LayoutHelper.dp(16f), 0)
+            setBackgroundColor(0xFF111111.toInt())
+        }
+        actions.addView(actionButton(context.getString(R.string.camera_retake)) {
+            handleRetake()
+        }, LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.MATCH_PARENT, 1f))
+        actions.addView(actionButton(context.getString(R.string.camera_use_photo), Gravity.END) {
+            handleAction(onUsePhoto)
+        }, LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.MATCH_PARENT, 1f))
+        rootView.addView(
+            actions,
+            FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, LayoutHelper.dp(88f), Gravity.BOTTOM)
+        )
+        setContentView(rootView)
+
+        val size = context.resources.displayMetrics.run { maxOf(widthPixels, heightPixels) }
+        imageRequest = MezonImageLoader.getInstance(context).loadFromUri(
+            capture.uri,
+            size,
+            size,
+            onSuccess = { photo.setImageBitmap(it) },
+            onError = { photo.setImageURI(capture.uri) }
+        )
+    }
+
+    private fun actionButton(label: String, textGravity: Int = Gravity.START, action: () -> Unit) =
+        TextView(context).apply {
+            text = label
+            textSize = 18f
+            setTextColor(Color.WHITE)
+            gravity = Gravity.CENTER_VERTICAL or textGravity
+            isClickable = true
+            isFocusable = true
+            setOnClickListener { action() }
+        }
+
+    private fun handleAction(action: () -> Unit) {
+        if (actionHandled) return
+        actionHandled = true
+        action()
+        rootView.animate()
+            .alpha(0f)
+            .setDuration(USE_PHOTO_FADE_MS)
+            .withEndAction { dismiss() }
+            .start()
+    }
+
+    private fun handleRetake() {
+        if (actionHandled) return
+        if (onRetake()) actionHandled = true
+    }
+
+    override fun cancel() {
+        if (!actionHandled) {
+            actionHandled = true
+            onCancelReview()
+        }
+        super.cancel()
+    }
+
+    override fun dismiss() {
+        rootView.animate().cancel()
+        imageRequest?.cancel()
+        imageRequest = null
+        super.dismiss()
+    }
+
+    companion object {
+        private const val USE_PHOTO_FADE_MS = 120L
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatAttachAlert.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatAttachAlert.kt
@@ -42,8 +42,10 @@ class ChatAttachAlert(
     interface ChatAttachAlertDelegate {
         fun canSelectMore(): Boolean = true
         fun onSelectionChanged(item: AttachmentPickerItem, selected: Boolean)
+        fun onCameraRequested() {}
         fun onFilesRequested() {}
         fun onSendRequested() {}
+        fun onDismissed() {}
     }
 
     var attachDelegate: ChatAttachAlertDelegate? = null
@@ -54,9 +56,9 @@ class ChatAttachAlert(
     private var gridView: RecyclerView? = null
     private var headerRowView: LinearLayout? = null
     private var adapter: PhotoAttachAdapter? = null
-    private var emptyView: TextView? = null
     private var sendBtn: SendButtonView? = null
     private var swipeDismissFromHandle = false
+    private var didNotifyDismiss = false
 
     private var allPhotos = ArrayList<AttachmentPickerItem>()
     private var itemSize = 0
@@ -146,15 +148,6 @@ class ChatAttachAlert(
             FrameLayout.LayoutParams.MATCH_PARENT, headerHeight, Gravity.TOP
         ))
 
-        emptyView = TextView(context).apply {
-            text = "No photos or videos"
-            setTextColor(theme.getColor(ThemeColors.key_text_secondary))
-            textSize = 14f
-            gravity = Gravity.CENTER
-            visibility = View.GONE
-        }
-        parent.addView(emptyView, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT))
-
         sendBtn = SendButtonView(context, theme)
         sendBtn!!.visibility = View.GONE
         sendBtn!!.setOnClickListener { onSendClicked() }
@@ -215,9 +208,8 @@ class ChatAttachAlert(
             if (previousSize == 0) {
                 adapter?.notifyDataSetChanged()
             } else if (insertedCount > 0) {
-                adapter?.notifyItemRangeInserted(previousSize, insertedCount)
+                adapter?.notifyItemRangeInserted(previousSize + 1, insertedCount)
             }
-            emptyView?.visibility = if (allPhotos.isEmpty()) View.VISIBLE else View.GONE
             Log.d(TAG, "Gallery page loaded: $totalLoaded items total, hasMore=$hasMore")
         }
     }
@@ -282,6 +274,10 @@ class ChatAttachAlert(
 
     override fun dismiss() {
         mediaController.setGalleryLoadListener(null)
+        if (!didNotifyDismiss) {
+            didNotifyDismiss = true
+            attachDelegate?.onDismissed()
+        }
         super.dismiss()
     }
 
@@ -316,6 +312,24 @@ class ChatAttachAlert(
     inner class PhotoAttachAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+            if (viewType == VIEW_TYPE_CAMERA) {
+                val cell = FrameLayout(parent.context).apply {
+                    setBackgroundColor(0xFF303238.toInt())
+                    isClickable = true
+                    setOnClickListener { attachDelegate?.onCameraRequested() }
+                }
+                val icon = ImageView(parent.context).apply {
+                    setImageDrawable(MezonIcon.cameraIcon.getDrawable(parent.context, Color.WHITE))
+                    scaleType = ImageView.ScaleType.CENTER_INSIDE
+                }
+                cell.addView(
+                    icon,
+                    FrameLayout.LayoutParams(LayoutHelper.dp(34f), LayoutHelper.dp(34f), Gravity.CENTER)
+                )
+                cell.layoutParams = RecyclerView.LayoutParams(itemSize, itemSize)
+                return object : RecyclerView.ViewHolder(cell) {}
+            }
+
             val cell = PhotoAttachPhotoCell(parent.context, theme)
             cell.onCheckClickListener = { onCheckClicked(it) }
             cell.layoutParams = RecyclerView.LayoutParams(itemSize, itemSize)
@@ -323,14 +337,18 @@ class ChatAttachAlert(
         }
 
         override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+            if (getItemViewType(position) == VIEW_TYPE_CAMERA) return
             val cell = holder.itemView as PhotoAttachPhotoCell
-            val item = allPhotos[position]
+            val item = allPhotos[position - 1]
             cell.setPhotoEntry(item)
             val idx = selectedPhotosOrder.indexOf(item.id)
             cell.setChecked(idx, idx >= 0, false)
         }
 
-        override fun getItemCount(): Int = allPhotos.size
+        override fun getItemViewType(position: Int): Int =
+            if (position == 0) VIEW_TYPE_CAMERA else VIEW_TYPE_MEDIA
+
+        override fun getItemCount(): Int = allPhotos.size + 1
     }
 
     private class SendButtonView(context: Context, private val theme: ThemeColors) : View(context) {
@@ -365,5 +383,7 @@ class ChatAttachAlert(
 
     companion object {
         const val REQUEST_CODE_MEDIA_PERMISSION = 1004
+        private const val VIEW_TYPE_CAMERA = 0
+        private const val VIEW_TYPE_MEDIA = 1
     }
 }

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -40,6 +40,7 @@ import android.widget.LinearLayout
 import android.widget.ProgressBar
 import android.widget.TextView
 import android.widget.PopupWindow
+import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -193,6 +194,8 @@ open class ChatFragment : BaseFragment() {
         private const val PAGE_DOWN_SCROLL_THRESHOLD = 2
         private const val REQUEST_CODE_LOCATION_PERMISSION = 1002
         private const val REQUEST_CODE_PICK_FILE = 1005
+        private const val REQUEST_CODE_TAKE_PHOTO = 1006
+        private const val REQUEST_CODE_CAMERA_PERMISSION = 1007
         private const val REQUEST_CODE_RECORD_AUDIO = 1003
         private const val MAX_LENGTH_MESSAGE_BUZZ = 160
         private const val VOICE_LONG_PRESS_DELAY_MS = 400L
@@ -296,6 +299,9 @@ open class ChatFragment : BaseFragment() {
     private lateinit var sizeNotifierRoot: SizeNotifierFrameLayout
 
     private val pendingAttachments = ArrayList<AttachmentPickerItem>()
+    private var pendingCameraCapture: CameraPhotoCapture? = null
+    private var cameraSourceAlert: ChatAttachAlert? = null
+    private var activeCameraReview: CameraPhotoReviewDialog? = null
     private var mediaPermissionDeniedOnce = false
     private var locationPermissionAskedBefore = false
     private val pendingAttachmentThumbTasks = ArrayList<Runnable?>()
@@ -4837,6 +4843,7 @@ open class ChatFragment : BaseFragment() {
         val ctx = getContext() ?: return
         val preselected = pendingAttachments.filter { !it.isFileType }
         val alert = ChatAttachAlert(ctx, mediaController, themeColors, preselected)
+        cameraSourceAlert = alert
         alert.attachDelegate = object : ChatAttachAlert.ChatAttachAlertDelegate {
             override fun canSelectMore(): Boolean {
                 return pendingAttachments.size < AttachmentPickerItem.GALLERY_MAX_SELECTION
@@ -4858,10 +4865,23 @@ open class ChatFragment : BaseFragment() {
                 launchDocumentPicker()
             }
 
+            override fun onCameraRequested() {
+                if (!ensureCanSendMessageOrNotify()) return
+                if (!canSelectMore()) {
+                    Toast.makeText(ctx, "Maximum ${AttachmentPickerItem.GALLERY_MAX_SELECTION} items", Toast.LENGTH_SHORT).show()
+                    return
+                }
+                requestCameraPhoto()
+            }
+
             override fun onSendRequested() {
                 if (pendingAttachments.isEmpty()) return
                 updateAttachmentPreview()
                 updateSendButtonState()
+            }
+
+            override fun onDismissed() {
+                if (cameraSourceAlert === alert) cameraSourceAlert = null
             }
         }
         alert.setDrawNavigationBar(true)
@@ -5041,7 +5061,54 @@ open class ChatFragment : BaseFragment() {
         )
     }
 
+    private fun requestCameraPhoto() {
+        val activity = getParentActivity() ?: return
+        if (ContextCompat.checkSelfPermission(activity, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
+            activity.requestPermissions(arrayOf(Manifest.permission.CAMERA), REQUEST_CODE_CAMERA_PERMISSION)
+            return
+        }
+        launchCameraPhoto()
+    }
+
+    private fun launchCameraPhoto(): Boolean {
+        val ctx = getContext() ?: return false
+        val capture = CameraPhotoCapture.create(ctx)
+        if (capture == null) {
+            MezonToast.show(this, ToastOverlay.ToastType.ERROR, getString(R.string.camera_not_available))
+            return false
+        }
+        pendingCameraCapture?.discard()
+        pendingCameraCapture = capture
+        try {
+            startActivityForResult(capture.intent, REQUEST_CODE_TAKE_PHOTO)
+            return true
+        } catch (_: android.content.ActivityNotFoundException) {
+            pendingCameraCapture = null
+            capture.discard()
+            MezonToast.show(this, ToastOverlay.ToastType.ERROR, getString(R.string.camera_not_available))
+            return false
+        }
+    }
+
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        if (requestCode == REQUEST_CODE_TAKE_PHOTO) {
+            val capture = pendingCameraCapture
+            pendingCameraCapture = null
+            if (resultCode != android.app.Activity.RESULT_OK) {
+                capture?.discard()
+                activeCameraReview?.dismiss()
+                activeCameraReview = null
+                return
+            }
+            val item = capture?.toAttachment()
+            if (item == null) {
+                capture?.discard()
+                MezonToast.show(this, ToastOverlay.ToastType.ERROR, getString(R.string.camera_capture_failed))
+                return
+            }
+            showCameraPhotoReview(capture, item)
+            return
+        }
         if (requestCode != REQUEST_CODE_PICK_FILE || resultCode != android.app.Activity.RESULT_OK) return
         if (!ensureCanSendMessageOrNotify()) return
         val uri = data?.data ?: return
@@ -5058,6 +5125,38 @@ open class ChatFragment : BaseFragment() {
         pendingAttachments.add(item)
         updateAttachmentPreview()
         updateSendButtonState()
+    }
+
+    private fun showCameraPhotoReview(capture: CameraPhotoCapture, item: AttachmentPickerItem) {
+        val ctx = getContext() ?: run {
+            capture.discard()
+            return
+        }
+        lateinit var review: CameraPhotoReviewDialog
+        review = CameraPhotoReviewDialog(
+            context = ctx,
+            capture = capture,
+            onRetake = {
+                launchCameraPhoto().also { launched ->
+                    if (launched) capture.discard()
+                }
+            },
+            onUsePhoto = {
+                if (activeCameraReview === review) activeCameraReview = null
+                if (pendingAttachments.none { it.id == item.id }) pendingAttachments.add(item)
+                cameraSourceAlert?.dismissWithoutAnimation()
+                updateAttachmentPreview()
+                updateSendButtonState()
+            },
+            onCancelReview = {
+                if (activeCameraReview === review) activeCameraReview = null
+                capture.discard()
+            }
+        )
+        val previousReview = activeCameraReview
+        activeCameraReview = review
+        review.show()
+        previousReview?.dismiss()
     }
 
     private fun requestLocationAndSend() {
@@ -5774,6 +5873,14 @@ open class ChatFragment : BaseFragment() {
         permissions: Array<out String>,
         grantResults: IntArray
     ) {
+        if (requestCode == REQUEST_CODE_CAMERA_PERMISSION) {
+            if (grantResults.firstOrNull() == PackageManager.PERMISSION_GRANTED) {
+                launchCameraPhoto()
+            } else {
+                getContext()?.let(CameraPermissionPrompt::show)
+            }
+            return
+        }
         if (requestCode == ChatAttachAlert.REQUEST_CODE_MEDIA_PERMISSION) {
             if (computeMediaPermissionGrantedFromResult(permissions, grantResults)) {
                 mediaPermissionDeniedOnce = false

--- a/app/src/main/java/com/mezon/mobile/home/chat/thread/CreateThreadFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/thread/CreateThreadFragment.kt
@@ -58,6 +58,9 @@ import com.mezon.mobile.home.chat.AttachmentPickerItem
 import com.mezon.mobile.home.chat.input.VoiceRecorder
 import com.mezon.mobile.home.chat.input.VoiceRecordingOverlay
 import com.mezon.mobile.home.chat.ChatAttachAlert
+import com.mezon.mobile.home.chat.CameraPhotoCapture
+import com.mezon.mobile.home.chat.CameraPhotoReviewDialog
+import com.mezon.mobile.home.chat.CameraPermissionPrompt
 import com.mezon.mobile.home.chat.EmojiItem
 import com.mezon.mobile.home.chat.emoji.EmojiView
 import com.mezon.mobile.home.chat.HashtagSpan
@@ -119,6 +122,8 @@ class CreateThreadFragment : BaseFragment() {
         private const val ARG_USE_TOPIC_FLOW = "useTopicFlow"
         private const val REQUEST_CODE_PICK_FILE = 1012
         private const val REQUEST_CODE_RECORD_AUDIO = 1013
+        private const val REQUEST_CODE_TAKE_PHOTO = 1014
+        private const val REQUEST_CODE_CAMERA_PERMISSION = 1015
         private const val VOICE_LONG_PRESS_DELAY_MS = 400L
         private const val VOICE_CANCEL_SLIDE_DP = 100f
 
@@ -193,6 +198,9 @@ class CreateThreadFragment : BaseFragment() {
     private var emojiViewVisible = false
     private var waitingForKeyboardOpen = false
     private val pendingAttachments = ArrayList<AttachmentPickerItem>()
+    private var pendingCameraCapture: CameraPhotoCapture? = null
+    private var cameraSourceAlert: ChatAttachAlert? = null
+    private var activeCameraReview: CameraPhotoReviewDialog? = null
     private val pendingAttachmentThumbTasks = ArrayList<Runnable?>()
     private val mentionTrackers = mutableListOf<MentionData>()
     private val hashtagTrackers = mutableListOf<HashtagData>()
@@ -1070,6 +1078,7 @@ class CreateThreadFragment : BaseFragment() {
         val ctx = getContext() ?: return
         val preselected = pendingAttachments.filter { !it.isFileType }
         val alert = ChatAttachAlert(ctx, mediaController, themeColors, preselected)
+        cameraSourceAlert = alert
         alert.attachDelegate = object : ChatAttachAlert.ChatAttachAlertDelegate {
             override fun canSelectMore(): Boolean {
                 return pendingAttachments.size < AttachmentPickerItem.GALLERY_MAX_SELECTION
@@ -1088,6 +1097,22 @@ class CreateThreadFragment : BaseFragment() {
 
             override fun onFilesRequested() {
                 launchDocumentPicker()
+            }
+
+            override fun onCameraRequested() {
+                if (!canSelectMore()) {
+                    android.widget.Toast.makeText(
+                        ctx,
+                        "Maximum ${AttachmentPickerItem.GALLERY_MAX_SELECTION} items",
+                        android.widget.Toast.LENGTH_SHORT
+                    ).show()
+                    return
+                }
+                requestCameraPhoto()
+            }
+
+            override fun onDismissed() {
+                if (cameraSourceAlert === alert) cameraSourceAlert = null
             }
         }
         alert.setDrawNavigationBar(true)
@@ -1126,7 +1151,54 @@ class CreateThreadFragment : BaseFragment() {
         )
     }
 
+    private fun requestCameraPhoto() {
+        val activity = getParentActivity() ?: return
+        if (ContextCompat.checkSelfPermission(activity, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
+            activity.requestPermissions(arrayOf(Manifest.permission.CAMERA), REQUEST_CODE_CAMERA_PERMISSION)
+            return
+        }
+        launchCameraPhoto()
+    }
+
+    private fun launchCameraPhoto(): Boolean {
+        val ctx = getContext() ?: return false
+        val capture = CameraPhotoCapture.create(ctx)
+        if (capture == null) {
+            MezonToast.show(this, ToastOverlay.ToastType.ERROR, getString(R.string.camera_not_available))
+            return false
+        }
+        pendingCameraCapture?.discard()
+        pendingCameraCapture = capture
+        try {
+            startActivityForResult(capture.intent, REQUEST_CODE_TAKE_PHOTO)
+            return true
+        } catch (_: android.content.ActivityNotFoundException) {
+            pendingCameraCapture = null
+            capture.discard()
+            MezonToast.show(this, ToastOverlay.ToastType.ERROR, getString(R.string.camera_not_available))
+            return false
+        }
+    }
+
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        if (requestCode == REQUEST_CODE_TAKE_PHOTO) {
+            val capture = pendingCameraCapture
+            pendingCameraCapture = null
+            if (resultCode != android.app.Activity.RESULT_OK) {
+                capture?.discard()
+                activeCameraReview?.dismiss()
+                activeCameraReview = null
+                return
+            }
+            val item = capture?.toAttachment()
+            if (item == null) {
+                capture?.discard()
+                MezonToast.show(this, ToastOverlay.ToastType.ERROR, getString(R.string.camera_capture_failed))
+                return
+            }
+            showCameraPhotoReview(capture, item)
+            return
+        }
         if (requestCode != REQUEST_CODE_PICK_FILE || resultCode != android.app.Activity.RESULT_OK) return
         val uri = data?.data ?: return
         val ctx = getContext() ?: return
@@ -1142,11 +1214,51 @@ class CreateThreadFragment : BaseFragment() {
         updateSendButtonState()
     }
 
+    private fun showCameraPhotoReview(capture: CameraPhotoCapture, item: AttachmentPickerItem) {
+        val ctx = getContext() ?: run {
+            capture.discard()
+            return
+        }
+        lateinit var review: CameraPhotoReviewDialog
+        review = CameraPhotoReviewDialog(
+            context = ctx,
+            capture = capture,
+            onRetake = {
+                launchCameraPhoto().also { launched ->
+                    if (launched) capture.discard()
+                }
+            },
+            onUsePhoto = {
+                if (activeCameraReview === review) activeCameraReview = null
+                if (pendingAttachments.none { it.id == item.id }) pendingAttachments.add(item)
+                cameraSourceAlert?.dismissWithoutAnimation()
+                updateAttachmentPreview()
+                updateSendButtonState()
+            },
+            onCancelReview = {
+                if (activeCameraReview === review) activeCameraReview = null
+                capture.discard()
+            }
+        )
+        val previousReview = activeCameraReview
+        activeCameraReview = review
+        review.show()
+        previousReview?.dismiss()
+    }
+
     override fun onRequestPermissionsResult(
         requestCode: Int,
         permissions: Array<out String>,
         grantResults: IntArray
     ) {
+        if (requestCode == REQUEST_CODE_CAMERA_PERMISSION) {
+            if (grantResults.firstOrNull() == PackageManager.PERMISSION_GRANTED) {
+                launchCameraPhoto()
+            } else {
+                getContext()?.let(CameraPermissionPrompt::show)
+            }
+            return
+        }
         if (requestCode == REQUEST_CODE_RECORD_AUDIO) {
             if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                 onVoiceLongPressFired()

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -86,6 +86,13 @@
     <string name="qr_login_failed">Xác nhận đăng nhập thất bại</string>
     <string name="qr_login_require_mobile_session">Phiên đăng nhập đã hết hạn. Vui lòng đăng nhập lại để xác nhận đăng nhập QR.</string>
     <string name="qr_camera_denied_title">Không có quyền camera</string>
+    <string name="camera_not_available">Không tìm thấy ứng dụng camera.</string>
+    <string name="camera_capture_failed">Không thể sử dụng ảnh này. Vui lòng thử lại.</string>
+    <string name="camera_photo_preview">Xem trước ảnh vừa chụp</string>
+    <string name="camera_retake">Chụp lại</string>
+    <string name="camera_use_photo">Dùng ảnh</string>
+    <string name="camera_permission_denied_title">Cần quyền truy cập camera</string>
+    <string name="camera_permission_denied_message">Vui lòng cho phép truy cập camera trong Cài đặt để chụp và gửi ảnh.</string>
     <string name="qr_camera_denied_message">Vui lòng bật quyền camera trong Cài đặt để quét QR.</string>
     <string name="qr_scan_title_hint">Quét mã QR</string>
     <string name="qr_scan_instructions">Hướng camera vào mã QR. Bạn cũng có thể chọn ảnh từ thư viện.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1159,6 +1159,13 @@
     <string name="permission_not_now">Not Now</string>
     <string name="permission_no_storage">Mezon needs access to your storage to send and save media. Please go to Settings and enable the permission.</string>
     <string name="permission_no_camera">Mezon needs access to your camera. Please go to Settings and enable the permission.</string>
+    <string name="camera_not_available">No camera app is available.</string>
+    <string name="camera_capture_failed">Couldn\'t use this photo. Please try again.</string>
+    <string name="camera_photo_preview">Captured photo preview</string>
+    <string name="camera_retake">Retake</string>
+    <string name="camera_use_photo">Use Photo</string>
+    <string name="camera_permission_denied_title">Camera access required</string>
+    <string name="camera_permission_denied_message">Please allow camera access in Settings to take and send photos.</string>
     <string name="permission_no_audio">Mezon needs access to your microphone. Please go to Settings and enable the permission.</string>
     <string name="permission_no_camera_mic_video">Mezon needs access to your camera and microphone for video messages. Please go to Settings and enable the permissions.</string>
     <string name="permission_no_location">Mezon needs access to your location. Please go to Settings and enable the permission.</string>


### PR DESCRIPTION
task: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-26
test cases:
Verify tapping the first gallery tile opens the camera.
Verify denying camera permission shows the Settings modal.
Verify “Open Settings” navigates to the app settings.
Verify “Retake” reopens the camera without screen flicker.
Verify “Use Photo” adds the photo to the attachment queue.
Verify the review screen closes smoothly after using a photo.
Verify canceling the camera returns to the gallery.
Verify the camera flow works in chats and thread creation.