### PR TITLE
260706-ANDROID-Update realtime files

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/ChannelFilesController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChannelFilesController.kt
@@ -5,6 +5,8 @@ import com.mezon.mezon.api.ChannelAttachment
 import com.mezon.mobile.core.NotificationCenter
 import com.mezon.mobile.di.ApplicationScope
 import com.mezon.mobile.di.IoDispatcher
+import com.mezon.mobile.home.chat.AttachmentInfo
+import com.mezon.mobile.home.chat.MessageEntity
 import com.mezon.mobile.home.chat.channelinfo.ChannelDocumentItem
 import com.mezon.mobile.network.ApiCacheTracker
 import com.mezon.mobile.network.MezonApi
@@ -35,6 +37,39 @@ class ChannelFilesController @Inject constructor(
     private val docsByChannel = HashMap<Long, ArrayList<ChannelDocumentItem>>()
     private val loadFailed = Collections.synchronizedSet(HashSet<Long>())
     private val loadingChannels = Collections.synchronizedSet(HashSet<Long>())
+
+    private val messageObserver = object : NotificationCenter.NotificationCenterDelegate {
+        override fun didReceivedNotification(id: Int, account: Int, vararg args: Any?) {
+            when (id) {
+                NotificationCenter.didReceiveNewMessages -> {
+                    val message = args.getOrNull(1) as? MessageEntity ?: return
+                    mergeFilesFromMessage(message, replaceExisting = false)
+                }
+
+                NotificationCenter.messageDidUpdate -> {
+                    val message = args.getOrNull(1) as? MessageEntity ?: return
+                    val mask = args.getOrNull(2) as? Int ?: 0
+                    if ((mask and NotificationCenter.UPDATE_MASK_ATTACHMENTS) == 0) return
+                    mergeFilesFromMessage(message, replaceExisting = true)
+                }
+
+                NotificationCenter.messageDidDelete -> {
+                    val channelId = args.getOrNull(0) as? Long ?: return
+                    val messageId = args.getOrNull(1) as? Long ?: return
+                    if (removeByMessageId(channelId, messageId)) {
+                        apiCacheTracker.invalidate(apiCacheKey("channelFiles", channelId))
+                        notifyFilesChanged(channelId)
+                    }
+                }
+            }
+        }
+    }
+
+    init {
+        notificationCenter.addObserver(messageObserver, NotificationCenter.didReceiveNewMessages)
+        notificationCenter.addObserver(messageObserver, NotificationCenter.messageDidUpdate)
+        notificationCenter.addObserver(messageObserver, NotificationCenter.messageDidDelete)
+    }
 
     fun getDocuments(channelId: Long): List<ChannelDocumentItem> {
         synchronized(this) {
@@ -84,6 +119,51 @@ class ChannelFilesController @Inject constructor(
         }
     }
 
+    private fun mergeFilesFromMessage(message: MessageEntity, replaceExisting: Boolean) {
+        if (message.code != MessageEntity.CODE_CHAT && message.code != MessageEntity.CODE_CHAT_UPDATE) return
+
+        val channelId = message.channelId
+        val newItems = message.toChannelDocumentItems()
+        if (!replaceExisting && newItems.isEmpty()) return
+
+        val cacheKey = apiCacheKey("channelFiles", channelId)
+        var changed = false
+
+        synchronized(this) {
+            val current = docsByChannel[channelId]
+            if (current == null) {
+                apiCacheTracker.invalidate(cacheKey)
+                return
+            }
+
+            if (replaceExisting) {
+                changed = current.removeAll { it.messageId == message.id } || changed
+            }
+
+            val existingIds = current.mapTo(HashSet(current.size)) { it.stableId }
+            newItems.forEach { item ->
+                if (existingIds.add(item.stableId)) {
+                    current.add(item)
+                    changed = true
+                }
+            }
+        }
+
+        if (changed) {
+            apiCacheTracker.invalidate(cacheKey)
+            notifyFilesChanged(channelId)
+        }
+    }
+
+    private fun removeByMessageId(channelId: Long, messageId: Long): Boolean = synchronized(this) {
+        val current = docsByChannel[channelId] ?: return@synchronized false
+        current.removeAll { it.messageId == messageId }
+    }
+
+    private fun notifyFilesChanged(channelId: Long) {
+        notificationCenter.postNotificationOnMainThread(NotificationCenter.channelFilesDidLoad, channelId)
+    }
+
     fun cleanup() {
         synchronized(this) { docsByChannel.clear() }
         synchronized(loadFailed) { loadFailed.clear() }
@@ -91,11 +171,31 @@ class ChannelFilesController @Inject constructor(
     }
 }
 
+private fun MessageEntity.toChannelDocumentItems(): List<ChannelDocumentItem> {
+    return allAttachmentsInfo.mapNotNull { attachment ->
+        attachment.toChannelDocumentItem(this)
+    }
+}
+
+private fun AttachmentInfo.toChannelDocumentItem(message: MessageEntity): ChannelDocumentItem? {
+    if (!filetype.isDocumentFiletype()) return null
+
+    val urlStr = url.trim()
+    if (urlStr.isEmpty() || urlStr.startsWith("content://") || urlStr.startsWith("file://")) return null
+
+    return ChannelDocumentItem(
+        stableId = "${message.id}_$urlStr",
+        filename = filename.ifBlank { "File" },
+        filetype = filetype.ifBlank { "File" },
+        url = urlStr,
+        uploader = message.senderId,
+        createTimeSeconds = message.timestampSeconds.coerceAtMost(Int.MAX_VALUE.toLong()).toInt(),
+        messageId = message.id
+    )
+}
+
 private fun ChannelAttachment.toFilteredDocumentOrNull(): ChannelDocumentItem? {
-    val ft = filetype.lowercase(Locale.US)
-    if (ft.startsWith("image")) return null
-    if (ft.startsWith("video")) return null
-    if (ft == "sticker") return null
+    if (!filetype.isDocumentFiletype()) return null
     val urlStr = url
     if (urlStr.isEmpty()) return null
     val msgId = messageId
@@ -108,4 +208,11 @@ private fun ChannelAttachment.toFilteredDocumentOrNull(): ChannelDocumentItem? {
         createTimeSeconds = createTimeSeconds,
         messageId = msgId
     )
+}
+
+private fun String.isDocumentFiletype(): Boolean {
+    val normalized = lowercase(Locale.US)
+    return !normalized.startsWith("image") &&
+        !normalized.startsWith("video") &&
+        normalized != "sticker"
 }

--- a/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/ChannelFileDocumentRowView.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/ChannelFileDocumentRowView.kt
@@ -2,6 +2,7 @@ package com.mezon.mobile.home.chat.channelinfo
 
 import android.content.Context
 import android.graphics.drawable.GradientDrawable
+import android.text.TextUtils
 import android.util.TypedValue
 import android.view.Gravity
 import android.widget.FrameLayout
@@ -52,7 +53,7 @@ class ChannelFileDocumentRowView(
     private fun updateBackground() {
         background = GradientDrawable().apply {
             cornerRadius = LayoutHelper.dpf(8f)
-            setColor(theme.channelPanelBg)
+            setColor(theme.surfaceVariant)
         }
     }
 
@@ -67,10 +68,12 @@ class ChannelFileDocumentRowView(
         nameView.setTextColor(theme.blurple)
         nameView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 14f)
         nameView.maxLines = 1
+        nameView.ellipsize = TextUtils.TruncateAt.END
         sharedView.text = sharedFooterText
         sharedView.setTextColor(theme.onSurface)
         sharedView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 12f)
         sharedView.maxLines = 1
+        sharedView.ellipsize = TextUtils.TruncateAt.END
         timeView.text = timeLabel
         timeView.setTextColor(theme.textDisabled)
         timeView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 12f)

--- a/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/FilesTabHelper.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/FilesTabHelper.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
+import android.graphics.drawable.GradientDrawable
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
@@ -59,10 +60,7 @@ class FilesTabHelper(
         override fun resolveSharerName(item: ChannelDocumentItem): String {
             if (item.uploader == anonymousUserId) return "Anonymous"
             val m = memberResolver.resolveMember(item.uploader, clanId, channelId, channelType)
-            return m?.let {
-                if (clanId == 0L) it.displayName.ifBlank { it.username }
-                else it.clanNick.ifBlank { it.displayName.ifBlank { it.username } }
-            } ?: ""
+            return m?.username.orEmpty()
         }
 
         override fun formatTime(createTimeSeconds: Int): String {
@@ -89,9 +87,12 @@ class FilesTabHelper(
             orientation = LinearLayout.HORIZONTAL
             gravity = Gravity.CENTER_VERTICAL
             val pad = LayoutHelper.dp(10f)
-            val gapBelowSearch = LayoutHelper.dp(8f)
-            setPadding(pad, pad, pad, pad + gapBelowSearch)
-            setBackgroundColor(0)
+            minimumHeight = LayoutHelper.dp(40f)
+            setPadding(pad, 0, pad, 0)
+            background = GradientDrawable().apply {
+                setColor(themeColors.surfaceVariant)
+                cornerRadius = LayoutHelper.dpf(10f)
+            }
         }
         val searchIcon = ImageView(context).apply {
             val d = MezonIcon.magnifyingIcon.getDrawable(context).mutate()
@@ -119,7 +120,7 @@ class FilesTabHelper(
             searchRow.addView(this, LayoutHelper.createLinear(0, LayoutHelper.WRAP_CONTENT, 1f, Gravity.CENTER_VERTICAL, 8f, 0f, 2f, 0f))
         }
 
-        root.addView(searchRow, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, Gravity.TOP))
+        root.addView(searchRow, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, 40, Gravity.TOP, 10f, 8f, 10f, 0f))
 
         adapter = ChannelFilesAdapter(themeColors, rowResolver)
         val ad = adapter!!
@@ -129,10 +130,10 @@ class FilesTabHelper(
             clipToPadding = false
             setPadding(LayoutHelper.dp(10f), 0, LayoutHelper.dp(10f), LayoutHelper.dp(6f))
         }
-        root.addView(recyclerView, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT, Gravity.TOP, 0f, 52f, 0f, 0f))
+        root.addView(recyclerView, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT, Gravity.TOP, 0f, 56f, 0f, 0f))
 
         emptyView = buildEmptyView(context)
-        root.addView(emptyView, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT, Gravity.TOP, 0f, 52f, 0f, 0f))
+        root.addView(emptyView, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT, Gravity.TOP, 0f, 56f, 0f, 0f))
 
         loadingView = ProgressBar(context).apply { visibility = View.VISIBLE }
         root.addView(loadingView, LayoutHelper.createFrame(48, 48, Gravity.CENTER))


### PR DESCRIPTION
issue: https://github.com/mezonai/mezon/issues/13398
Root Cause: The Android Files section relied only on cached REST data and excluded audio/* attachments from realtime updates. It also resolved clan display names instead of usernames.
Solution: Subscribe to message create/update/delete events, synchronize document attachments including audio files, display usernames, and improve UI contrast and long-text truncation.
Test Cases:
Verify a newly sent EXE file appears in Files without reopening the screen.
Verify a newly sent MP3 file appears in Files without reopening the screen.
Verify a deleted file disappears from Files immediately.
Verify “Shared by” displays the sender’s username.

