### PR TITLE
260703-ANDROID-Fix bug UI poll detail

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/chat/poll/PollDetailModal.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/poll/PollDetailModal.kt
@@ -304,9 +304,13 @@ class PollDetailModal(
             }
             VoterRow(
                 uid,
-                m?.displayName?.ifBlank { m.username }.orEmpty().ifEmpty { uid.toString() },
+                m?.let { member ->
+                    member.clanNick.ifBlank { member.displayName.ifBlank { member.username } }
+                }
+                    .orEmpty()
+                    .ifEmpty { uid.toString() },
                 m?.username.orEmpty().ifEmpty { uid.toString() },
-                m?.avatarUrl.orEmpty()
+                m?.let { member -> member.clanAvatar.ifBlank { member.avatarUrl } }.orEmpty()
             )
         }
         voterAdapter.submit(models)


### PR DESCRIPTION
[issue](issue: https://github.com/mezonai/mezon/issues/13389)
Root cause: Poll Detail always used the global displayName and avatarUrl, ignoring clan-specific profile fields.
Solution: Prioritize clanNick and clanAvatar, then fall back to the global display name and avatar.
Test cases:
Verify Poll Detail shows the clan nickname and clan avatar for voters in a clan.
Verify Poll Detail falls back to the global display name when the clan nickname is empty.
Verify Poll Detail falls back to the user avatar when the clan avatar is empty.
Verify Poll Detail shows the global user profile correctly outside a clan.