### PR TITLE
260706-ANDROID-Refactor navigation

### DIFF
--- a/app/src/main/java/com/mezon/mobile/MainActivity.kt
+++ b/app/src/main/java/com/mezon/mobile/MainActivity.kt
@@ -17,6 +17,7 @@ import android.view.Menu
 import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.FrameLayout
+import androidx.activity.OnBackPressedCallback
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
@@ -213,6 +214,12 @@ class MainActivity : BasePermissionsActivity(),
 
         setContentView(drawerLayoutContainer)
 
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                handleBackPressed()
+            }
+        })
+
         @Suppress("DEPRECATION")
         window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
 
@@ -312,7 +319,6 @@ class MainActivity : BasePermissionsActivity(),
         super.onDestroy()
         dismissVoiceRoom()
         dismissStreamingRoom()
-        actionBarLayout.unregisterBackCallback()
         AndroidUtilities.cancelRunOnUIThread(dismissSplashRunnable)
         appUpdateGateRunnable?.let { AndroidUtilities.cancelRunOnUIThread(it) }
         appUpdateGateRunnable = null
@@ -400,6 +406,10 @@ class MainActivity : BasePermissionsActivity(),
 
     @Deprecated("Deprecated in Java")
     override fun onBackPressed() {
+        handleBackPressed()
+    }
+
+    private fun handleBackPressed() {
         val manager = voiceOverlayManager
         if (manager != null && manager.isExpanded()) {
             minimizeVoiceRoom()
@@ -409,7 +419,7 @@ class MainActivity : BasePermissionsActivity(),
             return
         }
         if (!actionBarLayout.onBackPressedInternal()) {
-            super.onBackPressed()
+            finishAndRemoveTask()
         }
     }
 

--- a/app/src/main/java/com/mezon/mobile/core/ActionBarLayout.kt
+++ b/app/src/main/java/com/mezon/mobile/core/ActionBarLayout.kt
@@ -22,8 +22,6 @@ import android.view.Window
 import android.view.animation.DecelerateInterpolator
 import android.widget.FrameLayout
 import android.view.KeyEvent
-import android.window.OnBackInvokedCallback
-import android.window.OnBackInvokedDispatcher
 import com.mezon.mobile.core.AndroidUtilities
 
 class ActionBarLayout(context: Context, private val activity: Activity) :
@@ -212,8 +210,6 @@ class ActionBarLayout(context: Context, private val activity: Activity) :
     private var velocityTracker: VelocityTracker? = null
     private var backAnimator: ValueAnimator? = null
 
-    private var onBackInvokedCallback: Any? = null
-
     private var headerShadowDrawable: Drawable? = null
 
     private var waitingForKeyboardCloseRunnable: Runnable? = null
@@ -244,26 +240,6 @@ class ActionBarLayout(context: Context, private val activity: Activity) :
             intArrayOf(0x1A000000, 0x00000000)
         ).apply { setSize(0, AndroidUtilities.getShadowHeight()) }
 
-        registerBackCallback()
-    }
-
-    private fun registerBackCallback() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            val callback = OnBackInvokedCallback { onBackPressed() }
-            onBackInvokedCallback = callback
-            activity.onBackInvokedDispatcher.registerOnBackInvokedCallback(
-                OnBackInvokedDispatcher.PRIORITY_DEFAULT, callback
-            )
-        }
-    }
-
-    fun unregisterBackCallback() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            (onBackInvokedCallback as? OnBackInvokedCallback)?.let {
-                activity.onBackInvokedDispatcher.unregisterOnBackInvokedCallback(it)
-            }
-            onBackInvokedCallback = null
-        }
     }
 
     fun setDependencies(themeColors: ThemeColors, notificationCenter: NotificationCenter) {
@@ -420,7 +396,6 @@ class ActionBarLayout(context: Context, private val activity: Activity) :
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
-        unregisterBackCallback()
         waitingForKeyboardCloseRunnable?.let { AndroidUtilities.cancelRunOnUIThread(it) }
         waitingForKeyboardCloseRunnable = null
     }
@@ -476,7 +451,7 @@ class ActionBarLayout(context: Context, private val activity: Activity) :
     fun onBackPressedInternal(): Boolean {
         if (startedTracking || checkTransitionAnimation()) return true
         val last = fragmentStack.lastOrNull() ?: return false
-        if (!last.onBackPressed()) return false
+        if (!last.onBackPressed()) return true
         if (fragmentStack.size > 1) {
             closeLastFragment(animated = true)
             return true


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-44
Root cause: Back handling was split between legacy and Android 13+ APIs, while the root state was indistinguishable from a consumed Back event.
Solution: Centralized Back handling in MainActivity, removed the duplicate platform callback, and closed the task only when navigation is truly at root.
Test cases:
Verify Back closes the app from the root screen.
Verify Back pops the current screen when the stack contains multiple screens.
Verify Back returns to the Clans tab before exiting from another tab.
Verify Back minimizes the expanded voice overlay without exiting.
Verify Back does nothing on the username update screen.
Verify the behavior is consistent on Android versions below and above Android 13.