### PR TITLE
260703-ANDROID-Fix bug search msg

### DIFF
--- a/app/src/main/java/com/mezon/mobile/MainActivity.kt
+++ b/app/src/main/java/com/mezon/mobile/MainActivity.kt
@@ -977,13 +977,46 @@ class MainActivity : BasePermissionsActivity(),
         val routeMeta = resolveChatRouteMeta(channelId, clanId, channelType)
         val resolvedChannelName = resolveChatDisplayName(channelId, channelName, clanId, routeMeta.channelType)
         val lastFragment = actionBarLayout.getLastFragment()
-        if (lastFragment is ChatFragment && lastFragment.getChannelId() == channelId && messageId == 0L && !forceRejoin) {
+        if (lastFragment is ChatFragment &&
+            lastFragment.getChannelId() == channelId &&
+            lastFragment.getClanId() == clanId &&
+            !forceRejoin
+        ) {
             preloadChatContext(channelId, resolvedChannelName, clanId, routeMeta)
             if (fromNotification) {
                 clearStackAboveTabs()
                 switchToTabForClan(clanId)
             }
+            if (messageId != 0L) {
+                notificationCenter.postNotificationOnMainThread(
+                    NotificationCenter.jumpToMessage,
+                    channelId,
+                    messageId
+                )
+            }
             return
+        }
+
+        if (messageId != 0L && !forceRejoin) {
+            val stack = ArrayList(actionBarLayout.getFragmentStack())
+            val existingIndex = stack.indexOfLast { fragment ->
+                fragment is ChatFragment &&
+                    fragment.getChannelId() == channelId &&
+                    fragment.getClanId() == clanId
+            }
+            if (existingIndex >= 0) {
+                preloadChatContext(channelId, resolvedChannelName, clanId, routeMeta)
+                for (index in stack.lastIndex downTo existingIndex + 1) {
+                    actionBarLayout.removeFragmentFromStack(stack[index])
+                }
+                notificationCenter.postNotificationOnMainThread(
+                    NotificationCenter.jumpToMessage,
+                    channelId,
+                    messageId
+                )
+                actionBarLayout.showLastFragment()
+                return
+            }
         }
 
         if (fromNotification) {

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -464,6 +464,7 @@ open class ChatFragment : BaseFragment() {
     }
 
     fun getChannelId(): Long = channelId
+    fun getClanId(): Long = clanId
 
     override fun onFragmentCreate(): Boolean {
         super.onFragmentCreate()
@@ -487,9 +488,12 @@ open class ChatFragment : BaseFragment() {
                 channelName = cachedName
             }
         }
-        startLoadFromMessageId = 0L
+        startLoadFromMessageId = arguments?.getLong(ARG_MESSAGE_ID) ?: 0L
         startLoadFromMessageOffset = Int.MAX_VALUE
-        needScrollRestore = false
+        needScrollRestore = startLoadFromMessageId != 0L
+        if (startLoadFromMessageId != 0L) {
+            pendingHighlightMessageId = startLoadFromMessageId
+        }
 
         val readStateChannelId = if (isTopicMode && topicId != 0L) topicId else channelId
         if (clanId == 0L) {
@@ -1370,7 +1374,11 @@ open class ChatFragment : BaseFragment() {
             val targetChannelId = args.getOrNull(0) as? Long ?: return@observe
             val targetMessageId = args.getOrNull(1) as? Long ?: return@observe
             if (targetChannelId == channelId) {
-                pendingJumpMessageId = targetMessageId
+                if (!isPaused && fragmentView != null && !firstLoad && !isLoading) {
+                    scrollToReplyMessage(targetMessageId)
+                } else {
+                    pendingJumpMessageId = targetMessageId
+                }
             }
         }
 
@@ -1383,7 +1391,24 @@ open class ChatFragment : BaseFragment() {
         notificationCenter.addPostponeNotificationsCallback(postponeNewMessagesCallback)
 
         isLoading = true
-        chatController.loadMessages(channelId, clanId, forceRefresh = true, preferHttp = openedFromNotification, topicId = topicId)
+        if (startLoadFromMessageId != 0L) {
+            chatController.loadMessagesAround(
+                channelId = channelId,
+                clanId = clanId,
+                anchorMessageId = startLoadFromMessageId,
+                requireExactAnchor = true,
+                preferHttp = true,
+                topicId = topicId
+            )
+        } else {
+            chatController.loadMessages(
+                channelId,
+                clanId,
+                forceRefresh = true,
+                preferHttp = openedFromNotification,
+                topicId = topicId
+            )
+        }
         return true
     }
 
@@ -7011,8 +7036,13 @@ open class ChatFragment : BaseFragment() {
         val adapterPos = adapter.messagesStartRow + idx
         lm.scrollToPositionWithOffset(adapterPos, recyclerView.height / 3)
         recyclerView.post {
+            recyclerView.visibility = View.VISIBLE
+            needScrollRestore = false
             val vh = recyclerView.findViewHolderForAdapterPosition(adapterPos)
-            (vh?.itemView as? ChatMessageCell)?.setHighlight()
+            when (val itemView = vh?.itemView) {
+                is ChatMessageCell -> itemView.setHighlight()
+                is SystemMessageCell -> itemView.setHighlight()
+            }
         }
     }
 

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
@@ -143,7 +143,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
     }
 
     var hasMentionHighlight: Boolean = false
-    private var highlightProgress = 0f
+    private var jumpHighlightStartedAtMs = 0L
 
     var messageEntity: MessageEntity? = null
         private set
@@ -472,7 +472,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
     fun clearState() {
         messageEntity = null
         pendingMessage = null
-        highlightProgress = 0f
+        jumpHighlightStartedAtMs = 0L
         contentLayout = null
         senderLayout = null
         timeLayout = null
@@ -2870,7 +2870,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
     }
 
     fun setHighlight() {
-        highlightProgress = 1f
+        jumpHighlightStartedAtMs = android.os.SystemClock.uptimeMillis()
         invalidate()
     }
 
@@ -2889,12 +2889,25 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             canvas.drawRect(0f, 0f, MENTION_BAR_WIDTH.toFloat(), height.toFloat(), MENTION_BAR_PAINT)
         }
 
-        if (highlightProgress > 0f) {
-            val a = (highlightProgress * 0x30).toInt().coerceIn(0, 0xFF)
-            HIGHLIGHT_BG_PAINT.color = theme.midnightBlue and 0x00FFFFFF or (a shl 24)
+        if (jumpHighlightStartedAtMs != 0L) {
+            val elapsed = android.os.SystemClock.uptimeMillis() - jumpHighlightStartedAtMs
+            val progress = when {
+                elapsed <= HIGHLIGHT_HOLD_MS -> 1f
+                elapsed < HIGHLIGHT_HOLD_MS + HIGHLIGHT_FADE_MS ->
+                    1f - (elapsed - HIGHLIGHT_HOLD_MS).toFloat() / HIGHLIGHT_FADE_MS
+                else -> 0f
+            }
+            val a = (progress * HIGHLIGHT_MAX_ALPHA).toInt().coerceIn(0, 0xFF)
+            HIGHLIGHT_BG_PAINT.color = theme.blurple and 0x00FFFFFF or (a shl 24)
             canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), HIGHLIGHT_BG_PAINT)
-            highlightProgress = (highlightProgress - HIGHLIGHT_DECAY_STEP).coerceAtLeast(0f)
-            if (highlightProgress > 0f && visibleOnScreen) postInvalidateDelayed(16)
+            HIGHLIGHT_BORDER_PAINT.color = theme.blurple
+            HIGHLIGHT_BORDER_PAINT.alpha = (progress * 255).toInt().coerceIn(0, 255)
+            canvas.drawRect(0f, 0f, HIGHLIGHT_BORDER_WIDTH.toFloat(), height.toFloat(), HIGHLIGHT_BORDER_PAINT)
+            if (progress > 0f && visibleOnScreen) {
+                postInvalidateDelayed(16)
+            } else if (progress <= 0f) {
+                jumpHighlightStartedAtMs = 0L
+            }
         }
 
         val alpha = when {
@@ -4878,7 +4891,11 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         }
 
         private val HIGHLIGHT_BG_PAINT = Paint()
