### PR TITLE
260707-ANDROID-Fix bug archived channel

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/clans/ChannelController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ChannelController.kt
@@ -24,6 +24,7 @@ import com.mezon.mezon.api.CategoryDescList
 import com.mezon.mezon.api.ChannelDescription
 import com.mezon.mezon.api.NotificationUserChannel
 import com.mezon.mezon.rtapi.CategoryEvent
+import com.mezon.mezon.rtapi.ChannelArchiveEvent
 import com.mezon.mobile.home.chat.SdTopicEntity
 import com.mezon.mobile.home.chat.toClanChannelEntity
 import com.mezon.mezon.rtapi.LastSeenMessageEvent
@@ -634,6 +635,62 @@ class ChannelController @Inject constructor(
             notificationCenter.postNotificationOnMainThread(NotificationCenter.closeChats, channelId, channelType)
             notificationCenter.postNotificationOnMainThread(NotificationCenter.navigateToClansTab)
         }
+    }
+
+    private fun applyChannelArchiveEvent(event: ChannelArchiveEvent) {
+        val clanId = event.clanId
+        val channelId = event.channelId
+        if (clanId == 0L || channelId == 0L || isDirectChannelType(event.channelType)) return
+
+        val existing = _channelsByClan.value[clanId].orEmpty()
+        if (event.active == 0) {
+            updateCache(clanId, existing.filter { it.channelId != channelId })
+            favoritesByClan[clanId]?.remove(channelId)
+            appScope.launch(ioDispatcher) {
+                clanChannelDao.delete(clanId, channelId)
+                favoriteChannelDao.delete(clanId, channelId)
+            }
+            notificationCenter.postNotificationOnMainThread(NotificationCenter.channelsDidLoad, clanId)
+            if (channelId == currentOpenChannelId) {
+                currentOpenChannelId = 0L
+                notificationCenter.postNotificationOnMainThread(
+                    NotificationCenter.closeChats,
+                    channelId,
+                    event.channelType
+                )
+                notificationCenter.postNotificationOnMainThread(NotificationCenter.navigateToClansTab)
+            }
+            return
+        }
+
+        val previous = existing.firstOrNull { it.channelId == channelId }
+        val categoryOrder = previous?.categoryOrder
+            ?: existing.firstOrNull { it.categoryId == event.categoryId && it.categoryOrder != 0 }?.categoryOrder
+            ?: 0
+        val restored = ClanChannelEntity(
+            clanId = clanId,
+            channelId = channelId,
+            parentId = event.parentId,
+            categoryId = event.categoryId,
+            categoryName = previous?.categoryName
+                ?: getCachedCategories(clanId).firstOrNull { it.categoryId == event.categoryId }?.categoryName.orEmpty(),
+            channelLabel = event.channelLabel.ifBlank { previous?.channelLabel.orEmpty() },
+            type = event.channelType.takeIf { it != 0 } ?: previous?.type ?: 0,
+            isPrivate = event.channelPrivate,
+            topic = event.topic.ifBlank { previous?.topic.orEmpty() },
+            unreadCount = event.countMessUnread,
+            isMuted = resolveChannelMuted(clanId, channelId, previous?.isMuted ?: false),
+            lastSeenMessageId = previous?.lastSeenMessageId ?: 0L,
+            lastSentMessageId = previous?.lastSentMessageId ?: 0L,
+            lastSeenMessageTs = previous?.lastSeenMessageTs ?: 0L,
+            lastSentMessageTs = previous?.lastSentMessageTs ?: 0L,
+            active = event.active,
+            categoryOrder = categoryOrder,
+            ageRestricted = event.ageRestricted,
+        )
+        updateCache(clanId, sortChannels(existing.filter { it.channelId != channelId } + restored))
+        appScope.launch(ioDispatcher) { clanChannelDao.upsert(restored) }
+        notificationCenter.postNotificationOnMainThread(NotificationCenter.channelsDidLoad, clanId)
     }
 
     suspend fun findOrFetchChannelLabel(channelId: Long, clanId: Long = 0L): String {
@@ -1601,6 +1658,12 @@ class ChannelController @Inject constructor(
                 updateCache(clanId, existing.filter { it.channelId != event.channelId })
                 appScope.launch(ioDispatcher) { clanChannelDao.delete(clanId, event.channelId) }
                 notificationCenter.postNotificationOnMainThread(NotificationCenter.channelsDidLoad, clanId)
+            }
+        }
+
+        appScope.launch {
+            dispatcher.channelArchiveEvents.collect { event ->
+                applyChannelArchiveEvent(event)
             }
         }
 

--- a/app/src/main/java/com/mezon/mobile/network/SocketEventDispatcher.kt
+++ b/app/src/main/java/com/mezon/mobile/network/SocketEventDispatcher.kt
@@ -14,6 +14,7 @@ import com.mezon.mezon.rtapi.AllowAnonymousEvent
 import com.mezon.mezon.rtapi.BannedUserEvent
 import com.mezon.mezon.rtapi.CategoryEvent
 import com.mezon.mezon.rtapi.ChannelAppEvent
+import com.mezon.mezon.rtapi.ChannelArchiveEvent
 import com.mezon.mezon.rtapi.ChannelCreatedEvent
 import com.mezon.mezon.rtapi.ChannelMessageUpdate
 import com.mezon.mezon.rtapi.ChannelDeletedEvent
@@ -119,6 +120,9 @@ class SocketEventDispatcher @Inject constructor(
 
     private val _channelUpdatedEvents = MutableSharedFlow<ChannelUpdatedEvent>(extraBufferCapacity = 8)
     val channelUpdatedEvents: SharedFlow<ChannelUpdatedEvent> = _channelUpdatedEvents.asSharedFlow()
+
+    private val _channelArchiveEvents = MutableSharedFlow<ChannelArchiveEvent>(extraBufferCapacity = 8)
+    val channelArchiveEvents: SharedFlow<ChannelArchiveEvent> = _channelArchiveEvents.asSharedFlow()
 
     private val _categoryEvents = MutableSharedFlow<CategoryEvent>(extraBufferCapacity = 8)
     val categoryEvents: SharedFlow<CategoryEvent> = _categoryEvents.asSharedFlow()
@@ -294,6 +298,8 @@ class SocketEventDispatcher @Inject constructor(
                 _channelDeletedEvents.emit(envelope.channelDeletedEvent)
             Envelope.MessageCase.CHANNEL_UPDATED_EVENT ->
                 _channelUpdatedEvents.emit(envelope.channelUpdatedEvent)
+            Envelope.MessageCase.CHANNEL_ARCHIVE_EVENT ->
+                _channelArchiveEvents.emit(envelope.channelArchiveEvent)
             Envelope.MessageCase.CATEGORY_EVENT ->
                 _categoryEvents.emit(envelope.categoryEvent)
             Envelope.MessageCase.CHANNEL_APP_EVENT ->


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-49
Root cause: Android did not handle CHANNEL_ARCHIVE_EVENT, so archived channels remained in memory and Room cache.
Solution: Handle the archive event, remove archived channels from memory, Room, and favorites, and restore them when unarchived.
Test cases:
Verify that a channel archived from Web immediately disappears from the Android channel list.
Verify that an archived channel remains hidden after restarting the Android app.
Verify that archiving the currently opened channel closes the chat screen.
