### PR TITLE
260702-ANDROID-Fix bug community

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/clans/settings/CommunitySettingsController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/settings/CommunitySettingsController.kt
@@ -131,8 +131,17 @@ class CommunitySettingsController @Inject constructor(
     private fun updateDraft(block: CommunityFormDraft.() -> CommunityFormDraft) {
         _uiState.update { state ->
             val newDraft = state.draft.block()
+            val e = state.fieldErrors
+            val bannerOk = newDraft.pendingBannerBytes != null || !newDraft.bannerPreviewUrl.isNullOrBlank()
+            val newErrors = e.copy(
+                about = if (e.about && newDraft.about.trim().isNotEmpty()) false else e.about,
+                description = if (e.description && newDraft.description.trim().isNotEmpty()) false else e.description,
+                shortUrl = if (e.shortUrl && newDraft.shortUrl.trim().isNotEmpty()) false else e.shortUrl,
+                banner = if (e.banner && bannerOk) false else e.banner,
+            )
             state.copy(
                 draft = newDraft,
+                fieldErrors = newErrors,
                 showSaveBar = state.server.isCommunityEnabled &&
                     newDraft.hasChangesComparedTo(state.initial),
             )

--- a/app/src/main/java/com/mezon/mobile/home/clans/settings/CommunitySettingsFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/settings/CommunitySettingsFragment.kt
@@ -399,18 +399,9 @@ class CommunitySettingsFragment : BaseFragment() {
         }
         fieldsLayout.addView(aboutInput, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 0f, Gravity.NO_GRAVITY, 0f, 0f, 0f, 16f))
 
-        fieldsLayout.addView(
-            TextView(ctx).apply {
-                text = getString(R.string.community_settings_vanity_hint)
-                textSize = 12f
-                setTextColor(themeColors.onSurfaceVariant)
-                setPadding(0, 0, 0, LayoutHelper.dp(4f))
-            },
-            LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 0f, Gravity.NO_GRAVITY, 0f, 0f, 0f, 4f),
-        )
-
         val vanityInput = InputCell(ctx, themeColors).apply {
             setLabel(getString(R.string.community_settings_vanity_label), required = true)
+            setDescription(getString(R.string.community_settings_vanity_hint))
             setMaxCharacter(50)
             setShowCharacterCount(true)
             editText.hint = "my-awesome-community"

--- a/app/src/main/java/com/mezon/mobile/home/clans/settings/EmojiSettingFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/settings/EmojiSettingFragment.kt
@@ -1092,14 +1092,70 @@ class EmojiSettingFragment : BaseFragment() {
 
             val url = item.src.ifBlank { getEmojiUrl(item.id).orEmpty() }
             if (url.isNotBlank()) {
-                MezonImageLoader.getInstance(holder.emojiIv.context).load(
-                    url,
-                    LayoutHelper.dp(40f),
-                    LayoutHelper.dp(40f),
-                    onSuccess = { bmp -> holder.emojiIv.setImageBitmap(bmp) },
-                    onError = { _: Exception -> holder.emojiIv.setImageDrawable(null) },
-                )
+                holder.cancellable?.cancel()
+                if (com.mezon.mobile.core.SharedConfig.deviceIsLow()) {
+                    holder.cancellable = MezonImageLoader.getInstance(holder.emojiIv.context).load(
+                        url,
+                        LayoutHelper.dp(40f),
+                        LayoutHelper.dp(40f),
+                        onSuccess = { bmp -> holder.emojiIv.setImageBitmap(bmp) },
+                        onError = errLow@{ _: Exception ->
+                            val direct = com.mezon.mobile.util.getEmojiDirectUrl(item.id) ?: return@errLow
+                            if (direct == url) return@errLow
+                            holder.cancellable = MezonImageLoader.getInstance(holder.emojiIv.context).load(
+                                direct,
+                                LayoutHelper.dp(40f),
+                                LayoutHelper.dp(40f),
+                                onSuccess = { bmp -> holder.emojiIv.setImageBitmap(bmp) },
+                                onError = { holder.emojiIv.setImageDrawable(null) }
+                            )
+                        },
+                    )
+                } else {
+                    holder.cancellable = MezonImageLoader.getInstance(holder.emojiIv.context).loadDrawable(
+                        url,
+                        LayoutHelper.dp(40f),
+                        LayoutHelper.dp(40f),
+                        onSuccess = { d ->
+                            holder.emojiIv.setImageDrawable(d)
+                            if (d is android.graphics.drawable.AnimatedImageDrawable) {
+                                d.start()
+                            }
+                        },
+                        onError = errDrawable@{ _: Exception ->
+                            val direct = com.mezon.mobile.util.getEmojiDirectUrl(item.id) ?: run {
+                                holder.emojiIv.setImageDrawable(null)
+                                return@errDrawable
+                            }
+                            if (direct == url) {
+                                holder.emojiIv.setImageDrawable(null)
+                                return@errDrawable
+                            }
+                            holder.cancellable = MezonImageLoader.getInstance(holder.emojiIv.context).loadDrawable(
+                                direct,
+                                LayoutHelper.dp(40f),
+                                LayoutHelper.dp(40f),
+                                onSuccess = { d ->
+                                    holder.emojiIv.setImageDrawable(d)
+                                    if (d is android.graphics.drawable.AnimatedImageDrawable) {
+                                        d.start()
+                                    }
+                                },
+                                onError = {
+                                    holder.cancellable = MezonImageLoader.getInstance(holder.emojiIv.context).load(
+                                        direct,
+                                        LayoutHelper.dp(40f),
+                                        LayoutHelper.dp(40f),
+                                        onSuccess = { bmp -> holder.emojiIv.setImageBitmap(bmp) },
+                                        onError = { holder.emojiIv.setImageDrawable(null) }
+                                    )
+                                }
+                            )
+                        },
+                    )
+                }
             } else {
+                holder.cancellable?.cancel()
                 holder.emojiIv.setImageDrawable(null)
             }
 
@@ -1120,6 +1176,18 @@ class EmojiSettingFragment : BaseFragment() {
             val del = MezonIcon.closeSmallBold.getDrawable(holder.deleteBtn.context, themeColors.error)
             holder.deleteBtn.setImageDrawable(del)
             holder.deleteBtn.visibility = if (allow) View.VISIBLE else View.INVISIBLE
+        }
+        override fun onViewRecycled(holder: RecyclerView.ViewHolder) {
+            super.onViewRecycled(holder)
+            if (holder is RowVH) {
+                holder.cancellable?.cancel()
+                holder.cancellable = null
+                val d = holder.emojiIv.drawable
+                if (d is android.graphics.drawable.AnimatedImageDrawable) {
+                    d.stop()
+                }
+                holder.emojiIv.setImageDrawable(null)
+            }
         }
 
         private fun RowVH.showNameDisplay(shortname: String) {
@@ -1154,6 +1222,7 @@ class EmojiSettingFragment : BaseFragment() {
             val forSaleBadge: ImageView,
         ) : RecyclerView.ViewHolder(view) {
             var item: EmojiItem? = null
+            var cancellable: MezonImageLoader.Cancellable? = null
         }
     }
 }

--- a/app/src/main/java/com/mezon/mobile/ui/cells/InputCell.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/cells/InputCell.kt
@@ -24,8 +24,10 @@ import com.mezon.mobile.core.ThemeColors
 
 class InputCell(context: Context, private val theme: ThemeColors) : LinearLayout(context) {
 
+    private val labelContainer: LinearLayout
     private val labelView: TextView
     private val requiredMark: TextView
+    private val descriptionView: TextView
     val editText: EditText
     private val errorView: TextView
     private val clearButton: ImageView
@@ -41,13 +43,16 @@ class InputCell(context: Context, private val theme: ThemeColors) : LinearLayout
     init {
         orientation = VERTICAL
 
+        labelContainer = LinearLayout(context).apply {
+            orientation = HORIZONTAL
+            visibility = View.GONE
+        }
         labelView = TextView(context).apply {
             setTextColor(theme.onSurfaceVariant)
             textSize = 15f
             typeface = android.graphics.Typeface.DEFAULT_BOLD
-            visibility = View.GONE
         }
-        addView(labelView, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 0f, Gravity.START, 0f, 0f, 0f, 4f))
+        labelContainer.addView(labelView, LayoutHelper.createLinear(LayoutHelper.WRAP_CONTENT, LayoutHelper.WRAP_CONTENT))
 
         requiredMark = TextView(context).apply {
             text = " *"
@@ -55,6 +60,16 @@ class InputCell(context: Context, private val theme: ThemeColors) : LinearLayout
             textSize = 14f
             visibility = View.GONE
         }
+        labelContainer.addView(requiredMark, LayoutHelper.createLinear(LayoutHelper.WRAP_CONTENT, LayoutHelper.WRAP_CONTENT))
+        
+        addView(labelContainer, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 0f, Gravity.START, 0f, 0f, 0f, 4f))
+
+        descriptionView = TextView(context).apply {
+            setTextColor(theme.onSurfaceVariant)
+            textSize = 12f
+            visibility = View.GONE
+        }
+        addView(descriptionView, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 0f, Gravity.START, 0f, 0f, 0f, 4f))
 
         bgDrawable = GradientDrawable().apply {
             setColor(theme.surfaceVariant)
@@ -81,6 +96,12 @@ class InputCell(context: Context, private val theme: ThemeColors) : LinearLayout
             LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, Gravity.CENTER_VERTICAL,
             rightMargin = 32f
         ))