-        private const val HIGHLIGHT_DECAY_STEP = 16f / 2000f
+        private val HIGHLIGHT_BORDER_PAINT = Paint()
+        private val HIGHLIGHT_BORDER_WIDTH = LayoutHelper.dp(2f)
+        private const val HIGHLIGHT_HOLD_MS = 1_500L
+        private const val HIGHLIGHT_FADE_MS = 300L
+        private const val HIGHLIGHT_MAX_ALPHA = 0x30
 
         private val REPLY_CONNECTOR_PAINT = Paint(Paint.ANTI_ALIAS_FLAG).apply {
             color = 0xFF5C5E66.toInt()

--- a/app/src/main/java/com/mezon/mobile/home/chat/SystemMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/SystemMessageCell.kt
@@ -1,6 +1,8 @@
 package com.mezon.mobile.home.chat
 
 import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
 import android.graphics.drawable.Drawable
 import android.text.SpannableStringBuilder
 import android.text.Spanned
@@ -83,9 +85,11 @@ class SystemMessageCell(context: Context, private val theme: ThemeColors) : Line
     }
 
     var channelName: String = ""
+    private var jumpHighlightStartedAtMs = 0L
 
     init {
         orientation = VERTICAL
+        setWillNotDraw(false)
         setPadding(PAD_H, PAD_V, PAD_H, PAD_V)
 
         plainMessageTextView.onMentionClick = { uid, rid ->
@@ -121,6 +125,40 @@ class SystemMessageCell(context: Context, private val theme: ThemeColors) : Line
 
         row.addView(textColumn)
         addView(row)
+    }
+
+    fun setHighlight() {
+        jumpHighlightStartedAtMs = android.os.SystemClock.uptimeMillis()
+        invalidate()
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        if (jumpHighlightStartedAtMs == 0L) return
+        val elapsed = android.os.SystemClock.uptimeMillis() - jumpHighlightStartedAtMs
+        val progress = when {
+            elapsed <= HIGHLIGHT_HOLD_MS -> 1f
+            elapsed < HIGHLIGHT_HOLD_MS + HIGHLIGHT_FADE_MS ->
+                1f - (elapsed - HIGHLIGHT_HOLD_MS).toFloat() / HIGHLIGHT_FADE_MS
+            else -> 0f
+        }
+        val alpha = (progress * HIGHLIGHT_MAX_ALPHA).toInt().coerceIn(0, 255)
+        JUMP_HIGHLIGHT_PAINT.color = theme.blurple and 0x00FFFFFF or (alpha shl 24)
+        canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), JUMP_HIGHLIGHT_PAINT)
+        JUMP_HIGHLIGHT_BORDER_PAINT.color = theme.blurple
+        JUMP_HIGHLIGHT_BORDER_PAINT.alpha = (progress * 255).toInt().coerceIn(0, 255)
+        canvas.drawRect(
+            0f,
+            0f,
+            HIGHLIGHT_BORDER_WIDTH.toFloat(),
+            height.toFloat(),
+            JUMP_HIGHLIGHT_BORDER_PAINT
+        )
+        if (progress > 0f) {
+            postInvalidateDelayed(16)
+        } else {
+            jumpHighlightStartedAtMs = 0L
+        }
     }
 
     fun update(mask: Int, newMsg: MessageEntity? = null): Boolean {
@@ -353,6 +391,12 @@ class SystemMessageCell(context: Context, private val theme: ThemeColors) : Line
     }
 
     companion object {
+        private val JUMP_HIGHLIGHT_PAINT = Paint()
+        private val JUMP_HIGHLIGHT_BORDER_PAINT = Paint()
+        private val HIGHLIGHT_BORDER_WIDTH = LayoutHelper.dp(2f)
+        private const val HIGHLIGHT_HOLD_MS = 1_500L
+        private const val HIGHLIGHT_FADE_MS = 300L
+        private const val HIGHLIGHT_MAX_ALPHA = 0x30
         private val ICON_SIZE_SMALL = LayoutHelper.dp(20)
         private val ICON_GAP = LayoutHelper.dp(8)
         private val PAD_H = LayoutHelper.dp(16)

--- a/app/src/main/java/com/mezon/mobile/search/GlobalSearchAdapter.kt
+++ b/app/src/main/java/com/mezon/mobile/search/GlobalSearchAdapter.kt
@@ -19,7 +19,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 class GlobalSearchAdapter(
-    private val themeColors: ThemeColors
+    private val themeColors: ThemeColors,
+    private val resolveMessageSenderName: (SearchMessageDocument) -> String? = { null }
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     companion object {
@@ -97,7 +98,9 @@ class GlobalSearchAdapter(
                 )
                 view.update(0, item)
             }
-            is MessageSearchCell -> if (item is SearchMessageDocument) view.update(0, item)
+            is MessageSearchCell -> if (item is SearchMessageDocument) {
+                view.update(0, item, resolveMessageSenderName(item))
+            }
             is HeaderCell -> if (item is SectionHeader) view.setText(item.title)
         }
     }
@@ -148,6 +151,12 @@ class GlobalSearchAdapter(
             newItems.addAll(messages)
         }
         submitList(newItems)
