### PR TITLE
260709-ANDROID-Fix cannot del msg

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/ChatController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChatController.kt
@@ -76,6 +76,7 @@ import com.mezon.mobile.home.chat.withTopicStats
 import com.mezon.mezon.rtapi.Envelope
 import com.mezon.mezon.rtapi.SdTopicEvent
 import com.mezon.mezon.rtapi.TopicInMessageEvent
+import com.mezon.mezon.rtapi.channelMessageRemove
 import com.mezon.mezon.rtapi.channelMessageSend
 import com.mezon.mezon.rtapi.channelMessageUpdate
 import com.mezon.mobile.network.ConnectionState
@@ -2778,12 +2779,35 @@ class ChatController @Inject constructor(
     }
 
     fun deleteMessage(channelId: Long, clanId: Long, channelType: Int, isChannelPrivate: Boolean, messageId: Long, topicId: Long = 0L) {
-        val mode = channelTypeToStreamMode(channelType)
-        val isPublic = !isChannelPrivate
+        val channelMeta = if (clanId != 0L) {
+            channelController.get().findChannelById(channelId, clanId) ?: channelController.get().findChannelById(channelId)
+        } else {
+            null
+        }
+        val effectiveType = when {
+            channelType != 0 -> channelType
+            clanId == 0L -> dialogsController.getDialog(channelId)?.type ?: CHANNEL_TYPE_DM
+            else -> channelMeta?.type ?: CHANNEL_TYPE_CHANNEL
+        }
+        val mode = channelTypeToStreamMode(effectiveType)
+        val effectivePrivate = channelMeta?.isPrivate ?: isChannelPrivate
+        val effectiveParentId = channelMeta?.parentId ?: 0L
+        val isPublic = clanId != 0L && effectiveType == CHANNEL_TYPE_CHANNEL && effectiveParentId == 0L && !effectivePrivate
         appScope.launch {
             try {
-                mezonSocket.removeChatMessage(clanId, channelId, mode, isPublic, messageId, topicId = topicId)
-                Log.d(TAG, "Message deleted: channelId=$channelId messageId=$messageId topicId=$topicId isPublic=$isPublic")
+                val session = sessionManager.sessionFlow.first() ?: return@launch
+                val request = channelMessageRemove {
+                    this.clanId = clanId
+                    this.channelId = channelId
+                    this.mode = mode
+                    this.isPublic = isPublic
+                    this.messageId = messageId
+                    if (topicId != 0L) this.topicId = topicId
+                }
+                withContext(ioDispatcher) {
+                    api.deleteChannelMessage(session.apiUrl, session.token, request)
+                }
+                Log.d(TAG, "Message deleted: channelId=$channelId messageId=$messageId topicId=$topicId mode=$mode isPublic=$isPublic")
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to delete message", e)
             }

--- a/app/src/main/java/com/mezon/mobile/network/MezonApi.kt
+++ b/app/src/main/java/com/mezon/mobile/network/MezonApi.kt
@@ -1690,6 +1690,12 @@ class MezonApi @Inject constructor(
         request: com.mezon.mezon.rtapi.ChannelMessageUpdate
     ): ByteArray = rpc(apiUrl, token, "UpdateChannelMessage", request.toByteArray())
 
+    suspend fun deleteChannelMessage(
+        apiUrl: String,
+        token: String,
+        request: com.mezon.mezon.rtapi.ChannelMessageRemove
+    ): ByteArray = rpc(apiUrl, token, "DeleteChannelMessage", request.toByteArray())
+
     suspend fun channelMessageReact(
         apiUrl: String,
         token: String,

--- a/app/src/main/java/com/mezon/mobile/network/MezonSocket.kt
+++ b/app/src/main/java/com/mezon/mobile/network/MezonSocket.kt
@@ -15,7 +15,6 @@ import com.mezon.mezon.rtapi.Envelope
 import com.mezon.mezon.rtapi.apiRequestEvent
 import com.mezon.mezon.rtapi.channelJoin
 import com.mezon.mezon.rtapi.channelLeave
-import com.mezon.mezon.rtapi.channelMessageRemove
 import com.mezon.mezon.rtapi.channelMessageSend
 import com.mezon.mezon.rtapi.channelMessageUpdate
 import com.mezon.mezon.rtapi.checkNameExistedEvent
@@ -430,30 +429,6 @@ class MezonSocket @Inject constructor(
             if (topicId != 0L) this.topicId = topicId
             if (isUpdateMsgTopic) this.isUpdateMsgTopic = isUpdateMsgTopic
             if (createTimeSeconds > 0) this.createTimeSeconds = createTimeSeconds
-        }
-    }
-
-    suspend fun removeChatMessage(
-        clanId: Long,
-        channelId: Long,
-        mode: Int,
-        isPublic: Boolean,
-        messageId: Long,
-        hasAttachment: Boolean = false,
-        topicId: Long = 0L,
-        mentions: com.google.protobuf.ByteString = com.google.protobuf.ByteString.EMPTY,
-        references: com.google.protobuf.ByteString = com.google.protobuf.ByteString.EMPTY
-    ): Envelope = send {
-        this.channelMessageRemove = channelMessageRemove {
-            this.clanId = clanId
-            this.channelId = channelId
-            this.messageId = messageId
-            this.mode = mode
-            this.isPublic = isPublic
-            this.hasAttachment = hasAttachment
-            this.topicId = topicId
-            this.mentions = mentions
-            this.references = references
         }
     }
 


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-59
Root Cause
Mobile apps were deleting messages through the realtime socket channelMessageRemove path, while web uses the DeleteChannelMessage API/RPC. On iOS, the client also deleted the local message optimistically, so it showed success locally even when the deletion was not propagated to other clients.
Solution
Updated Android and iOS to call DeleteChannelMessage with ChannelMessageRemove payload, and removed the old outgoing socket delete path. iOS no longer deletes the local message optimistically; message removal is synced through the server messageRemoved event.
Test Cases
Delete a message in a DM from Android and verify it disappears on Android, iOS, and web.
Delete a message in a DM from iOS and verify it disappears on Android, iOS, and web.
Delete a message in a public channel and verify all clients receive the removal update.
Delete a message in a private channel or thread and verify the correct message is removed only in that conversation.
Force the delete API to fail and verify the client does not remove the message locally as if it succeeded.