+        
+        inputContainer.setOnClickListener {
+            editText.requestFocus()
+            val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as android.view.inputmethod.InputMethodManager
+            imm.showSoftInput(editText, android.view.inputmethod.InputMethodManager.SHOW_IMPLICIT)
+        }
 
         clearButton = ImageView(context).apply {
             setImageResource(android.R.drawable.ic_menu_close_clear_cancel)
@@ -132,10 +153,19 @@ class InputCell(context: Context, private val theme: ThemeColors) : LinearLayout
     fun setLabel(label: String?, uppercase: Boolean = false, required: Boolean = false) {
         if (label != null) {
             labelView.text = if (uppercase) label.uppercase() else label
-            labelView.visibility = View.VISIBLE
+            labelContainer.visibility = View.VISIBLE
             requiredMark.visibility = if (required) View.VISIBLE else View.GONE
         } else {
-            labelView.visibility = View.GONE
+            labelContainer.visibility = View.GONE
+        }
+    }
+
+    fun setDescription(desc: String?) {
+        if (desc != null) {
+            descriptionView.text = desc
+            descriptionView.visibility = View.VISIBLE
+        } else {
+            descriptionView.visibility = View.GONE
         }
     }
 
@@ -156,7 +186,6 @@ class InputCell(context: Context, private val theme: ThemeColors) : LinearLayout
             editText.isSingleLine = false
             editText.maxLines = 6
             editText.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
-            editText.minHeight = LayoutHelper.dp(80)
             editText.gravity = Gravity.TOP or LayoutHelper.getAbsoluteGravityStart()
             (editText.layoutParams as FrameLayout.LayoutParams).gravity =
                 Gravity.TOP or LayoutHelper.getAbsoluteGravityStart()

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1538,4 +1538,25 @@
     <string name="transaction_detail_time">Thời gian</string>
     <string name="transaction_detail_sender">Tên người gửi</string>
     <string name="transaction_detail_receiver">Tên người nhận</string>
+    <string name="community_settings_title">Cài đặt cộng đồng</string>
+    <string name="community_settings_enable_button">Bật cộng đồng</string>
+    <string name="community_settings_enable_and_save">Bật &amp; Lưu</string>
+    <string name="community_settings_disable">Tắt cộng đồng</string>
+    <string name="community_settings_landing_title">Bật tính năng Cộng đồng</string>
+    <string name="community_settings_landing_subtitle">Thiết lập clan của bạn thành cộng đồng để khám phá và nhiều hơn thế.</string>
+    <string name="community_settings_banner_label">Ảnh bìa cộng đồng</string>
+    <string name="community_settings_banner_hint">Kích thước đề xuất: 1920×480. Tối đa 10 MB.</string>
+    <string name="community_settings_about_label">Giới thiệu</string>
+    <string name="community_settings_about_hint">Mô tả ngắn gọn cộng đồng của bạn (tối đa 100 ký tự)</string>
+    <string name="community_settings_description_label">Mô tả</string>
+    <string name="community_settings_description_hint">Nói cho mọi người biết cộng đồng của bạn về cái gì (tối đa 300 ký tự)</string>
+    <string name="community_settings_vanity_label">Đường dẫn tuỳ chỉnh</string>
+    <string name="community_settings_vanity_hint">VD: my-clan (viết thường, chữ cái, số, dấu gạch ngang)</string>
+    <string name="community_settings_pick_banner">Chọn ảnh bìa</string>
+    <string name="community_settings_error_required">Trường này là bắt buộc</string>
+    <string name="community_settings_error_fill_required">Vui lòng điền tất cả các trường bắt buộc</string>
+    <string name="community_settings_error_banner">Cần có ảnh bìa</string>
+    <string name="community_settings_error_banner_size">Kích thước ảnh phải nhỏ hơn 10 MB</string>
+    <string name="community_settings_error_banner_type">Vui lòng chọn file ảnh hợp lệ</string>
+    <string name="community_settings_permission_denied">Bạn không có quyền quản lý cài đặt cộng đồng</string>
 </resources>


### PR DESCRIPTION
[Bug 1]: UI bugs (Missing red *, extra space, wrong description position)

Root cause: The * mark was not added to the view hierarchy, editText had a forced minHeight causing misalignment, and the hint was placed as a separate view above the input field.
Solution: Wrapped the title and * in a horizontal layout, removed minHeight while delegating touch focus to the container, and used a built-in descriptionView below the title.
Test Case: Verify that required fields show a red asterisk, text areas have no extra top spacing, and the Vanity URL hint is displayed directly below its title.
[Bug 2]: Error message persists after typing in required fields

Root cause: The draft update logic did not re-evaluate or clear existing validation errors upon text changes.
Solution: Updated updateDraft to dynamically clear the specific field error in the UI state as soon as valid input is entered.
Test Case: Verify that the validation error message disappears immediately after typing text into a previously empty required field.
[Bug 3]: Missing Vietnamese localization

Root cause: The Vietnamese strings file (values-vi/strings.xml) lacked translations for the Community Settings screen.
Solution: Added all missing community_settings_* keys and their localized values to values-vi/strings.xml.
Test Case: Switch the device language to Vietnamese and verify that all texts in the Community Settings screen are correctly translated.