+    }
+
+    fun refreshMessageSenders() {
+        if (items.any { it is SearchMessageDocument }) {
+            notifyItemRangeChanged(0, itemCount)
+        }
     }
 
     private fun submitList(newItems: List<Any>) {

--- a/app/src/main/java/com/mezon/mobile/search/GlobalSearchFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/search/GlobalSearchFragment.kt
@@ -3,20 +3,26 @@ package com.mezon.mobile.search
 import android.content.Context
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
+import android.graphics.Typeface
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.GradientDrawable
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewOutlineProvider
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.ProgressBar
+import android.widget.PopupWindow
 import android.widget.TextView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.mezon.mezon.api.SearchMessageDocument
 import com.mezon.mobile.R
 import com.mezon.mobile.core.AndroidUtilities
 import com.mezon.mobile.core.BaseFragment
@@ -38,7 +44,6 @@ import com.mezon.mobile.home.stream.JoinMediaSheetKind
 import com.mezon.mobile.home.stream.StreamingController
 import com.mezon.mobile.ui.cells.ChannelSearchCell
 import com.mezon.mobile.ui.cells.MezonIcon
-import com.mezon.mobile.ui.cells.PopupMenu
 import com.mezon.mobile.ui.cells.ProfileSearchCell
 import com.mezon.mobile.core.ThemeColors
 import com.mezon.mobile.network.CHANNEL_TYPE_DM
@@ -46,6 +51,11 @@ import com.mezon.mobile.ui.cells.SearchCell
 import com.mezon.mobile.ui.cells.SearchTabHeader
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+
+private enum class MessageUserFilter {
+    FROM,
+    MENTIONS
+}
 
 class GlobalSearchFragment : BaseFragment() {
 
@@ -125,6 +135,9 @@ class GlobalSearchFragment : BaseFragment() {
     private var pickerQuery = ""
     private var pickerDisplayLimit = LOCAL_PAGE_SIZE
     private var pickerFilterRunnable: Runnable? = null
+    private var activeUserFilter: MessageUserFilter? = null
+    private var filterUser: SearchMember? = null
+    private var isPickingFilterUser = false
 
     var onOpenChat: ((channelId: Long, channelName: String, clanId: Long, channelType: Int) -> Unit)? = null
 
@@ -174,9 +187,14 @@ class GlobalSearchFragment : BaseFragment() {
         }
         observe(NotificationCenter.clanMembersDidLoad) { _, _, _ ->
             if (fragmentView == null || isPaused) return@observe
-            if (channelScopedMembers == null) return@observe
-            buildChannelScopedMembers()
-            if (currentTab == TAB_MEMBERS) updateMembersList()
+            if (channelScopedMembers != null) {
+                buildChannelScopedMembers()
+                if (currentTab == TAB_MEMBERS) updateMembersList()
+            }
+            if (currentTab == TAB_MESSAGES) {
+                updateMessagesList()
+                adapter.refreshMessageSenders()
+            }
             updateTabCounts()
         }
         observe(NotificationCenter.channelMembersDidLoad) { _, _, _ ->
@@ -221,6 +239,7 @@ class GlobalSearchFragment : BaseFragment() {
             membersRequested = true
             searchController.loadMembers()
         }
+        if (argClanId != 0L) userClanController.loadClanMembers(argClanId)
         return true
     }
 
@@ -231,7 +250,7 @@ class GlobalSearchFragment : BaseFragment() {
             SearchMember(
                 id = m.userId,
                 username = m.username,
-                displayName = m.displayName.ifEmpty { m.username },
+                displayName = m.clanNick.ifEmpty { m.displayName }.ifEmpty { m.username },
                 avatarUrl = m.clanAvatar.ifEmpty { m.avatarUrl },
                 isOnline = m.isOnline,
                 isDm = argClanId == 0L,
@@ -281,17 +300,20 @@ class GlobalSearchFragment : BaseFragment() {
         })
 
         searchCell = SearchCell(context, themeColors).apply {
-            setPlaceholder("Search")
+            setPlaceholder(context.getString(R.string.common_search))
             onTextChanged = { text ->
                 if (isChannelPickerMode) {
                     pickerQuery = text
                     schedulePickerFilter()
                 } else {
                     searchText = text
+                    if (text.isBlank() && filterUser == null) {
+                        searchController.clearSearchMessages()
+                    }
                     scheduleSearch()
                 }
             }
-            onBadgeRemoved = { clearChannelFilter() }
+            onBadgeRemoved = { clearActiveBadgeFilter() }
         }
         headerRow.addView(searchCell, LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f))
 
@@ -330,9 +352,9 @@ class GlobalSearchFragment : BaseFragment() {
 
         val tabLabels = visibleTabs.map { tab ->
             when (tab) {
-                TAB_MEMBERS -> "Members"
-                TAB_CHANNELS -> "Channels"
-                TAB_MESSAGES -> "Messages"
+                TAB_MEMBERS -> context.getString(R.string.search_tab_members)
+                TAB_CHANNELS -> context.getString(R.string.search_tab_channels)
+                TAB_MESSAGES -> context.getString(R.string.search_tab_messages)
                 else -> ""
             }
         }
@@ -349,8 +371,8 @@ class GlobalSearchFragment : BaseFragment() {
         }
 
         if (filterChannelId != 0L) {
-            searchCell.setBadge("in: $filterChannelName")
-            searchCell.setPlaceholder("Search messages...")
+            searchCell.setBadge(context.getString(R.string.search_filter_channel_badge, filterChannelName))
+            searchCell.setPlaceholder(context.getString(R.string.search_messages_placeholder))
         }
         root.addView(tabHeader, LinearLayout.LayoutParams(
             LinearLayout.LayoutParams.MATCH_PARENT,
@@ -385,7 +407,7 @@ class GlobalSearchFragment : BaseFragment() {
         loadingView = ProgressBar(context).apply { visibility = View.GONE }
         contentFrame!!.addView(loadingView, LayoutHelper.createFrame(48, 48, Gravity.CENTER))
 
-        adapter = GlobalSearchAdapter(themeColors)
+        adapter = GlobalSearchAdapter(themeColors, ::resolveMessageSenderName)
         adapter.onChannelJoinClick = { d ->
             showJoinVoiceBottomSheet(d.channel)
         }
@@ -395,6 +417,10 @@ class GlobalSearchFragment : BaseFragment() {
             when (view) {
                 is ProfileSearchCell -> {
                     val member = view.member ?: return@OnItemClickListener
+                    if (isPickingFilterUser) {
+                        applyUserFilter(member)
+                        return@OnItemClickListener
+                    }
                     if (member.isDm && member.channelId != 0L) {
                         onOpenChat?.invoke(member.channelId, member.displayName, 0L, member.channelType)
                     } else {
@@ -409,7 +435,19 @@ class GlobalSearchFragment : BaseFragment() {
                     val doc = view.document ?: return@OnItemClickListener
                     val channelId = doc.channelId.toLongOrNull() ?: return@OnItemClickListener
                     val clanId = doc.clanId.toLongOrNull() ?: 0L
-                    onOpenChat?.invoke(channelId, doc.channelLabel, clanId, doc.channelType)
+                    val messageId = doc.messageId.toLongOrNull() ?: return@OnItemClickListener
+                    val activity = getParentActivity() as? MainActivity
+                    if (activity != null) {
+                        activity.openChat(
+                            channelId = channelId,
+                            channelName = doc.channelLabel,
+                            clanId = clanId,
+                            channelType = doc.channelType,
+                            messageId = messageId
+                        )
+                    } else {
+                        onOpenChat?.invoke(channelId, doc.channelLabel, clanId, doc.channelType)
+                    }
                 }
             }
         })
@@ -507,13 +545,10 @@ class GlobalSearchFragment : BaseFragment() {
                 }
             }
             TAB_MESSAGES -> {
-                if (searchText.isNotBlank()) {
+                if (searchText.isNotBlank() || filterUser != null) {
                     loadingView.visibility = View.VISIBLE
                     recyclerView.visibility = View.GONE
-                    searchController.searchMessagesApi(
-                        channelId = filterChannelId,
-                        content = searchText
-                    )
+                    searchMessages()
                 } else {
                     loadingView.visibility = View.GONE
                     searchController.clearSearchMessages()
@@ -577,7 +612,7 @@ class GlobalSearchFragment : BaseFragment() {
         val messages = searchController.getMessages()
         adapter.setMessages(messages)
         adapter.hasMore = searchController.hasMoreMessages && messages.isNotEmpty()
-        updateEmptyState(messages.isEmpty() && searchText.isNotBlank())
+        updateEmptyState(messages.isEmpty() && (searchText.isNotBlank() || filterUser != null))
     }
 
     private fun loadMoreResults() {
@@ -600,11 +635,14 @@ class GlobalSearchFragment : BaseFragment() {
                 isLoadingMore = false
             }
             TAB_MESSAGES -> {
-                if (!searchController.hasMoreMessages || searchText.isBlank()) return
+                if (!searchController.hasMoreMessages ||
+                    (searchText.isBlank() && filterUser == null)) return
                 isLoadingMore = true
                 searchController.loadMoreMessages(
                     channelId = filterChannelId,
-                    content = searchText
+                    content = searchText,
+                    username = filterUsername(),
+                    mentionUserId = filterMentionUserId()
                 )
             }
         }
@@ -635,7 +673,11 @@ class GlobalSearchFragment : BaseFragment() {
             searchController.filterMembersCount(searchText)
         }
         val channelsCount = searchController.filterChannelsCount(searchText)
-        val messagesCount = searchController.searchMessagesTotal
+        val messagesCount = if (searchText.isBlank() && filterUser == null) {
+            0
+        } else {
+            searchController.searchMessagesTotal
+        }
         val counts = visibleTabs.map { tab ->
             when (tab) {
                 TAB_MEMBERS -> membersCount
@@ -653,12 +695,230 @@ class GlobalSearchFragment : BaseFragment() {
     }
 
     private fun showFilterOptions(anchor: View) {
-        val popup = PopupMenu(anchor.context, themeColors)
-        popup.addItem("in: filter by channel", MezonIcon.channelText)
-        popup.setOnItemClickListener { _ ->
-            enterChannelPicker()
+        val context = anchor.context
+        val menuWidth = LayoutHelper.dp(220f)
+        val container = LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+            background = GradientDrawable().apply {
+                cornerRadius = LayoutHelper.dpf(10f)
+                setColor(themeColors.surface)
+                setStroke(LayoutHelper.dp(1f), themeColors.borderDim)
+            }
+            clipToOutline = true
+            outlineProvider = ViewOutlineProvider.BACKGROUND
+            elevation = LayoutHelper.dpf(8f)
         }
-        popup.show(anchor)
+
+        container.addView(TextView(context).apply {
+            text = context.getString(R.string.search_filter_results)
+            setTextColor(themeColors.onSurface)
+            textSize = 14f
+            setTypeface(typeface, Typeface.BOLD)
+            gravity = Gravity.CENTER_VERTICAL
+            setPadding(LayoutHelper.dp(14f), 0, LayoutHelper.dp(14f), 0)
+        }, LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.MATCH_PARENT,
+            LayoutHelper.dp(36f)
+        ))
+        container.addView(createFilterDivider(context))
+
+        lateinit var popup: PopupWindow
+        container.addView(createFilterOptionRow(
+            context = context,
+            label = context.getString(R.string.search_filter_from_label),
+            description = context.getString(R.string.search_filter_from_description),
+            icon = MezonIcon.userIcon,
+            onClick = {
+                popup.dismiss()
+                selectUserFilter(MessageUserFilter.FROM)
+            }
+        ))
+        container.addView(createFilterDivider(context, horizontalInset = 10f))
+        container.addView(createFilterOptionRow(
+            context = context,
+            label = context.getString(R.string.search_filter_mentions_label),
+            description = context.getString(R.string.search_filter_mentions_description),
+            icon = MezonIcon.atIcon,
+            onClick = {
+                popup.dismiss()
+                selectUserFilter(MessageUserFilter.MENTIONS)
+            }
+        ))
+
+        popup = PopupWindow(
+            container,
+            menuWidth,
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            true
+        ).apply {
+            isOutsideTouchable = true
+            elevation = LayoutHelper.dpf(8f)
+            setBackgroundDrawable(ColorDrawable(android.graphics.Color.TRANSPARENT))
+        }
+        popup.showAsDropDown(anchor, 0, LayoutHelper.dp(6f), Gravity.END)
+    }
+
+    private fun createFilterOptionRow(
+        context: Context,
+        label: String,
+        description: String,
+        icon: MezonIcon,
+        onClick: () -> Unit
+    ): View {
+        return LinearLayout(context).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+            setPadding(LayoutHelper.dp(14f), 0, LayoutHelper.dp(12f), 0)
+            isClickable = true
+            isFocusable = true
+            background = context.getDrawable(android.R.drawable.list_selector_background)
+            setOnClickListener { onClick() }
+
+            addView(LinearLayout(context).apply {
+                orientation = LinearLayout.VERTICAL
+                gravity = Gravity.CENTER_VERTICAL
+                addView(TextView(context).apply {
+                    text = label
+                    setTextColor(themeColors.onSurface)
+                    textSize = 14f
+                    setTypeface(typeface, Typeface.BOLD)
+                    includeFontPadding = false
+                })
+                addView(TextView(context).apply {
+                    text = description
+                    setTextColor(themeColors.onSurfaceVariant)
+                    textSize = 13f
+                    includeFontPadding = false
+                }, LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.WRAP_CONTENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT
+                ).apply { topMargin = LayoutHelper.dp(2f) })
+            }, LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f))
+
+            addView(ImageView(context).apply {
+                setImageDrawable(icon.getDrawable(context, themeColors.onSurfaceVariant))
+                scaleType = ImageView.ScaleType.CENTER_INSIDE
+            }, LinearLayout.LayoutParams(LayoutHelper.dp(20f), LayoutHelper.dp(20f)))
+        }.also {
+            it.layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LayoutHelper.dp(52f)
+            )
+        }
+    }
+
+    private fun createFilterDivider(context: Context, horizontalInset: Float = 0f): View {
+        return View(context).apply {
+            setBackgroundColor(themeColors.borderDim)
+            layoutParams = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LayoutHelper.dp(1f)
+            ).apply {
+                marginStart = LayoutHelper.dp(horizontalInset)
+                marginEnd = LayoutHelper.dp(horizontalInset)
+            }
+        }
+    }
+
+    private fun selectUserFilter(filter: MessageUserFilter) {
+        activeUserFilter = filter
+        filterUser = null
+        isPickingFilterUser = true
+        currentTab = TAB_MEMBERS
+        tabHeader.visibility = View.GONE
+        updateFilterButtonVisibility()
+        searchCell.setBadge(filterLabel(filter))
+        searchCell.editText.text?.clear()
+        searchRunnable?.let { handler.removeCallbacks(it) }
+        searchText = ""
+        updateMembersList()
+        searchCell.focusInput()
+    }
+
+    private fun applyUserFilter(member: SearchMember) {
+        filterUser = member
+        isPickingFilterUser = false
+        tabHeader.visibility = View.VISIBLE
+        currentTab = TAB_MESSAGES
+        visibleTabs.indexOf(TAB_MESSAGES).takeIf { it >= 0 }?.let(tabHeader::selectTab)
+        updateFilterButtonVisibility()
+
+        searchCell.editText.text?.clear()
+        searchRunnable?.let { handler.removeCallbacks(it) }
+        searchText = ""
+        updateSearchBadge()
+        loadingView.visibility = View.VISIBLE
+        recyclerView.visibility = View.GONE
+        searchMessages()
+    }
+
+    private fun clearActiveBadgeFilter() {
+        if (activeUserFilter != null || filterUser != null || isPickingFilterUser) {
+            activeUserFilter = null
+            filterUser = null
+            isPickingFilterUser = false
+            tabHeader.visibility = View.VISIBLE
+            currentTab = TAB_MEMBERS
+            visibleTabs.indexOf(TAB_MEMBERS).takeIf { it >= 0 }?.let(tabHeader::selectTab)
+            updateFilterButtonVisibility()
+            updateSearchBadge()
+            searchController.clearSearchMessages()
+            updateCurrentTab()
+            updateTabCounts()
+        } else {
+            clearChannelFilter()
+        }
+    }
+
+    private fun updateSearchBadge() {
+        val user = filterUser
+        if (user != null && activeUserFilter != null) {
+            searchCell.setBadge(getString(
+                R.string.search_filter_user_badge,
+                filterLabel(activeUserFilter!!),
+                filterDisplayName(user)
+            ))
+        } else if (filterChannelId != 0L) {
+            searchCell.setBadge(getString(R.string.search_filter_channel_badge, filterChannelName))
+        } else {
+            searchCell.removeBadge()
+        }
+    }
+
+    private fun filterDisplayName(member: SearchMember): String {
+        val clanId = argClanId.takeIf { it != 0L }
+        val clanNick = clanId?.let { id ->
+            userClanController.getClanMembers(id)
+                .firstOrNull { it.userId == member.id }
+                ?.clanNick
+        }
+        return clanNick?.takeIf { it.isNotBlank() }
+            ?: member.displayName.ifEmpty { member.username }
+    }
+
+    private fun filterLabel(filter: MessageUserFilter): String = getString(
+        if (filter == MessageUserFilter.FROM) {
+            R.string.search_filter_from_label
+        } else {
+            R.string.search_filter_mentions_label
+        }
+    )
+
+    private fun filterUsername(): String =
+        if (activeUserFilter == MessageUserFilter.FROM) {
+            filterUser?.let(::filterDisplayName).orEmpty()
+        } else ""
+
+    private fun filterMentionUserId(): Long =
+        if (activeUserFilter == MessageUserFilter.MENTIONS) filterUser?.id ?: 0L else 0L
+
+    private fun searchMessages() {
+        searchController.searchMessagesApi(
+            channelId = filterChannelId,
+            content = searchText,
+            username = filterUsername(),
+            mentionUserId = filterMentionUserId()
+        )
     }
 
     private fun ensureChannelPicker() {
@@ -713,7 +973,7 @@ class GlobalSearchFragment : BaseFragment() {
 
         searchCell.editText.text?.clear()
         searchRunnable?.let { handler.removeCallbacks(it) }
-        searchCell.setPlaceholder("Search channels...")
+        searchCell.setPlaceholder(getString(R.string.search_channels_placeholder))
         searchCell.focusInput()
     }
 
@@ -727,7 +987,7 @@ class GlobalSearchFragment : BaseFragment() {
 
         searchCell.editText.text?.clear()
         searchRunnable?.let { handler.removeCallbacks(it) }
-        searchCell.setPlaceholder("Search")
+        searchCell.setPlaceholder(getString(R.string.common_search))
         AndroidUtilities.hideKeyboard(searchCell.editText)
 
         updateCurrentTab()
@@ -736,7 +996,7 @@ class GlobalSearchFragment : BaseFragment() {
     private fun applyChannelFilter(channel: ClanChannelEntity) {
         filterChannelId = channel.channelId
         filterChannelName = channel.channelLabel
-        searchCell.setBadge("in: ${channel.channelLabel}")
+        searchCell.setBadge(getString(R.string.search_filter_channel_badge, channel.channelLabel))
 
         isChannelPickerMode = false
         channelPickerView?.jumpDrawablesToCurrentState()
@@ -747,15 +1007,12 @@ class GlobalSearchFragment : BaseFragment() {
 
         searchCell.editText.text?.clear()
         searchRunnable?.let { handler.removeCallbacks(it) }
-        searchCell.setPlaceholder("Search messages...")
+        searchCell.setPlaceholder(getString(R.string.search_messages_placeholder))
         AndroidUtilities.hideKeyboard(searchCell.editText)
 
         if (currentTab == TAB_MESSAGES) {
             loadingView.visibility = View.VISIBLE
-            searchController.searchMessagesApi(
-                channelId = filterChannelId,
-                content = searchText
-            )
+            searchMessages()
         }
     }
 
@@ -763,11 +1020,11 @@ class GlobalSearchFragment : BaseFragment() {
         filterChannelId = 0L
         filterChannelName = ""
         searchCell.removeBadge()
-        searchCell.setPlaceholder("Search")
+        searchCell.setPlaceholder(getString(R.string.common_search))
         if (currentTab == TAB_MESSAGES) {
-            if (searchText.isNotBlank()) {
+            if (searchText.isNotBlank() || filterUser != null) {
                 loadingView.visibility = View.VISIBLE
-                searchController.searchMessagesApi(content = searchText)
+                searchMessages()
             } else {
                 searchController.clearSearchMessages()
                 updateMessagesList()
@@ -823,11 +1080,25 @@ class GlobalSearchFragment : BaseFragment() {
         for (m in clanMembers) memberMap[m.userId] = m
         return memberIds.map { uid ->
             val m = memberMap[uid]
-            val name = m?.clanNick?.ifEmpty { null } ?: m?.displayName?.ifEmpty { null } ?: m?.username ?: "User"
+            val name = m?.clanNick?.ifEmpty { null }
+                ?: m?.displayName?.ifEmpty { null }
+                ?: m?.username
+                ?: getString(R.string.search_user_fallback)
             val username = m?.username.orEmpty()
             val avatar = m?.clanAvatar?.ifEmpty { null } ?: m?.avatarUrl
             VoiceMemberDisplay(uid, name, username, avatar)
         }
+    }
+
+    private fun resolveMessageSenderName(document: SearchMessageDocument): String? {
+        val clanId = document.clanId.toLongOrNull() ?: argClanId
+        val senderId = document.senderId.toLongOrNull() ?: return null
+        val member = userClanController.getClanMembers(clanId)
+            .firstOrNull { it.userId == senderId }
+        return member?.clanNick?.takeIf { it.isNotBlank() }
+            ?: member?.displayName?.takeIf { it.isNotBlank() }
+            ?: document.displayName.takeIf { it.isNotBlank() }
+            ?: document.username
     }
 
     private fun navigateToDm(member: SearchMember) {

--- a/app/src/main/java/com/mezon/mobile/search/GlobalSearchFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/search/GlobalSearchFragment.kt
@@ -789,7 +789,14 @@ class GlobalSearchFragment : BaseFragment() {
             setPadding(LayoutHelper.dp(14f), 0, LayoutHelper.dp(12f), 0)
             isClickable = true
             isFocusable = true
-            background = context.getDrawable(android.R.drawable.list_selector_background)
+            val rippleColor = android.content.res.ColorStateList.valueOf(
+                (themeColors.onSurface and 0x00FFFFFF) or 0x1A000000
+            )
+            background = android.graphics.drawable.RippleDrawable(
+                rippleColor,
+                android.graphics.drawable.ColorDrawable(android.graphics.Color.TRANSPARENT),
+                android.graphics.drawable.ColorDrawable(android.graphics.Color.WHITE)
+            )
             setOnClickListener { onClick() }
 
             addView(LinearLayout(context).apply {

--- a/app/src/main/java/com/mezon/mobile/search/GlobalSearchFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/search/GlobalSearchFragment.kt
@@ -546,6 +546,7 @@ class GlobalSearchFragment : BaseFragment() {
             }
             TAB_MESSAGES -> {
                 if (searchText.isNotBlank() || filterUser != null) {
+                    emptyView.visibility = View.GONE
                     loadingView.visibility = View.VISIBLE
                     recyclerView.visibility = View.GONE
                     searchMessages()
@@ -612,7 +613,18 @@ class GlobalSearchFragment : BaseFragment() {
         val messages = searchController.getMessages()
         adapter.setMessages(messages)
         adapter.hasMore = searchController.hasMoreMessages && messages.isNotEmpty()
-        updateEmptyState(messages.isEmpty() && (searchText.isNotBlank() || filterUser != null))
+        val hasSearchCriteria = searchText.isNotBlank() || filterUser != null
+        when {
+            !hasSearchCriteria -> updateEmptyState(
+                isEmpty = true,
+                emptyTextRes = R.string.search_type_to_search_messages
+            )
+            messages.isEmpty() -> updateEmptyState(
+                isEmpty = true,
+                emptyTextRes = R.string.search_no_messages_found
+            )
+            else -> updateEmptyState(false)
+        }
     }
 
     private fun loadMoreResults() {
@@ -648,8 +660,12 @@ class GlobalSearchFragment : BaseFragment() {
         }
     }
 
-    private fun updateEmptyState(isEmpty: Boolean) {
+    private fun updateEmptyState(
+        isEmpty: Boolean,
+        emptyTextRes: Int = R.string.common_no_results_found
+    ) {
         if (isEmpty) {
+            emptyView.setText(emptyTextRes)
             emptyView.visibility = View.VISIBLE
             recyclerView.visibility = View.GONE
         } else {
@@ -690,7 +706,9 @@ class GlobalSearchFragment : BaseFragment() {
     }
 
     private fun updateFilterButtonVisibility() {
-        val showFilter = currentTab == TAB_MESSAGES && !isChannelPickerMode
+        val showFilter = (currentTab == TAB_MEMBERS || currentTab == TAB_MESSAGES) &&
+            !isChannelPickerMode &&
+            !isPickingFilterUser
         filterButton?.visibility = if (showFilter) View.VISIBLE else View.GONE
     }
 
@@ -838,7 +856,7 @@ class GlobalSearchFragment : BaseFragment() {
     private fun applyUserFilter(member: SearchMember) {
         filterUser = member
         isPickingFilterUser = false
-        tabHeader.visibility = View.VISIBLE
+        tabHeader.visibility = View.GONE
         currentTab = TAB_MESSAGES
         visibleTabs.indexOf(TAB_MESSAGES).takeIf { it >= 0 }?.let(tabHeader::selectTab)
         updateFilterButtonVisibility()

--- a/app/src/main/java/com/mezon/mobile/search/MessageSearchCell.kt
+++ b/app/src/main/java/com/mezon/mobile/search/MessageSearchCell.kt
@@ -6,6 +6,7 @@ import android.graphics.RectF
 import android.text.StaticLayout
 import android.text.TextUtils
 import com.mezon.mezon.api.SearchMessageDocument
+import com.mezon.mobile.R
 import com.mezon.mobile.core.AvatarDrawable
 import com.mezon.mobile.core.BaseCell
 import com.mezon.mobile.core.LayoutHelper
@@ -27,6 +28,7 @@ class MessageSearchCell(context: Context, private val theme: ThemeColors) : Base
     private var senderLayout: StaticLayout? = null
     private var contentLayout: StaticLayout? = null
     private var channelLayout: StaticLayout? = null
+    private var resolvedSenderName: String? = null
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
@@ -35,8 +37,13 @@ class MessageSearchCell(context: Context, private val theme: ThemeColors) : Base
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        setMeasuredDimension(MeasureSpec.getSize(widthMeasureSpec), CELL_HEIGHT)
-        buildLayouts()
+        val width = MeasureSpec.getSize(widthMeasureSpec)
+        buildLayouts(width)
+        val textHeight = listOfNotNull(senderLayout, contentLayout, channelLayout)
+            .sumOf { it.height } + LINE_GAP.toInt() *
+            (listOfNotNull(senderLayout, contentLayout, channelLayout).size - 1).coerceAtLeast(0)
+        val contentHeight = maxOf(AVATAR_SIZE, textHeight)
+        setMeasuredDimension(width, PAD_TOP + contentHeight + PAD_BOTTOM)
     }
 
     override fun invalidate() {
@@ -48,31 +55,44 @@ class MessageSearchCell(context: Context, private val theme: ThemeColors) : Base
         update(0, doc)
     }
 
-    fun update(mask: Int, newDoc: SearchMessageDocument? = null) {
+    fun update(
+        mask: Int,
+        newDoc: SearchMessageDocument? = null,
+        senderName: String? = null
+    ) {
         val doc = newDoc ?: document ?: return
         if (newDoc != null) document = newDoc
+        resolvedSenderName = senderName
         avatarDrawable.setInfo(doc.senderId.hashCode().toLong(), doc.username)
         loadAvatar(doc.avatarUrl)
-        buildLayouts()
+        buildLayouts(measuredWidth)
+        requestLayout()
         invalidate()
     }
 
-    private fun buildLayouts() {
+    private fun buildLayouts(width: Int) {
         val doc = document ?: return
-        val w = measuredWidth
-        if (w == 0) return
+        val w = width
+        if (w <= 0) return
 
         val textLeft = AVATAR_LEFT + AVATAR_SIZE + TEXT_LEFT_MARGIN
         val textWidth = w - textLeft - PAD_RIGHT
         if (textWidth <= 0) return
 
-        val sender = doc.displayName.ifEmpty { doc.username }
+        val sender = resolvedSenderName?.takeIf { it.isNotBlank() }
+            ?: doc.displayName.ifEmpty { doc.username }
         senderLayout = StaticLayout.Builder.obtain(sender, 0, sender.length, theme.dialogNamePaint, textWidth)
             .setMaxLines(1)
             .setEllipsize(TextUtils.TruncateAt.END)
             .build()
 
-        val preview = parseContentPreview(doc.content)
+        val parsedPreview = parseContentPreview(doc.content)
+        val preview = when {
+            parsedPreview == "[file]" -> context.getString(R.string.search_message_attachment)
+            parsedPreview.isNotEmpty() -> parsedPreview
+            hasAttachmentPayload(doc.attachments) -> context.getString(R.string.search_message_attachment)
+            else -> ""
+        }
         if (preview.isNotEmpty()) {
             contentLayout = StaticLayout.Builder.obtain(preview, 0, preview.length, theme.dialogMessagePaint, textWidth)
                 .setMaxLines(2)
@@ -167,12 +187,18 @@ class MessageSearchCell(context: Context, private val theme: ThemeColors) : Base
     }
 
     companion object {
-        private val CELL_HEIGHT = LayoutHelper.dp(80f)
         private val AVATAR_SIZE = LayoutHelper.dp(40f)
         private val AVATAR_LEFT = LayoutHelper.dp(16f)
         private val TEXT_LEFT_MARGIN = LayoutHelper.dp(12f)
         private val PAD_RIGHT = LayoutHelper.dp(16f)
         private val PAD_TOP = LayoutHelper.dp(10f)
+        private val PAD_BOTTOM = LayoutHelper.dp(10f)
         private val LINE_GAP = LayoutHelper.dp(2f).toFloat()
+
+        internal fun hasAttachmentPayload(raw: String): Boolean {
+            val value = raw.trim()
+            return value.isNotEmpty() && value != "[]" && value != "{}" &&
+                !value.equals("null", ignoreCase = true)
+        }
     }
 }

--- a/app/src/main/java/com/mezon/mobile/search/SearchController.kt
+++ b/app/src/main/java/com/mezon/mobile/search/SearchController.kt
@@ -20,6 +20,7 @@ import com.mezon.mobile.network.CHANNEL_TYPE_GROUP
 import com.mezon.mobile.network.MezonApi
 import com.mezon.mobile.network.apiCacheKey
 import com.mezon.mobile.session.SessionManager
+import com.mezon.mobile.network.SocketEventDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
@@ -70,6 +71,7 @@ class SearchController @Inject constructor(
     private val userClanController: UserClanController,
     private val notificationCenter: NotificationCenter,
     private val cacheTracker: ApiCacheTracker,
+    private val dispatcher: SocketEventDispatcher,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     @ApplicationScope private val appScope: CoroutineScope
 ) {
@@ -83,6 +85,61 @@ class SearchController @Inject constructor(
 
     private var membersLoaded = false
     private var channelsLoaded = false
+
+    init {
+        appScope.launch {
+            dispatcher.clanDeletedEvents.collect { event ->
+                removeClanData(event.clanId)
+            }
+        }
+        appScope.launch {
+            dispatcher.userClanRemovedEvents.collect { event ->
+                removeClanData(event.clanId)
+            }
+        }
+        appScope.launch {
+            dispatcher.channelDeletedEvents.collect { event ->
+                removeChannelData(event.channelId)
+            }
+        }
+    }
+
+    private fun removeClanData(clanId: Long) {
+        var channelsChanged = false
+        synchronized(this) {
+            val hasChannelsToRemove = allChannels.any { it.clanId == clanId }
+            if (hasChannelsToRemove) {
+                allChannels.removeAll { it.clanId == clanId }
+                val toRemove = channelById.filterValues { it.clanId == clanId }.keys
+                for (id in toRemove) channelById.remove(id)
+                channelsChanged = true
+            }
+        }
+
+        if (channelsChanged) {
+            cacheTracker.invalidate(apiCacheKey("searchChannels"))
+            invalidateFilterCache()
+            notificationCenter.postNotificationOnMainThread(NotificationCenter.searchChannelsDidLoad)
+        }
+
+        rebuildMembers()
+    }
+
+    private fun removeChannelData(channelId: Long) {
+        var changed = false
+        synchronized(this) {
+            if (channelById.containsKey(channelId)) {
+                channelById.remove(channelId)
+                allChannels.removeAll { it.channelId == channelId }
+                changed = true
+            }
+        }
+        if (changed) {
+            cacheTracker.invalidate(apiCacheKey("searchChannels"))
+            invalidateFilterCache()
+            notificationCenter.postNotificationOnMainThread(NotificationCenter.searchChannelsDidLoad)
+        }
+    }
 
     @Synchronized
     fun getMembers(): List<SearchMember> = ArrayList(allMembers)
@@ -187,13 +244,26 @@ class SearchController @Inject constructor(
     var hasMoreMessages = true
         private set
     private var messagesPage = 1
+    private var messageSearchGeneration = 0L
 
     fun searchMessagesApi(
         channelId: Long = 0L,
         content: String = "",
+        username: String = "",
+        mentionUserId: Long = 0L,
         from: Int = 1,
         size: Int = SIZE_PAGE_SEARCH
     ) {
+        val generation = synchronized(this) {
+            if (from <= 1) {
+                messageSearchGeneration++
+                searchMessages.clear()
+                searchMessagesTotal = 0
+                messagesPage = 1
+                hasMoreMessages = true
+            }
+            messageSearchGeneration
+        }
         appScope.launch(ioDispatcher) {
             try {
                 sessionManager.withAutoRefresh { session ->
@@ -203,17 +273,20 @@ class SearchController @Inject constructor(
                     filters.add("channel_id" to channelId.toString())
                     filters.add("clan_id" to clanId.toString())
                     if (content.isNotBlank()) filters.add("content" to content.trim())
+                    if (username.isNotBlank()) filters.add("username" to username)
+                    if (mentionUserId != 0L) filters.add("mention" to mentionUserId.toString())
 
                     val response = api.searchMessages(
                         session.apiUrl, session.token, filters, from, size
                     )
 
                     synchronized(this@SearchController) {
+                        if (generation != messageSearchGeneration) return@withAutoRefresh
                         if (from <= 1) searchMessages.clear()
                         searchMessages.addAll(response.messagesList)
                         searchMessagesTotal = response.total
                         messagesPage = from
-                        hasMoreMessages = response.messagesList.isNotEmpty()
+                        hasMoreMessages = searchMessages.size < searchMessagesTotal
                     }
 
                     notificationCenter.postNotificationOnMainThread(NotificationCenter.searchMessagesDidLoad)
@@ -224,13 +297,24 @@ class SearchController @Inject constructor(
         }
     }
 
-    fun loadMoreMessages(channelId: Long = 0L, content: String = "") {
+    fun loadMoreMessages(
+        channelId: Long = 0L,
+        content: String = "",
+        username: String = "",
+        mentionUserId: Long = 0L
+    ) {
         val nextPage: Int
         synchronized(this) {
             if (!hasMoreMessages) return
             nextPage = messagesPage + 1
         }
-        searchMessagesApi(channelId = channelId, content = content, from = nextPage)
+        searchMessagesApi(
+            channelId = channelId,
+            content = content,
+            username = username,
+            mentionUserId = mentionUserId,
+            from = nextPage
+        )
     }
 
     private var cachedMembersQuery: String? = null
@@ -367,6 +451,7 @@ class SearchController @Inject constructor(
 
     fun clearSearchMessages() {
         synchronized(this) {
+            messageSearchGeneration++
             searchMessages.clear()
             searchMessagesTotal = 0
             messagesPage = 1

--- a/app/src/main/java/com/mezon/mobile/ui/cells/ProfileSearchCell.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/cells/ProfileSearchCell.kt
@@ -15,6 +15,7 @@ import com.mezon.mobile.home.messages.loadChannelAvatar
 import com.mezon.mobile.search.SearchMember
 import com.mezon.mobile.search.avatarEntityId
 import com.mezon.mobile.search.avatarPlaceholderKey
+import com.mezon.mobile.network.CHANNEL_TYPE_GROUP
 
 class ProfileSearchCell(context: Context, private val theme: ThemeColors) : BaseCell(context) {
 
@@ -84,7 +85,7 @@ class ProfileSearchCell(context: Context, private val theme: ThemeColors) : Base
             .setEllipsize(TextUtils.TruncateAt.END)
             .build()
 
-        val status = if (m.username.isNotEmpty()) {
+        val status = if (m.username.isNotEmpty() && !(m.isDm && m.channelType == CHANNEL_TYPE_GROUP)) {
             "@${m.username}"
         } else {
             ""

--- a/app/src/main/java/com/mezon/mobile/ui/cells/ProfileSearchCell.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/cells/ProfileSearchCell.kt
@@ -12,7 +12,6 @@ import com.mezon.mobile.core.ThemeColors
 import com.mezon.mobile.home.messages.ChannelAvatarLoadState
 import com.mezon.mobile.home.messages.ChannelAvatarRequest
 import com.mezon.mobile.home.messages.loadChannelAvatar
-import com.mezon.mobile.network.CHANNEL_TYPE_DM
 import com.mezon.mobile.search.SearchMember
 import com.mezon.mobile.search.avatarEntityId
 import com.mezon.mobile.search.avatarPlaceholderKey
@@ -85,7 +84,7 @@ class ProfileSearchCell(context: Context, private val theme: ThemeColors) : Base
             .setEllipsize(TextUtils.TruncateAt.END)
             .build()
 
-        val status = if (m.username.isNotEmpty() && m.channelType == CHANNEL_TYPE_DM) {
+        val status = if (m.username.isNotEmpty()) {
             "@${m.username}"
         } else {
             ""

--- a/app/src/main/java/com/mezon/mobile/ui/cells/SearchCell.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/cells/SearchCell.kt
@@ -12,6 +12,7 @@ import android.widget.EditText
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
+import com.mezon.mobile.R
 import com.mezon.mobile.core.AndroidUtilities
 import com.mezon.mobile.core.LayoutHelper
 import com.mezon.mobile.core.ThemeColors
@@ -86,7 +87,7 @@ class SearchCell(context: Context, private val theme: ThemeColors) : LinearLayou
         }.apply {
             setTextColor(theme.onSurface)
             setHintTextColor(theme.onSurfaceVariant)
-            hint = "Search"
+            hint = context.getString(R.string.common_search)
             textSize = 14f
             background = null
             setPadding(0, 0, 0, 0)
@@ -114,7 +115,7 @@ class SearchCell(context: Context, private val theme: ThemeColors) : LinearLayou
         addView(barContainer, LayoutHelper.createLinear(0, LayoutHelper.WRAP_CONTENT, 1f))
 
         cancelButton = TextView(context).apply {
-            text = "Cancel"
+            text = context.getString(R.string.common_cancel)
             setTextColor(theme.primary)
             textSize = 14f
             visibility = View.GONE
@@ -148,6 +149,11 @@ class SearchCell(context: Context, private val theme: ThemeColors) : LinearLayou
         }
     }
 
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        badgeView.maxWidth = (w * BADGE_MAX_WIDTH_RATIO).toInt()
+    }
+
     fun setPlaceholder(text: String) {
         editText.hint = text
     }
@@ -171,5 +177,9 @@ class SearchCell(context: Context, private val theme: ThemeColors) : LinearLayou
             editText.requestFocus()
             AndroidUtilities.showKeyboard(editText)
         }
+    }
+
+    companion object {
+        private const val BADGE_MAX_WIDTH_RATIO = 0.3f
     }
 }

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1043,6 +1043,8 @@
     <string name="search_filter_user_badge">%1$s %2$s</string>
     <string name="search_message_attachment">[Tệp đính kèm]</string>
     <string name="search_user_fallback">Người dùng</string>
+    <string name="search_type_to_search_messages">Nhập để tìm kiếm tin nhắn</string>
+    <string name="search_no_messages_found">Không tìm thấy tin nhắn</string>
 
     <string name="voice_room_agent_request_failed">Không cập nhật được trợ lý thoại.</string>
     <string name="voice_room_agent_server_error">Lỗi máy chủ khi cập nhật trợ lý thoại. Vui lòng thử lại sau.</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1029,6 +1029,20 @@
     <string name="search_section_voice_channels">Kênh thoại</string>
     <string name="search_section_streaming_channels">Kênh phát trực tuyến</string>
     <string name="search_join_channel">Tham gia</string>
+    <string name="search_tab_members">Thành viên</string>
+    <string name="search_tab_channels">Kênh</string>
+    <string name="search_tab_messages">Tin nhắn</string>
+    <string name="search_messages_placeholder">Tìm tin nhắn…</string>
+    <string name="search_channels_placeholder">Tìm kênh…</string>
+    <string name="search_filter_results">Lọc kết quả</string>
+    <string name="search_filter_from_label">from:</string>
+    <string name="search_filter_from_description">từ người dùng</string>
+    <string name="search_filter_mentions_label">mentions:</string>
+    <string name="search_filter_mentions_description">nhắc đến người dùng</string>
+    <string name="search_filter_channel_badge">in: %1$s</string>
+    <string name="search_filter_user_badge">%1$s %2$s</string>
+    <string name="search_message_attachment">[Tệp đính kèm]</string>
+    <string name="search_user_fallback">Người dùng</string>
 
     <string name="voice_room_agent_request_failed">Không cập nhật được trợ lý thoại.</string>
     <string name="voice_room_agent_server_error">Lỗi máy chủ khi cập nhật trợ lý thoại. Vui lòng thử lại sau.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1250,6 +1250,20 @@
     <string name="search_section_voice_channels">Voice Channels</string>
     <string name="search_section_streaming_channels">Streaming Channels</string>
     <string name="search_join_channel">Join</string>
+    <string name="search_tab_members">Members</string>
+    <string name="search_tab_channels">Channels</string>
+    <string name="search_tab_messages">Messages</string>
+    <string name="search_messages_placeholder">Search messages…</string>
+    <string name="search_channels_placeholder">Search channels…</string>
+    <string name="search_filter_results">Filter results</string>
+    <string name="search_filter_from_label">from:</string>
+    <string name="search_filter_from_description">from user</string>
+    <string name="search_filter_mentions_label">mentions:</string>
+    <string name="search_filter_mentions_description">mention user</string>
+    <string name="search_filter_channel_badge">in: %1$s</string>
+    <string name="search_filter_user_badge">%1$s %2$s</string>
+    <string name="search_message_attachment">[Attachment]</string>
+    <string name="search_user_fallback">User</string>
 
     <string name="buzz_dialog_title">Enter your message Buzz!!</string>
     <string name="buzz_dialog_send">Send</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1264,6 +1264,8 @@
     <string name="search_filter_user_badge">%1$s %2$s</string>
     <string name="search_message_attachment">[Attachment]</string>
     <string name="search_user_fallback">User</string>
+    <string name="search_type_to_search_messages">Type to search messages</string>
+    <string name="search_no_messages_found">No messages found</string>
 
     <string name="buzz_dialog_title">Enter your message Buzz!!</string>
     <string name="buzz_dialog_send">Send</string>


### PR DESCRIPTION
issue: https://github.com/mezonai/mezon/issues/13327
Root cause: Android search had stale query/result state, incomplete iOS parity for filters and jump-to-message behavior, hardcoded or inconsistent labels, fixed-height rows that could overlap, and sender/user rendering that did not match the iOS logic.
Solution: Aligned Android search with iOS by invalidating stale results, adding from and mentions filters, localizing all search strings, fixing sender/user display rules, improving message row sizing and empty states, and implementing target-message jump plus temporary highlight.
Test cases:
Search an attachment-only message and verify it shows [Attachment].
Clear the search text after switching tabs and verify the message count resets correctly.
Search a message sender and verify the display name uses clan nickname or fallback rules correctly.
Open the filter modal and verify from and mentions are available on both Members and Messages tabs.
Select a filter option and verify the tab switcher is hidden until the filter is cleared.
Open an empty Messages tab and verify it shows Type to search messages.
Search with no matching messages and verify it shows No messages found.
Verify long message results do not overlap or get clipped in the list.
Tap a search result and verify the app jumps to the target message.
Verify the target message is briefly highlighted with the violet container after jump.
Verify group DM search results do not show username under the member row.
Verify filter option pressed state follows the theme color and does not show the old yellow highlight.
Verify all search-related text uses i18n strings in both supported languages.