### PR TITLE
260713-ANDROID-Update UI topic

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/TopicController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/TopicController.kt
@@ -3,6 +3,7 @@ package com.mezon.mobile.home
 import android.util.Log
 import android.util.LongSparseArray
 import com.mezon.mobile.core.NotificationCenter
+import com.mezon.mobile.data.db.MessageDao
 import com.mezon.mobile.di.ApplicationScope
 import com.mezon.mobile.di.IoDispatcher
 import com.mezon.mobile.home.chat.SdTopicEntity
@@ -30,6 +31,7 @@ class TopicController @Inject constructor(
     private val dispatcher: SocketEventDispatcher,
     private val notificationCenter: NotificationCenter,
     private val channelController: dagger.Lazy<ChannelController>,
+    private val messageDao: MessageDao,
     private val cacheTracker: ApiCacheTracker,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     @ApplicationScope private val appScope: CoroutineScope
@@ -101,7 +103,11 @@ class TopicController @Inject constructor(
                         clanId,
                         TOPICS_PAGE_SIZE
                     )
-                    val items = response.topicsList.map { it.toSdTopicEntity() }
+                    val enriched = ArrayList<SdTopicEntity>(response.topicsList.size)
+                    for (topic in response.topicsList) {
+                        enriched.add(enrichRootMessageFromCache(topic.toSdTopicEntity()))
+                    }
+                    val items = enriched
                         .sortedByDescending { it.lastSentTimestampSeconds.takeIf { ts -> ts > 0L } ?: it.updateTimeSeconds }
                     synchronized(this@TopicController) {
                         topics.clear()
@@ -126,7 +132,7 @@ class TopicController @Inject constructor(
         return try {
             sessionManager.withAutoRefresh { session ->
                 val detail = api.getTopicDetail(session.apiUrl, session.token, topicId)
-                detail.toSdTopicEntity()
+                enrichRootMessageFromCache(detail.toSdTopicEntity())
             }
         } catch (e: Exception) {
             Log.e(TAG, "fetchTopicDetail failed topicId=$topicId", e)
@@ -149,7 +155,7 @@ class TopicController @Inject constructor(
                     channelId = parentChannelId,
                     messageId = messageId
                 )
-            }.toSdTopicEntity()
+            }.toSdTopicEntity().let { enrichRootMessageFromCache(it) }
             synchronized(this) {
                 if (currentClanId == clanId) {
                     val index = topics.indexOfFirst { it.id == created.id }
@@ -196,6 +202,12 @@ class TopicController @Inject constructor(
                 notificationCenter.postNotificationOnMainThread(NotificationCenter.topicsNeedReload)
             }
         }
+    }
+
+    private suspend fun enrichRootMessageFromCache(topic: SdTopicEntity): SdTopicEntity {
+        if (topic.channelId == 0L || topic.messageId == 0L) return topic
+        val root = messageDao.getById(topic.channelId, topic.messageId)
+        return topic.withRootMessageMetadata(root)
     }
 
     private suspend fun observeTopicMessages() {

--- a/app/src/main/java/com/mezon/mobile/home/TopicController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/TopicController.kt
@@ -5,6 +5,7 @@ import android.util.LongSparseArray
 import com.mezon.mobile.core.NotificationCenter
 import com.mezon.mobile.di.ApplicationScope
 import com.mezon.mobile.di.IoDispatcher
+import com.mezon.mobile.home.chat.MessageEntity
 import com.mezon.mobile.home.chat.SdTopicEntity
 import com.mezon.mobile.home.chat.toSdTopicEntity
 import com.mezon.mobile.home.chat.toSdTopicEntityFromEvent
@@ -137,7 +138,8 @@ class TopicController @Inject constructor(
     suspend fun createTopic(
         clanId: Long,
         parentChannelId: Long,
-        messageId: Long
+        messageId: Long,
+        rootMessage: MessageEntity? = null
     ): SdTopicEntity? {
         if (clanId == 0L || parentChannelId == 0L || messageId == 0L) return null
         return try {
@@ -149,7 +151,17 @@ class TopicController @Inject constructor(
                     channelId = parentChannelId,
                     messageId = messageId
                 )
-            }.toSdTopicEntity()
+            }.toSdTopicEntity().let { created ->
+                rootMessage?.let { root ->
+                    created.copy(
+                        messageId = created.messageId.takeIf { it != 0L } ?: root.id,
+                        content = root.content,
+                        createTimeSeconds = root.timestampSeconds,
+                        updateTimeSeconds = created.updateTimeSeconds.takeIf { it > 0L }
+                            ?: root.timestampSeconds
+                    )
+                } ?: created
+            }
             synchronized(this) {
                 if (currentClanId == clanId) {
                     val index = topics.indexOfFirst { it.id == created.id }
@@ -172,12 +184,41 @@ class TopicController @Inject constructor(
         dispatcher.sdTopicEvents.collect { event ->
             val clanId = event.clanId
             if (clanId == 0L) return@collect
-            val entity = event.toSdTopicEntityFromEvent()
+            val incomingEntity = event.toSdTopicEntityFromEvent()
+            var entity = incomingEntity
             var shouldReload = false
             synchronized(this) {
                 if (!clanBound || clanId != currentClanId) return@collect
-                val existing = topicsDict.get(entity.id)
+                val existing = topicsDict.get(incomingEntity.id)
                 if (existing != null) {
+                    entity = incomingEntity.copy(
+                        creatorId = existing.creatorId,
+                        messageId = existing.messageId,
+                        channelId = existing.channelId,
+                        content = existing.content.ifBlank { incomingEntity.content },
+                        createTimeSeconds = existing.createTimeSeconds.takeIf { it > 0L }
+                            ?: incomingEntity.createTimeSeconds,
+                        lastSentMessageId = if (event.hasLastSentMessage()) {
+                            incomingEntity.lastSentMessageId
+                        } else {
+                            existing.lastSentMessageId
+                        },
+                        lastSentSenderId = if (event.hasLastSentMessage()) {
+                            incomingEntity.lastSentSenderId
+                        } else {
+                            existing.lastSentSenderId
+                        },
+                        lastSentContent = if (event.hasLastSentMessage()) {
+                            incomingEntity.lastSentContent
+                        } else {
+                            existing.lastSentContent
+                        },
+                        lastSentTimestampSeconds = if (event.hasLastSentMessage()) {
+                            incomingEntity.lastSentTimestampSeconds
+                        } else {
+                            existing.lastSentTimestampSeconds
+                        }
+                    )
                     val index = topics.indexOfFirst { it.id == entity.id }
                     if (index >= 0) {
                         topics.removeAt(index)

--- a/app/src/main/java/com/mezon/mobile/home/TopicController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/TopicController.kt
@@ -3,7 +3,6 @@ package com.mezon.mobile.home
 import android.util.Log
 import android.util.LongSparseArray
 import com.mezon.mobile.core.NotificationCenter
-import com.mezon.mobile.data.db.MessageDao
 import com.mezon.mobile.di.ApplicationScope
 import com.mezon.mobile.di.IoDispatcher
 import com.mezon.mobile.home.chat.SdTopicEntity
@@ -31,7 +30,6 @@ class TopicController @Inject constructor(
     private val dispatcher: SocketEventDispatcher,
     private val notificationCenter: NotificationCenter,
     private val channelController: dagger.Lazy<ChannelController>,
-    private val messageDao: MessageDao,
     private val cacheTracker: ApiCacheTracker,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     @ApplicationScope private val appScope: CoroutineScope
@@ -103,11 +101,7 @@ class TopicController @Inject constructor(
                         clanId,
                         TOPICS_PAGE_SIZE
                     )
-                    val enriched = ArrayList<SdTopicEntity>(response.topicsList.size)
-                    for (topic in response.topicsList) {
-                        enriched.add(enrichRootMessageFromCache(topic.toSdTopicEntity()))
-                    }
-                    val items = enriched
+                    val items = response.topicsList.map { it.toSdTopicEntity() }
                         .sortedByDescending { it.lastSentTimestampSeconds.takeIf { ts -> ts > 0L } ?: it.updateTimeSeconds }
                     synchronized(this@TopicController) {
                         topics.clear()
@@ -132,7 +126,7 @@ class TopicController @Inject constructor(
         return try {
             sessionManager.withAutoRefresh { session ->
                 val detail = api.getTopicDetail(session.apiUrl, session.token, topicId)
-                enrichRootMessageFromCache(detail.toSdTopicEntity())
+                detail.toSdTopicEntity()
             }
         } catch (e: Exception) {
             Log.e(TAG, "fetchTopicDetail failed topicId=$topicId", e)
@@ -155,7 +149,7 @@ class TopicController @Inject constructor(
                     channelId = parentChannelId,
                     messageId = messageId
                 )
-            }.toSdTopicEntity().let { enrichRootMessageFromCache(it) }
+            }.toSdTopicEntity()
             synchronized(this) {
                 if (currentClanId == clanId) {
                     val index = topics.indexOfFirst { it.id == created.id }
@@ -202,12 +196,6 @@ class TopicController @Inject constructor(
                 notificationCenter.postNotificationOnMainThread(NotificationCenter.topicsNeedReload)
             }
         }
-    }
-
-    private suspend fun enrichRootMessageFromCache(topic: SdTopicEntity): SdTopicEntity {
-        if (topic.channelId == 0L || topic.messageId == 0L) return topic
-        val root = messageDao.getById(topic.channelId, topic.messageId)
-        return topic.withRootMessageMetadata(root)
     }
 
     private suspend fun observeTopicMessages() {

--- a/app/src/main/java/com/mezon/mobile/home/chat/SdTopicEntity.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/SdTopicEntity.kt
@@ -5,7 +5,9 @@ import com.mezon.mezon.api.SdTopic
 import com.mezon.mezon.rtapi.SdTopicEvent
 import com.mezon.mobile.home.clans.ClanChannelEntity
 import com.mezon.mobile.network.CHANNEL_TYPE_THREAD
+import com.mezon.mobile.util.TopicOriginalPreviewToken
 import com.mezon.mobile.util.parseContentPreview
+import com.mezon.mobile.util.parseTopicOriginalMessagePreview
 import org.json.JSONObject
 
 data class SdTopicEntity(
@@ -20,15 +22,39 @@ data class SdTopicEntity(
     val lastSentMessageId: Long = 0L,
     val lastSentSenderId: Long = 0L,
     val lastSentContent: String = "",
-    val lastSentTimestampSeconds: Long = 0L
+    val lastSentTimestampSeconds: Long = 0L,
+    val rootMessageCode: Int = 0,
+    val rootHasAttachment: Boolean = false
 ) {
     val rootMessagePreview: String
-        get() = parseContentPreview(content).ifBlank { parseMessagePreview(content) }
+        get() {
+            if (rootMessageCode == MessageEntity.CODE_SHARE_CONTACT) return TopicOriginalPreviewToken.CONTACT
+            if (rootHasAttachment) return TopicOriginalPreviewToken.ATTACHMENT
+            val parsed = parseTopicOriginalMessagePreview(content).ifBlank {
+                parseContentPreview(content).ifBlank { parseMessagePreview(content) }
+            }
+            if (parsed.isNotBlank()) return parsed
+            return ""
+        }
 
     val lastMessagePreview: String
         get() = parseContentPreview(lastSentContent).ifBlank { parseMessagePreview(lastSentContent) }
 
     fun senderIdForAvatar(): Long = lastSentSenderId.takeIf { it != 0L } ?: creatorId
+
+    fun withRootMessageMetadata(root: MessageEntity?): SdTopicEntity {
+        root ?: return this
+        val rootContent = content.ifBlank { root.content }
+        val hasAttachment = rootHasAttachment ||
+            root.attachmentUrl.isNotBlank() ||
+            root.extraAttachmentsJson.isNotBlank() ||
+            root.messageType != MessageEntity.TYPE_TEXT
+        return copy(
+            content = rootContent,
+            rootMessageCode = rootMessageCode.takeIf { it != 0 } ?: root.code,
+            rootHasAttachment = hasAttachment
+        )
+    }
 }
 
 fun SdTopic.toSdTopicEntity(): SdTopicEntity {
@@ -52,6 +78,7 @@ fun SdTopic.toSdTopicEntity(): SdTopicEntity {
 fun SdTopicEvent.toSdTopicEntityFromEvent(): SdTopicEntity {
     val last = if (hasLastSentMessage()) lastSentMessage else ChannelMessageHeader.getDefaultInstance()
     val rootContent = if (hasMessage()) message.content else ""
+    val root = if (hasMessage()) message else null
     val createTs = last.timestampSeconds.toLong().takeIf { it > 0L }
         ?: if (hasMessage()) message.createTimeSeconds.toLong() else 0L
     return SdTopicEntity(
@@ -66,7 +93,9 @@ fun SdTopicEvent.toSdTopicEntityFromEvent(): SdTopicEntity {
         lastSentMessageId = last.id,
         lastSentSenderId = last.senderId,
         lastSentContent = last.content,
-        lastSentTimestampSeconds = last.timestampSeconds.toLong()
+        lastSentTimestampSeconds = last.timestampSeconds.toLong(),
+        rootMessageCode = root?.code ?: 0,
+        rootHasAttachment = root?.attachments?.isEmpty == false
     )
 }
 
@@ -74,7 +103,7 @@ fun SdTopicEntity.toClanChannelEntity(
     parent: ClanChannelEntity? = null,
     existing: ClanChannelEntity? = null
 ): ClanChannelEntity {
-    val label = rootMessagePreview.take(80).ifBlank { "Topic" }
+    val label = channelLabelPreview(rootMessagePreview).take(80).ifBlank { "Topic" }
     val lastSentId = lastSentMessageId.takeIf { it > 0L } ?: messageId
     val lastSentTs = lastSentTimestampSeconds.takeIf { it > 0L }
         ?: updateTimeSeconds.takeIf { it > 0L }
@@ -105,7 +134,15 @@ private fun parseMessagePreview(raw: String): String {
     return runCatching {
         val json = JSONObject(raw)
         json.optString("t", "").ifBlank {
-            if (json.has("embed") || json.has("components")) "[attachment]" else ""
+            if (json.has("embed") || json.has("components")) TopicOriginalPreviewToken.ATTACHMENT else ""
         }
     }.getOrDefault("")
 }
+
+private fun channelLabelPreview(preview: String): String =
+    when (preview) {
+        TopicOriginalPreviewToken.ATTACHMENT -> "[Attachment]"
+        TopicOriginalPreviewToken.CONTACT -> "[Contact]"
+        TopicOriginalPreviewToken.INTERACTIVE_MESSAGE -> "[Interactive message]"
+        else -> preview
+    }

--- a/app/src/main/java/com/mezon/mobile/home/chat/SdTopicEntity.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/SdTopicEntity.kt
@@ -6,9 +6,7 @@ import com.mezon.mezon.rtapi.SdTopicEvent
 import com.mezon.mobile.home.clans.ClanChannelEntity
 import com.mezon.mobile.network.CHANNEL_TYPE_THREAD
 import com.mezon.mobile.util.TopicOriginalPreviewToken
-import com.mezon.mobile.util.parseContentPreview
 import com.mezon.mobile.util.parseTopicOriginalMessagePreview
-import org.json.JSONObject
 
 data class SdTopicEntity(
     val id: Long,
@@ -27,34 +25,9 @@ data class SdTopicEntity(
     val rootHasAttachment: Boolean = false
 ) {
     val rootMessagePreview: String
-        get() {
-            if (rootMessageCode == MessageEntity.CODE_SHARE_CONTACT) return TopicOriginalPreviewToken.CONTACT
-            if (rootHasAttachment) return TopicOriginalPreviewToken.ATTACHMENT
-            val parsed = parseTopicOriginalMessagePreview(content).ifBlank {
-                parseContentPreview(content).ifBlank { parseMessagePreview(content) }
-            }
-            if (parsed.isNotBlank()) return parsed
-            return ""
-        }
-
-    val lastMessagePreview: String
-        get() = parseContentPreview(lastSentContent).ifBlank { parseMessagePreview(lastSentContent) }
+        get() = parseTopicOriginalMessagePreview(content)
 
     fun senderIdForAvatar(): Long = lastSentSenderId.takeIf { it != 0L } ?: creatorId
-
-    fun withRootMessageMetadata(root: MessageEntity?): SdTopicEntity {
-        root ?: return this
-        val rootContent = content.ifBlank { root.content }
-        val hasAttachment = rootHasAttachment ||
-            root.attachmentUrl.isNotBlank() ||
-            root.extraAttachmentsJson.isNotBlank() ||
-            root.messageType != MessageEntity.TYPE_TEXT
-        return copy(
-            content = rootContent,
-            rootMessageCode = rootMessageCode.takeIf { it != 0 } ?: root.code,
-            rootHasAttachment = hasAttachment
-        )
-    }
 }
 
 fun SdTopic.toSdTopicEntity(): SdTopicEntity {
@@ -127,16 +100,6 @@ fun SdTopicEntity.toClanChannelEntity(
         active = 1,
         categoryOrder = 0
     )
-}
-
-private fun parseMessagePreview(raw: String): String {
-    if (raw.isBlank()) return ""
-    return runCatching {
-        val json = JSONObject(raw)
-        json.optString("t", "").ifBlank {
-            if (json.has("embed") || json.has("components")) TopicOriginalPreviewToken.ATTACHMENT else ""
-        }
-    }.getOrDefault("")
 }
 
 private fun channelLabelPreview(preview: String): String =

--- a/app/src/main/java/com/mezon/mobile/home/chat/SdTopicEntity.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/SdTopicEntity.kt
@@ -20,9 +20,7 @@ data class SdTopicEntity(
     val lastSentMessageId: Long = 0L,
     val lastSentSenderId: Long = 0L,
     val lastSentContent: String = "",
-    val lastSentTimestampSeconds: Long = 0L,
-    val rootMessageCode: Int = 0,
-    val rootHasAttachment: Boolean = false
+    val lastSentTimestampSeconds: Long = 0L
 ) {
     val rootMessagePreview: String
         get() = parseTopicOriginalMessagePreview(content)
@@ -51,9 +49,8 @@ fun SdTopic.toSdTopicEntity(): SdTopicEntity {
 fun SdTopicEvent.toSdTopicEntityFromEvent(): SdTopicEntity {
     val last = if (hasLastSentMessage()) lastSentMessage else ChannelMessageHeader.getDefaultInstance()
     val rootContent = if (hasMessage()) message.content else ""
-    val root = if (hasMessage()) message else null
-    val createTs = last.timestampSeconds.toLong().takeIf { it > 0L }
-        ?: if (hasMessage()) message.createTimeSeconds.toLong() else 0L
+    val createTs = if (hasMessage()) message.createTimeSeconds.toLong() else 0L
+    val updateTs = last.timestampSeconds.toLong().takeIf { it > 0L } ?: createTs
     return SdTopicEntity(
         id = id,
         creatorId = userId,
@@ -62,13 +59,11 @@ fun SdTopicEvent.toSdTopicEntityFromEvent(): SdTopicEntity {
         channelId = channelId,
         content = rootContent,
         createTimeSeconds = createTs,
-        updateTimeSeconds = createTs,
+        updateTimeSeconds = updateTs,
         lastSentMessageId = last.id,
         lastSentSenderId = last.senderId,
         lastSentContent = last.content,
-        lastSentTimestampSeconds = last.timestampSeconds.toLong(),
-        rootMessageCode = root?.code ?: 0,
-        rootHasAttachment = root?.attachments?.isEmpty == false
+        lastSentTimestampSeconds = last.timestampSeconds.toLong()
     )
 }
 

--- a/app/src/main/java/com/mezon/mobile/home/chat/thread/CreateThreadFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/thread/CreateThreadFragment.kt
@@ -2184,7 +2184,8 @@ class CreateThreadFragment : BaseFragment() {
                         topicController.createTopic(
                             clanId = clanId,
                             parentChannelId = parentChannelId,
-                            messageId = seedMessageId
+                            messageId = seedMessageId,
+                            rootMessage = seedMessage
                         )
                     } ?: throw IllegalStateException("create topic failed")
                     val topicRootMessageId = createdTopic.messageId.takeIf { it != 0L } ?: seedMessageId

--- a/app/src/main/java/com/mezon/mobile/home/notifications/TopicNotificationCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/notifications/TopicNotificationCell.kt
@@ -13,6 +13,7 @@ import com.mezon.mobile.core.ThemeColors
 import com.mezon.mobile.home.ClanMember
 import com.mezon.mobile.home.chat.MezonImageLoader
 import com.mezon.mobile.home.chat.SdTopicEntity
+import com.mezon.mobile.util.TopicOriginalPreviewToken
 import com.mezon.mobile.util.avatarImgproxyUrl
 import com.mezon.mobile.util.convertTimestampToTimeAgo
 
@@ -34,8 +35,6 @@ class TopicNotificationCell(
 
     private var headerLayout: StaticLayout? = null
     private var repliedToLayout: StaticLayout? = null
-    private var senderLayout: StaticLayout? = null
-    private var previewLayout: StaticLayout? = null
     private var timeLayout: StaticLayout? = null
 
     override fun invalidate() {
@@ -73,7 +72,7 @@ class TopicNotificationCell(
             (mask and NotificationCenter.UPDATE_MASK_NAME) != 0
         if (rebuildText) {
             if (layoutWidth > 0) {
-                buildLayouts(item, displayName, layoutWidth)
+                buildLayouts(item, layoutWidth)
                 measuredCellHeight = computeHeight()
             }
         }
@@ -96,7 +95,7 @@ class TopicNotificationCell(
 
     override fun onDraw(canvas: Canvas) {
         val avatarLeft = PADDING_H
-        val avatarTop = PADDING_V
+        val avatarTop = (height - AVATAR_SIZE) / 2
         avatarDrawable.setBounds(
             avatarLeft,
             avatarTop,
@@ -106,7 +105,8 @@ class TopicNotificationCell(
         avatarDrawable.draw(canvas)
 
         val textLeft = (avatarLeft + AVATAR_SIZE + GAP_H).toFloat()
-        var textTop = PADDING_V.toFloat()
+        var textTop = ((height - textBlockHeight()) / 2f).coerceAtLeast(PADDING_V.toFloat())
+        val headerTop = textTop
 
         headerLayout?.let {
             canvas.save()
@@ -121,28 +121,12 @@ class TopicNotificationCell(
             canvas.translate(textLeft, textTop)
             it.draw(canvas)
             canvas.restore()
-            textTop += it.height + GAP_AFTER_REPLIED
-        }
-
-        senderLayout?.let {
-            canvas.save()
-            canvas.translate(textLeft, textTop)
-            it.draw(canvas)
-            canvas.restore()
-            textTop += it.height
-        }
-
-        previewLayout?.let {
-            canvas.save()
-            canvas.translate(textLeft, textTop)
-            it.draw(canvas)
-            canvas.restore()
         }
 
         timeLayout?.let {
             val tx = width - PADDING_H - it.getLineWidth(0)
             canvas.save()
-            canvas.translate(tx, PADDING_V.toFloat())
+            canvas.translate(tx, headerTop)
             it.draw(canvas)
             canvas.restore()
         }
@@ -158,22 +142,22 @@ class TopicNotificationCell(
 
     private fun rebuildFromEntity() {
         val item = entity ?: return
-        val member = memberResolver?.invoke(item)
-        buildLayouts(item, member?.displayLabel().orEmpty(), layoutWidth)
+        buildLayouts(item, layoutWidth)
         measuredCellHeight = computeHeight()
     }
 
     private fun computeHeight(): Int {
-        val textBlockH = (headerLayout?.height ?: 0) +
-            GAP_AFTER_HEADER +
-            (repliedToLayout?.height ?: 0) +
-            GAP_AFTER_REPLIED +
-            (senderLayout?.height ?: 0) +
-            (previewLayout?.height ?: 0)
-        return PADDING_V * 2 + AVATAR_SIZE.coerceAtLeast(textBlockH)
+        return PADDING_V * 2 + AVATAR_SIZE.coerceAtLeast(textBlockHeight())
     }
 
-    private fun buildLayouts(item: SdTopicEntity, senderName: String, width: Int) {
+    private fun textBlockHeight(): Int {
+        val headerH = headerLayout?.height ?: 0
+        val repliedH = repliedToLayout?.height ?: 0
+        if (headerH == 0 && repliedH == 0) return 0
+        return headerH + GAP_AFTER_HEADER + repliedH
+    }
+
+    private fun buildLayouts(item: SdTopicEntity, width: Int) {
         if (width <= 0) return
         val contentWidth = width - PADDING_H * 2 - AVATAR_SIZE - GAP_H
         if (contentWidth <= 0) return
@@ -186,28 +170,12 @@ class TopicNotificationCell(
             .build()
 
         val repliedPrefix = context.getString(R.string.notif_replied_to)
-        val repliedText = "$repliedPrefix ${item.rootMessagePreview}"
+        val repliedText = "$repliedPrefix ${localizedRootMessagePreview(item.rootMessagePreview)}"
         repliedToLayout = StaticLayout.Builder
             .obtain(repliedText, 0, repliedText.length, theme.dialogMessagePaint, contentWidth)
             .setMaxLines(2)
             .setEllipsize(TextUtils.TruncateAt.END)
             .build()
-
-        val senderText = senderName.ifBlank { " " }
-        senderLayout = StaticLayout.Builder
-            .obtain(senderText, 0, senderText.length, theme.dialogNamePaint, contentWidth)
-            .setMaxLines(1)
-            .setEllipsize(TextUtils.TruncateAt.END)
-            .build()
-
-        val preview = item.lastMessagePreview
-        previewLayout = if (preview.isNotBlank()) {
-            StaticLayout.Builder
-                .obtain(preview, 0, preview.length, theme.dialogMessagePaint, contentWidth)
-                .setMaxLines(2)
-                .setEllipsize(TextUtils.TruncateAt.END)
-                .build()
-        } else null
 
         val ts = item.lastSentTimestampSeconds.takeIf { it > 0L } ?: item.updateTimeSeconds
         val timeText = convertTimestampToTimeAgo(context, ts)
@@ -216,6 +184,16 @@ class TopicNotificationCell(
             .setMaxLines(1)
             .build()
     }
+
+    private fun localizedRootMessagePreview(preview: String): String =
+        when (preview) {
+            TopicOriginalPreviewToken.ATTACHMENT -> context.getString(R.string.notif_topic_original_attachment)
+            TopicOriginalPreviewToken.CONTACT -> context.getString(R.string.notif_topic_original_contact)
+            TopicOriginalPreviewToken.INTERACTIVE_MESSAGE -> {
+                context.getString(R.string.notif_topic_original_interactive_message)
+            }
+            else -> preview
+        }
 
     private fun loadAvatar(url: String) {
         if (url == currentAvatarUrl && avatarDrawable.hasPhoto()) return
@@ -247,7 +225,6 @@ class TopicNotificationCell(
         private val PADDING_V = LayoutHelper.dp(12)
         private val GAP_H = LayoutHelper.dp(12)
         private val GAP_AFTER_HEADER = LayoutHelper.dp(2)
-        private val GAP_AFTER_REPLIED = LayoutHelper.dp(4)
         private val MIN_HEIGHT = LayoutHelper.dp(88)
     }
 }

--- a/app/src/main/java/com/mezon/mobile/home/notifications/TopicNotificationCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/notifications/TopicNotificationCell.kt
@@ -164,7 +164,6 @@ class TopicNotificationCell(
 
         val timeText = convertTimestampToTimeAgo(context, item.createTimeSeconds)
         val timePaint = theme.dialogTimePaint
-        timePaint.color = theme.onSurfaceVariant
         timeLayout = StaticLayout.Builder
             .obtain(timeText, 0, timeText.length, timePaint, contentWidth)
             .setMaxLines(1)
@@ -173,14 +172,14 @@ class TopicNotificationCell(
 
         val timeWidth = timeLayout?.let { it.getLineWidth(0).toInt() + LayoutHelper.dp(8) } ?: 0
         val headerWidth = (contentWidth - timeWidth).coerceAtLeast(1)
-        val headerText = context.getString(R.string.notif_topic_and_you).uppercase()
+        val headerText = context.getString(R.string.notif_topic_discussion).uppercase()
         headerLayout = StaticLayout.Builder
             .obtain(headerText, 0, headerText.length, theme.dialogNameBoldPaint, headerWidth)
             .setMaxLines(1)
             .setEllipsize(TextUtils.TruncateAt.END)
             .build()
 
-        val repliedPrefix = context.getString(R.string.notif_replied_to)
+        val repliedPrefix = context.getString(R.string.notif_original_message)
         val repliedText = "$repliedPrefix ${localizedRootMessagePreview(item.rootMessagePreview)}"
         repliedToLayout = StaticLayout.Builder
             .obtain(repliedText, 0, repliedText.length, theme.dialogMessagePaint, contentWidth)

--- a/app/src/main/java/com/mezon/mobile/home/notifications/TopicNotificationCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/notifications/TopicNotificationCell.kt
@@ -162,9 +162,20 @@ class TopicNotificationCell(
         val contentWidth = width - PADDING_H * 2 - AVATAR_SIZE - GAP_H
         if (contentWidth <= 0) return
 
+        val timeText = convertTimestampToTimeAgo(context, item.createTimeSeconds)
+        val timePaint = theme.dialogTimePaint
+        timePaint.color = theme.onSurfaceVariant
+        timeLayout = StaticLayout.Builder
+            .obtain(timeText, 0, timeText.length, timePaint, contentWidth)
+            .setMaxLines(1)
+            .setEllipsize(TextUtils.TruncateAt.END)
+            .build()
+
+        val timeWidth = timeLayout?.let { it.getLineWidth(0).toInt() + LayoutHelper.dp(8) } ?: 0
+        val headerWidth = (contentWidth - timeWidth).coerceAtLeast(1)
         val headerText = context.getString(R.string.notif_topic_and_you).uppercase()
         headerLayout = StaticLayout.Builder
-            .obtain(headerText, 0, headerText.length, theme.dialogNameBoldPaint, contentWidth)
+            .obtain(headerText, 0, headerText.length, theme.dialogNameBoldPaint, headerWidth)
             .setMaxLines(1)
             .setEllipsize(TextUtils.TruncateAt.END)
             .build()
@@ -177,12 +188,6 @@ class TopicNotificationCell(
             .setEllipsize(TextUtils.TruncateAt.END)
             .build()
 
-        val ts = item.lastSentTimestampSeconds.takeIf { it > 0L } ?: item.updateTimeSeconds
-        val timeText = convertTimestampToTimeAgo(context, ts)
-        timeLayout = StaticLayout.Builder
-            .obtain(timeText, 0, timeText.length, theme.dialogTimePaint, contentWidth)
-            .setMaxLines(1)
-            .build()
     }
 
     private fun localizedRootMessagePreview(preview: String): String =

--- a/app/src/main/java/com/mezon/mobile/util/ContentParser.kt
+++ b/app/src/main/java/com/mezon/mobile/util/ContentParser.kt
@@ -122,6 +122,145 @@ fun parseContentPreview(content: String): String {
     return extractContentText(content.trim(), preview = true)
 }
 
+object TopicOriginalPreviewToken {
+    const val ATTACHMENT = "__topic_original_attachment__"
+    const val CONTACT = "__topic_original_contact__"
+    const val INTERACTIVE_MESSAGE = "__topic_original_interactive_message__"
+}
+
+fun parseTopicOriginalMessagePreview(content: String): String {
+    val trimmed = content.trim()
+    if (trimmed.isBlank()) return TopicOriginalPreviewToken.ATTACHMENT
+
+    val obj = parseContentObject(trimmed)
+    if (obj == null) {
+        if (isStructuralJsonPayload(trimmed)) return TopicOriginalPreviewToken.ATTACHMENT
+        return trimmed.replace("\n", " ").take(200)
+    }
+
+    if (isShareContactPayload(obj)) return TopicOriginalPreviewToken.CONTACT
+    if (hasAttachmentsPayload(obj)) return TopicOriginalPreviewToken.ATTACHMENT
+
+    val text = obj.optString("t", obj.optString("text", "")).trim()
+    val link = extractLinkValue(obj)
+    if (hasInteractivePayload(obj, includeRichEmbedOnly = text.isBlank() && link.isBlank())) {
+        return TopicOriginalPreviewToken.INTERACTIVE_MESSAGE
+    }
+    if (text.isNotBlank()) return text.replace("\n", " ").take(200)
+    if (link.isNotBlank()) return link.replace("\n", " ").take(200)
+
+    val embedPreview = firstTopicEmbedPreview(obj)
+    if (embedPreview.isNotBlank()) {
+        return embedPreview.replace("\n", " ").take(200)
+    }
+
+    return if (obj.has("embed") || obj.has("embeds")) TopicOriginalPreviewToken.ATTACHMENT else ""
+}
+
+private fun hasAttachmentsPayload(obj: JSONObject): Boolean =
+    obj.optBoolean("has_attachment", false) ||
+        obj.optBoolean("hasAttachment", false) ||
+        obj.optBoolean("attachment", false) ||
+        (obj.optJSONArray("attachments")?.length() ?: 0) > 0 ||
+        (obj.optJSONArray("a")?.length() ?: 0) > 0 ||
+        hasNonEmptyPayloadValue(obj.opt("attachments")) ||
+        hasNonEmptyPayloadValue(obj.opt("attachment")) ||
+        hasNonEmptyPayloadValue(obj.opt("files")) ||
+        hasNonEmptyPayloadValue(obj.opt("file"))
+
+private fun hasNonEmptyPayloadValue(value: Any?): Boolean =
+    when (value) {
+        null, JSONObject.NULL -> false
+        is JSONArray -> value.length() > 0
+        is JSONObject -> value.length() > 0
+        is Boolean -> value
+        is String -> value.trim().isNotEmpty()
+        else -> true
+    }
+
+private fun isShareContactPayload(obj: JSONObject): Boolean {
+    for (embed in embedObjects(obj)) {
+        val fields = embed.optJSONArray("fields") ?: continue
+        for (j in 0 until fields.length()) {
+            val field = fields.optJSONObject(j) ?: continue
+            val name = field.optString("name", "").trim().lowercase()
+            val value = field.optString("value", "").trim().lowercase()
+            if ((name == "key" && (value == SHARE_CONTACT_KEY || value == "share_contact_key")) ||
+                value == SHARE_CONTACT_KEY ||
+                value == "share_contact_key"
+            ) return true
+        }
+    }
+    return false
+}
+
+private fun hasInteractivePayload(obj: JSONObject, includeRichEmbedOnly: Boolean): Boolean {
+    if ((obj.optJSONArray("components")?.length() ?: 0) > 0) return true
+    for (embed in embedObjects(obj)) {
+        val fields = embed.optJSONArray("fields") ?: continue
+        if (fields.length() > 0) return true
+    }
+    if (!includeRichEmbedOnly) return false
+    return embedObjects(obj).any { hasRichIntegrationEmbedPayload(it) }
+}
+
+private fun hasRichIntegrationEmbedPayload(embed: JSONObject): Boolean {
+    return hasNonEmptyPayloadValue(embed.opt("author")) ||
+        hasNonEmptyPayloadValue(embed.opt("footer")) ||
+        hasNonEmptyPayloadValue(embed.opt("image")) ||
+        hasNonEmptyPayloadValue(embed.opt("thumbnail")) ||
+        hasNonEmptyPayloadValue(embed.opt("video"))
+}
+
+private fun firstTopicEmbedPreview(obj: JSONObject): String {
+    for (embed in embedObjects(obj)) {
+        val title = embed.optString("title", "").trim()
+        if (title.isNotBlank()) return title
+        val description = embed.optString("description", "").trim()
+        if (description.isNotBlank()) return description
+        val url = embed.optString("url", "").trim()
+        if (url.isNotBlank()) return url
+    }
+    return ""
+}
+
+private fun embedObjects(obj: JSONObject): List<JSONObject> =
+    jsonObjectsFromValue(obj.opt("embed")).ifEmpty { jsonObjectsFromValue(obj.opt("embeds")) }
+
+private fun jsonObjectsFromValue(value: Any?): List<JSONObject> =
+    when (value) {
+        is JSONObject -> listOf(value)
+        is JSONArray -> {
+            val result = mutableListOf<JSONObject>()
+            for (i in 0 until value.length()) {
+                value.optJSONObject(i)?.let(result::add)
+            }
+            result
+        }
+        else -> emptyList()
+    }
+
+private fun extractLinkValue(obj: JSONObject): String {
+    val lk = obj.opt("lk") ?: return ""
+    return when (lk) {
+        is String -> lk.trim()
+        is JSONObject -> lk.optString("url", lk.optString("href", "")).trim()
+        is JSONArray -> {
+            for (i in 0 until lk.length()) {
+                val item = lk.opt(i)
+                val value = when (item) {
+                    is String -> item.trim()
+                    is JSONObject -> item.optString("url", item.optString("href", "")).trim()
+                    else -> ""
+                }
+                if (value.isNotBlank()) return value
+            }
+            ""
+        }
+        else -> ""
+    }
+}
+
 const val MENTION_HERE_USER_ID = "1775731111020111321"
 
 fun buildTextContent(text: String): String {

--- a/app/src/main/java/com/mezon/mobile/util/ContentParser.kt
+++ b/app/src/main/java/com/mezon/mobile/util/ContentParser.kt
@@ -154,7 +154,7 @@ fun parseTopicOriginalMessagePreview(content: String): String {
         return embedPreview.replace("\n", " ").take(200)
     }
 
-    return if (obj.has("embed") || obj.has("embeds")) TopicOriginalPreviewToken.ATTACHMENT else ""
+    return TopicOriginalPreviewToken.ATTACHMENT
 }
 
 private fun hasAttachmentsPayload(obj: JSONObject): Boolean =

--- a/app/src/main/java/com/mezon/mobile/util/ContentParser.kt
+++ b/app/src/main/java/com/mezon/mobile/util/ContentParser.kt
@@ -161,9 +161,8 @@ private fun hasAttachmentsPayload(obj: JSONObject): Boolean =
     obj.optBoolean("has_attachment", false) ||
         obj.optBoolean("hasAttachment", false) ||
         obj.optBoolean("attachment", false) ||
-        (obj.optJSONArray("attachments")?.length() ?: 0) > 0 ||
-        (obj.optJSONArray("a")?.length() ?: 0) > 0 ||
         hasNonEmptyPayloadValue(obj.opt("attachments")) ||
+        hasNonEmptyPayloadValue(obj.opt("a")) ||
         hasNonEmptyPayloadValue(obj.opt("attachment")) ||
         hasNonEmptyPayloadValue(obj.opt("files")) ||
         hasNonEmptyPayloadValue(obj.opt("file"))

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -321,8 +321,11 @@
     <string name="notif_tab_messages">Tin nhắn</string>
     <string name="notif_tab_topics">Chủ đề</string>
     <string name="notif_tab_topics_empty">Không có hoạt động chủ đề</string>
-    <string name="notif_topic_and_you">Chủ đề và bạn</string>
-    <string name="notif_replied_to">Trả lời:</string>
+    <string name="notif_topic_and_you">THẢO LUẬN CHỦ ĐỀ</string>
+    <string name="notif_replied_to">Tin nhắn gốc:</string>
+    <string name="notif_topic_original_attachment">[Tệp đính kèm]</string>
+    <string name="notif_topic_original_contact">[Liên hệ]</string>
+    <string name="notif_topic_original_interactive_message">[Tin nhắn tương tác]</string>
     <string name="topic_discussion">Thảo luận chủ đề</string>
     <string name="topic_creator">Người tạo</string>
     <string name="topic_view">Xem chủ đề</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -321,8 +321,8 @@
     <string name="notif_tab_messages">Tin nhắn</string>
     <string name="notif_tab_topics">Chủ đề</string>
     <string name="notif_tab_topics_empty">Không có hoạt động chủ đề</string>
-    <string name="notif_topic_and_you">THẢO LUẬN CHỦ ĐỀ</string>
-    <string name="notif_replied_to">Tin nhắn gốc:</string>
+    <string name="notif_topic_discussion">THẢO LUẬN CHỦ ĐỀ</string>
+    <string name="notif_original_message">Tin nhắn gốc:</string>
     <string name="notif_topic_original_attachment">[Tệp đính kèm]</string>
     <string name="notif_topic_original_contact">[Liên hệ]</string>
     <string name="notif_topic_original_interactive_message">[Tin nhắn tương tác]</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -386,8 +386,11 @@
     <string name="notif_tab_messages">Messages</string>
     <string name="notif_tab_topics">Topics</string>
     <string name="notif_tab_topics_empty">No topic activity</string>
-    <string name="notif_topic_and_you">Topic and you</string>
-    <string name="notif_replied_to">Replied To:</string>
+    <string name="notif_topic_and_you">TOPIC DISCUSSION</string>
+    <string name="notif_replied_to">Original message:</string>
+    <string name="notif_topic_original_attachment">[Attachment]</string>
+    <string name="notif_topic_original_contact">[Contact]</string>
+    <string name="notif_topic_original_interactive_message">[Interactive message]</string>
     <string name="topic_discussion">Topic Discussion</string>
     <string name="topic_creator">Creator</string>
     <string name="topic_view">View topic</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -386,8 +386,8 @@
     <string name="notif_tab_messages">Messages</string>
     <string name="notif_tab_topics">Topics</string>
     <string name="notif_tab_topics_empty">No topic activity</string>
-    <string name="notif_topic_and_you">TOPIC DISCUSSION</string>
-    <string name="notif_replied_to">Original message:</string>
+    <string name="notif_topic_discussion">TOPIC DISCUSSION</string>
+    <string name="notif_original_message">Original message:</string>
     <string name="notif_topic_original_attachment">[Attachment]</string>
     <string name="notif_topic_original_contact">[Contact]</string>
     <string name="notif_topic_original_interactive_message">[Interactive message]</string>


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-53
Mobile topic notifications used platform-specific hardcoded labels and incomplete root message metadata, so iOS/Android did not match web for topic title and original message preview cases.
Solution
Updated iOS and Android topic notification rendering to use i18n keys, parse root message previews consistently, support attachment/contact/interactive/link/text cases, and remove the extra sender/last-message line from Android topic records.
Test Cases
Verify topic notifications show TOPIC DISCUSSION as the title in English.
Verify topic notifications show Original message: before the root message preview in English.
Verify attachment root messages display the localized attachment placeholder.
Verify contact root messages display the localized contact placeholder.
Verify interactive messages display their title when available.
Verify raw text, emoji, hyperlink, and code block root messages render as normal preview text.
Verify Android topic notification rows remain vertically centered after removing the sender name line.
Verify Vietnamese locale displays localized topic notification labels and placeholders.