### PR TITLE
260708-ANDROID-Fix miss preview msg DM after relogin

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/DialogsController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/DialogsController.kt
@@ -54,6 +54,7 @@ import com.mezon.mobile.util.FileUtils
 import com.mezon.mobile.util.parseContentPreview
 import com.mezon.mobile.util.AttachmentUploader
 import com.mezon.mobile.home.call.messagePreviewForDialog
+import com.mezon.mobile.home.call.messageHeaderPreviewForDialog
 import dagger.Lazy
 import com.mezon.mezon.api.ChannelDescription
 import com.mezon.mezon.rtapi.LastSeenMessageEvent
@@ -1268,12 +1269,20 @@ class DialogsController @Inject constructor(
                     next = next.copy(lastSentMessageTs = mergedTs)
                 }
             }
-            if (m.content.isNotEmpty()) {
+            if (m.content.isNotEmpty() || next.lastMessageContent.isBlank()) {
                 val sameLastMessage = m.id != 0L && m.id == next.lastSentMessageId
                 val sameTsHeader = m.id == 0L && ts > 0L && ts == next.lastSentMessageTs
                 val needsPreview = next.lastMessageContent.isBlank() || sameLastMessage || sameTsHeader || isNewer
                 if (needsPreview) {
-                    val preview = formatDirectMessagePreview(messagePreviewForDialog(appContext, m.content))
+                    val preview = formatDirectMessagePreview(
+                        messageHeaderPreviewForDialog(
+                            appContext,
+                            m.content,
+                            m.id,
+                            ts,
+                            m.senderId
+                        )
+                    )
                     if (preview.isNotBlank() && preview != next.lastMessageContent) {
                         changed = true
                         next = next.copy(lastMessageContent = preview)

--- a/app/src/main/java/com/mezon/mobile/home/call/CallLogMessageInfo.kt
+++ b/app/src/main/java/com/mezon/mobile/home/call/CallLogMessageInfo.kt
@@ -6,6 +6,10 @@ import com.mezon.mezon.api.MessageAttachmentList
 import com.mezon.mobile.home.chat.MessageEntity
 import com.mezon.mobile.util.parseContentPreview
 import com.google.protobuf.ByteString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
 import org.json.JSONObject
 
 object CallLogMessageType {
@@ -129,4 +133,48 @@ fun messagePreviewForDialog(
     }
     val cl = parseCallLogMessage(content) ?: return ""
     return dialogPreviewForCallLog(context, cl)
+}
+
+private val ATTACHMENT_ONLY_HEADER_KEYS = setOf("t", "mk", "ej", "hg")
+
+fun shouldInferAttachmentOnlyHeaderPreview(
+    content: String,
+    messageId: Long,
+    timestampSeconds: Long,
+    senderId: Long
+): Boolean {
+    if (senderId == 0L || (messageId == 0L && timestampSeconds == 0L)) return false
+
+    val trimmed = content.trim()
+    if (trimmed.isEmpty() || trimmed == "{}") return true
+
+    val obj = runCatching { Json.parseToJsonElement(trimmed) as? JsonObject }.getOrNull() ?: return false
+    val keys = obj.keys
+    if (!ATTACHMENT_ONLY_HEADER_KEYS.containsAll(keys)) return false
+    if (runCatching { obj["t"]?.jsonPrimitive?.contentOrNull.orEmpty() }.getOrDefault("").isNotBlank()) return false
+    return true
+}
+
+fun messageHeaderPreviewForDialog(
+    context: Context,
+    content: String,
+    messageId: Long,
+    timestampSeconds: Long,
+    senderId: Long
+): String {
+    val preview = messagePreviewForDialog(context, content)
+    if (preview.isNotBlank()) return preview
+
+    val hasEmbed = runCatching {
+        val obj = Json.parseToJsonElement(content.trim()) as? JsonObject
+        obj?.containsKey("embed") == true || obj?.containsKey("embeds") == true
+    }.getOrDefault(false)
+    if (hasEmbed) {
+        return "[${context.getString(R.string.message_attachment_embed)}]"
+    }
+
+    if (shouldInferAttachmentOnlyHeaderPreview(content, messageId, timestampSeconds, senderId)) {
+        return "[${context.getString(R.string.message_attachment_file)}]"
+    }
+    return ""
 }

--- a/app/src/main/java/com/mezon/mobile/home/call/CallLogMessageInfo.kt
+++ b/app/src/main/java/com/mezon/mobile/home/call/CallLogMessageInfo.kt
@@ -4,12 +4,9 @@ import android.content.Context
 import com.mezon.mobile.R
 import com.mezon.mezon.api.MessageAttachmentList
 import com.mezon.mobile.home.chat.MessageEntity
+import com.mezon.mobile.util.parseContentObject
 import com.mezon.mobile.util.parseContentPreview
 import com.google.protobuf.ByteString
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.contentOrNull
-import kotlinx.serialization.json.jsonPrimitive
 import org.json.JSONObject
 
 object CallLogMessageType {
@@ -31,20 +28,22 @@ fun parseCallLogMessage(content: String): ParsedCallLogMessage? {
     val trimmed = content.trimStart()
     if (!trimmed.startsWith("{")) return null
     return try {
-        val root = JSONObject(content)
-        if (root.has("callLog")) {
-            val cl = root.optJSONObject("callLog") ?: return null
-            val type = cl.optInt("callLogType", 0)
-            if (type == 0) return null
-            val isVideo = cl.optBoolean("isVideo", false)
-            val t = root.optString("t", "")
-            ParsedCallLogMessage(type, isVideo, t)
-        } else {
-            legacyParseCallLog(root)
-        }
+        parseCallLogMessage(JSONObject(content))
     } catch (_: Exception) {
         null
     }
+}
+
+private fun parseCallLogMessage(root: JSONObject): ParsedCallLogMessage? {
+    if (!root.has("callLog")) return legacyParseCallLog(root)
+    val cl = root.optJSONObject("callLog") ?: return null
+    val type = cl.optInt("callLogType", 0)
+    if (type == 0) return null
+    return ParsedCallLogMessage(
+        callLogType = type,
+        isVideo = cl.optBoolean("isVideo", false),
+        tText = root.optString("t", "")
+    )
 }
 
 private fun legacyParseCallLog(root: JSONObject): ParsedCallLogMessage? {
@@ -105,7 +104,17 @@ fun messagePreviewForDialog(
     attachments: ByteString = ByteString.EMPTY,
     code: Int = 0
 ): String {
-    val base = parseContentPreview(content)
+    return messagePreviewForDialog(context, content, parseContentObject(content.trim()), attachments, code)
+}
+
+private fun messagePreviewForDialog(
+    context: Context,
+    content: String,
+    contentObject: JSONObject?,
+    attachments: ByteString = ByteString.EMPTY,
+    code: Int = 0
+): String {
+    val base = parseContentPreview(content, contentObject)
     if (base.isNotBlank()) {
         if (base == "[Contact]") {
             return "[${context.getString(R.string.message_attachment_contact)}]"
@@ -131,7 +140,7 @@ fun messagePreviewForDialog(
             return "[${context.getString(R.string.message_attachment_file)}]"
         }
     }
-    val cl = parseCallLogMessage(content) ?: return ""
+    val cl = contentObject?.let(::parseCallLogMessage) ?: return ""
     return dialogPreviewForCallLog(context, cl)
 }
 
@@ -143,15 +152,31 @@ fun shouldInferAttachmentOnlyHeaderPreview(
     timestampSeconds: Long,
     senderId: Long
 ): Boolean {
+    return shouldInferAttachmentOnlyHeaderPreview(
+        content = content,
+        contentObject = parseContentObject(content.trim()),
+        messageId = messageId,
+        timestampSeconds = timestampSeconds,
+        senderId = senderId
+    )
+}
+
+private fun shouldInferAttachmentOnlyHeaderPreview(
+    content: String,
+    contentObject: JSONObject?,
+    messageId: Long,
+    timestampSeconds: Long,
+    senderId: Long
+): Boolean {
     if (senderId == 0L || (messageId == 0L && timestampSeconds == 0L)) return false
 
     val trimmed = content.trim()
     if (trimmed.isEmpty() || trimmed == "{}") return true
 
-    val obj = runCatching { Json.parseToJsonElement(trimmed) as? JsonObject }.getOrNull() ?: return false
-    val keys = obj.keys
+    val obj = contentObject ?: return false
+    val keys = obj.keys().asSequence().toSet()
     if (!ATTACHMENT_ONLY_HEADER_KEYS.containsAll(keys)) return false
-    if (runCatching { obj["t"]?.jsonPrimitive?.contentOrNull.orEmpty() }.getOrDefault("").isNotBlank()) return false
+    if (obj.optString("t", "").isNotBlank()) return false
     return true
 }
 
@@ -162,18 +187,16 @@ fun messageHeaderPreviewForDialog(
     timestampSeconds: Long,
     senderId: Long
 ): String {
-    val preview = messagePreviewForDialog(context, content)
+    val contentObject = parseContentObject(content.trim())
+    val preview = messagePreviewForDialog(context, content, contentObject)
     if (preview.isNotBlank()) return preview
 
-    val hasEmbed = runCatching {
-        val obj = Json.parseToJsonElement(content.trim()) as? JsonObject
-        obj?.containsKey("embed") == true || obj?.containsKey("embeds") == true
-    }.getOrDefault(false)
+    val hasEmbed = contentObject?.let { it.has("embed") || it.has("embeds") } == true
     if (hasEmbed) {
         return "[${context.getString(R.string.message_attachment_embed)}]"
     }
 
-    if (shouldInferAttachmentOnlyHeaderPreview(content, messageId, timestampSeconds, senderId)) {
+    if (shouldInferAttachmentOnlyHeaderPreview(content, contentObject, messageId, timestampSeconds, senderId)) {
         return "[${context.getString(R.string.message_attachment_file)}]"
     }
     return ""

--- a/app/src/main/java/com/mezon/mobile/home/messages/DirectMessage.kt
+++ b/app/src/main/java/com/mezon/mobile/home/messages/DirectMessage.kt
@@ -1,6 +1,7 @@
 package com.mezon.mobile.home.messages
 
 import com.mezon.mobile.home.call.messagePreviewForDialog
+import com.mezon.mobile.home.call.messageHeaderPreviewForDialog
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
@@ -159,9 +160,12 @@ fun ChannelDescription.toDirectMessage(currentUserId: Long, previewContext: andr
     }
     val lastMsgContent = if (hasLastSentMessage()) {
         if (previewContext != null) {
-            messagePreviewForDialog(
+            messageHeaderPreviewForDialog(
                 previewContext,
-                lastSentMessage.content
+                lastSentMessage.content,
+                lastSentMessage.id,
+                lastSentMessage.timestampSeconds.toLong() and 0xFFFF_FFFFL,
+                lastSentMessage.senderId
             )
         } else {
             parseContentPreview(lastSentMessage.content)

--- a/app/src/main/java/com/mezon/mobile/util/ContentParser.kt
+++ b/app/src/main/java/com/mezon/mobile/util/ContentParser.kt
@@ -8,7 +8,7 @@ import org.json.JSONObject
 
 private val CONTENT_REGEX = Regex("\"t\"\\s*:\\s*\"((?:[^\"\\\\]|\\\\.)*)\"")
 
-private fun parseContentObject(raw: String): JSONObject? {
+internal fun parseContentObject(raw: String): JSONObject? {
     if (raw.isEmpty() || raw == "[]" || !raw.startsWith("{")) return null
     return try {
         JSONObject(raw)
@@ -40,8 +40,12 @@ private fun extractTopLevelTextFromRegex(trimmed: String): String {
     return match.groupValues.getOrNull(1).orEmpty().trim()
 }
 
-private fun extractContentText(trimmed: String, preview: Boolean): String {
-    parseContentObject(trimmed)?.let { return textFromContentObject(it, preview) }
+private fun extractContentText(
+    trimmed: String,
+    preview: Boolean,
+    contentObject: JSONObject? = parseContentObject(trimmed)
+): String {
+    contentObject?.let { return textFromContentObject(it, preview) }
     if (trimmed.startsWith("{")) {
         val fromRegex = extractTopLevelTextFromRegex(trimmed)
         if (fromRegex.isNotBlank()) {
@@ -120,6 +124,11 @@ fun parseContentText(content: String): String {
 fun parseContentPreview(content: String): String {
     if (content.isBlank()) return ""
     return extractContentText(content.trim(), preview = true)
+}
+
+internal fun parseContentPreview(content: String, contentObject: JSONObject?): String {
+    if (content.isBlank()) return ""
+    return extractContentText(content.trim(), preview = true, contentObject)
 }
 
 const val MENTION_HERE_USER_ID = "1775731111020111321"

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1187,6 +1187,7 @@
     <string name="message_attachment_video">Video</string>
     <string name="message_attachment_gif">GIF</string>
     <string name="message_attachment_file">Tệp</string>
+    <string name="message_attachment_embed">Embed</string>
     <string name="message_attachment_contact">Liên hệ</string>
     <string name="message_attachment_location">Vị trí</string>
     <string name="message_attachment_poll">Bình chọn</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -337,6 +337,7 @@
     <string name="message_attachment_video">Video</string>
     <string name="message_attachment_gif">GIF</string>
     <string name="message_attachment_file">File</string>
+    <string name="message_attachment_embed">Embed</string>
     <string name="message_attachment_contact">Contact</string>
     <string name="message_attachment_location">Location</string>
     <string name="message_attachment_poll">Poll</string>


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-27
Root cause: Android did not infer attachment-only messages from a valid last-message header when attachment metadata was unavailable after re-login.
Solution: Added the same fallback as iOS to display [File] for attachment-only messages and [Embed] for empty embed messages.
Test cases:
Verify attachment-only DMs show [File] after re-login.
Verify empty embed DMs show [Embed] after re-login.
Verify text messages keep their original preview.
Verify invalid or incomplete headers do not show [File].
Verify realtime DM previews remain unchanged.