### PR TITLE
260706-ANDROID-Fix default value not fill on embed form

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
@@ -4447,6 +4447,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             val specKey = "${spec.textarea}|${spec.numberInput}|${spec.dateInput}|${spec.disabled}|${spec.placeholder}|${spec.defaultValue}"
             val identityChanged =
                 boundMessageId != messageId || boundComponentId != componentId || boundSpecKey != specKey
+            suppressWatch = true
             boundMessageId = messageId
             boundComponentId = componentId
             boundSpecKey = specKey
@@ -4535,14 +4536,13 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
 
             if (identityChanged) {
                 val stored = EmbedFormUtil.getValue(messageId, componentId)
-                suppressWatch = true
                 edit.setText(stored ?: spec.defaultValue)
-                suppressWatch = false
                 edit.scrollTo(0, 0)
                 if (stored == null && spec.defaultValue.isNotEmpty()) {
                     EmbedFormUtil.setValue(messageId, componentId, spec.defaultValue)
                 }
             }
+            suppressWatch = false
         }
 
         private fun showDatePicker() {


### PR DESCRIPTION
task: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-41
Root cause: Changing EditText.inputType triggered TextWatcher, storing an empty value before the backend default value was applied.
Solution: Suppress TextWatcher during input binding and configuration, then apply and store the backend default value.
Test cases:
Verify a number input displays the backend default value 8.
Verify the default value is included when submitting without editing.
Verify user-edited values replace the default value.
Verify inputs without a default value remain empty.