### PR TITLE
260716-ANDROID-Implement image editor

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/ChatController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChatController.kt
@@ -2006,41 +2006,47 @@ class ChatController @Inject constructor(
         cdnBaseUrl: String,
         maxRetries: Int,
     ): PreparedAttachmentSlot? {
-        for (attempt in 1..maxRetries) {
-            try {
-                if (!item.isVideo && AttachmentUploader.isCompressibleImage(item.mimeType)) {
-                    val compressed = imageCompressionSlots.withPermit {
-                        AttachmentUploader.compressImageFromUri(
-                            contentResolver, item.uri, item.mimeType, item.filename, item.size,
-                        )
+        try {
+            for (attempt in 1..maxRetries) {
+                try {
+                    if (!item.isVideo && AttachmentUploader.isCompressibleImage(item.mimeType)) {
+                        val compressed = imageCompressionSlots.withPermit {
+                            AttachmentUploader.compressImageFromUri(
+                                contentResolver, item.uri, item.mimeType, item.filename, item.size,
+                            )
+                        }
+                        if (compressed != null) {
+                            val uploadItem = item.copy(
+                                filename = compressed.filename,
+                                mimeType = compressed.mimeType,
+                                width = compressed.width,
+                                height = compressed.height,
+                                size = compressed.bytes.size.toLong(),
+                            )
+                            return presignCachedAttachment(
+                                index, uploadItem, compressed.bytes, apiUrl, token, cdnBaseUrl,
+                            )
+                        }
                     }
-                    if (compressed != null) {
-                        val uploadItem = item.copy(
-                            filename = compressed.filename,
-                            mimeType = compressed.mimeType,
-                            width = compressed.width,
-                            height = compressed.height,
-                            size = compressed.bytes.size.toLong(),
-                        )
-                        return presignCachedAttachment(index, uploadItem, compressed.bytes, apiUrl, token, cdnBaseUrl)
-                    }
-                }
 
-                val tmpFile = AttachmentUploader.copyUriToTempFile(
-                    contentResolver, item.uri, item.mimeType, appContext.cacheDir,
-                ) ?: return null
-                return try {
-                    presignStreamedAttachment(index, item, tmpFile, apiUrl, token, cdnBaseUrl)
+                    val tmpFile = AttachmentUploader.copyUriToTempFile(
+                        contentResolver, item.uri, item.mimeType, appContext.cacheDir,
+                    ) ?: return null
+                    return try {
+                        presignStreamedAttachment(index, item, tmpFile, apiUrl, token, cdnBaseUrl)
+                    } catch (e: Exception) {
+                        runCatching { tmpFile.delete() }
+                        throw e
+                    }
                 } catch (e: Exception) {
-                    runCatching { tmpFile.delete() }
-                    throw e
+                    Log.e(TAG, "Failed to presign attachment: ${item.filename}", e)
+                    if (attempt < maxRetries) delay(SHARE_RETRY_DELAY_MS)
                 }
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to presign attachment: ${item.filename}", e)
-                if (attempt < maxRetries) delay(SHARE_RETRY_DELAY_MS)
             }
+            return null
+        } finally {
+            item.deleteOwnedCacheFile()
         }
-        return null
     }
 
     private suspend fun presignCachedAttachment(

--- a/app/src/main/java/com/mezon/mobile/home/chat/AttachmentPickerItem.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/AttachmentPickerItem.kt
@@ -3,6 +3,7 @@ package com.mezon.mobile.home.chat
 import android.content.Context
 import android.net.Uri
 import android.provider.OpenableColumns
+import java.io.File
 
 data class AttachmentPickerItem(
     val id: Long,
@@ -16,8 +17,13 @@ data class AttachmentPickerItem(
     val duration: Int,
     val isVideo: Boolean,
     val isSelected: Boolean = false,
-    val selectionIndex: Int = -1
+    val selectionIndex: Int = -1,
+    val ownedCachePath: String? = null,
 ) {
+
+    fun deleteOwnedCacheFile() {
+        ownedCachePath?.let { path -> runCatching { File(path).delete() } }
+    }
 
     val isFileType: Boolean
         get() = !mimeType.startsWith("image/") && !mimeType.startsWith("video/")

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatAttachAlert.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatAttachAlert.kt
@@ -44,6 +44,8 @@ class ChatAttachAlert(
         fun onSelectionChanged(item: AttachmentPickerItem, selected: Boolean)
         fun onCameraRequested() {}
         fun onFilesRequested() {}
+        fun canEdit(item: AttachmentPickerItem): Boolean = false
+        fun onEditRequested(item: AttachmentPickerItem) {}
         fun onSendRequested() {}
         fun onDismissed() {}
     }
@@ -57,6 +59,7 @@ class ChatAttachAlert(
     private var headerRowView: LinearLayout? = null
     private var adapter: PhotoAttachAdapter? = null
     private var sendBtn: SendButtonView? = null
+    private var editBtn: View? = null
     private var swipeDismissFromHandle = false
     private var didNotifyDismiss = false
 
@@ -148,11 +151,36 @@ class ChatAttachAlert(
             FrameLayout.LayoutParams.MATCH_PARENT, headerHeight, Gravity.TOP
         ))
 
-        sendBtn = SendButtonView(context, theme)
-        sendBtn!!.visibility = View.GONE
-        sendBtn!!.setOnClickListener { onSendClicked() }
+        val actionRow = LinearLayout(context).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+        }
+        editBtn = TextView(context).apply {
+            visibility = View.GONE
+            isClickable = true
+            isFocusable = true
+            text = context.getString(R.string.image_editor_edit)
+            textSize = 16f
+            typeface = Typeface.DEFAULT_BOLD
+            gravity = Gravity.CENTER
+            setTextColor(Color.BLACK)
+            background = android.graphics.drawable.GradientDrawable().apply {
+                cornerRadius = LayoutHelper.dpf(8f)
+                setColor(Color.WHITE)
+            }
+            setOnClickListener { onEditClicked() }
+        }
+        actionRow.addView(editBtn, LinearLayout.LayoutParams(0, LayoutHelper.dp(48f), 1f).apply {
+            rightMargin = LayoutHelper.dp(8f)
+        })
+
+        sendBtn = SendButtonView(context, theme).apply {
+            visibility = View.GONE
+            setOnClickListener { onSendClicked() }
+        }
+        actionRow.addView(sendBtn, LinearLayout.LayoutParams(0, LayoutHelper.dp(48f), 3f))
         parent.addView(
-            sendBtn,
+            actionRow,
             FrameLayout.LayoutParams(
                 LayoutHelper.MATCH_PARENT, LayoutHelper.dp(48f),
                 Gravity.BOTTOM
@@ -264,6 +292,19 @@ class ChatAttachAlert(
         val count = selectedPhotosOrder.size
         sendBtn?.visibility = if (count > 0) View.VISIBLE else View.GONE
         sendBtn?.setCount(count)
+        val editableItem = selectedPhotosOrder.singleOrNull()?.let { selectedPhotos[it] }
+        editBtn?.visibility = if (
+            editableItem != null &&
+            !editableItem.isVideo &&
+            editableItem.mimeType.startsWith("image/", ignoreCase = true) &&
+            attachDelegate?.canEdit(editableItem) == true
+        ) View.VISIBLE else View.GONE
+    }
+
+    private fun onEditClicked() {
+        val item = selectedPhotosOrder.singleOrNull()?.let { selectedPhotos[it] } ?: return
+        if (attachDelegate?.canEdit(item) != true) return
+        attachDelegate?.onEditRequested(item)
     }
 
     private fun onSendClicked() {

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -302,6 +302,7 @@ open class ChatFragment : BaseFragment() {
     private var pendingCameraCapture: CameraPhotoCapture? = null
     private var cameraSourceAlert: ChatAttachAlert? = null
     private var activeCameraReview: CameraPhotoReviewDialog? = null
+    private var activeImageEditor: ChatImageEditorDialog? = null
     private var mediaPermissionDeniedOnce = false
     private var locationPermissionAskedBefore = false
     private val pendingAttachmentThumbTasks = ArrayList<Runnable?>()
@@ -2957,6 +2958,9 @@ open class ChatFragment : BaseFragment() {
     }
 
     override fun onFragmentDestroy() {
+        activeImageEditor?.setOnDismissListener(null)
+        activeImageEditor?.dismiss()
+        activeImageEditor = null
         emojiExpandAnimator?.cancel()
         emojiExpandAnimator = null
         activePhotoViewer?.setOnDismissListener(null)
@@ -2987,6 +2991,7 @@ open class ChatFragment : BaseFragment() {
         pendingAttachmentThumbTasks.clear()
         attachmentProgressReloadRunnable?.let { AndroidUtilities.cancelRunOnUIThread(it) }
         attachmentProgressReloadRunnable = null
+        pendingAttachments.forEach { it.deleteOwnedCacheFile() }
         pendingAttachments.clear()
         replyingToMessage = null
         editingMessage = null
@@ -4573,22 +4578,30 @@ open class ChatFragment : BaseFragment() {
         return m.copy(startOffset = s - leading, endOffset = e - leading)
     }
 
-    private fun sendMessage() {
+    private fun sendMessage(attachmentOverride: List<AttachmentPickerItem>? = null) {
         dismissPasteImagePopup()
+        val outgoingAttachments = attachmentOverride ?: pendingAttachments
+        fun discardUnusedOverride() {
+            attachmentOverride.orEmpty()
+                .filter { override -> pendingAttachments.none { it.uri == override.uri } }
+                .forEach { it.deleteOwnedCacheFile() }
+        }
         val rawInput = inputField.text?.toString() ?: ""
         val text = rawInput.trim()
         val editMsg = editingMessage
         if (editMsg != null) {
             val oldText = com.mezon.mobile.util.restoreInputFromContent(editMsg.content).rawText.trim()
             if (text == oldText) {
+                discardUnusedOverride()
                 clearEditState()
                 return
             }
         }
         val preservingShareContactEmbed = editMsg != null &&
             isShareContactMessage(editMsg.code, editMsg.content)
-        if (text.isBlank() && pendingAttachments.isEmpty() && !preservingShareContactEmbed) return
+        if (text.isBlank() && outgoingAttachments.isEmpty() && !preservingShareContactEmbed) return
         if (editMsg == null && !canSendMessageInCurrentChannel()) {
+            discardUnusedOverride()
             refreshPermissionGates()
             MezonToast.show(this, ToastOverlay.ToastType.ERROR, getString(R.string.message_no_send_permission))
             return
@@ -4611,7 +4624,7 @@ open class ChatFragment : BaseFragment() {
                         if (finished == null) inputOgpFetchJob?.cancel()
                     } finally {
                         awaitingOgpForSend = false
-                        sendMessage()
+                        sendMessage(attachmentOverride)
                     }
                 }
                 return
@@ -4662,6 +4675,7 @@ open class ChatFragment : BaseFragment() {
         val hashtags = hashtagsFromTrackers.ifEmpty { null }
 
         if (editMsg != null) {
+            discardUnusedOverride()
             val emojiMarkers = buildEmojiMarkers(cleanedText)
             chatController.editMessage(
                 channelId, clanId, channelType, isPrivate, editMsg.id,
@@ -4673,14 +4687,17 @@ open class ChatFragment : BaseFragment() {
             return
         }
 
-        Log.d(TAG, "sendMessage channelId=$channelId clanId=$clanId channelType=$channelType isPrivate=$isPrivate textLen=${cleanedText.length} attachments=${pendingAttachments.size} hasReply=${references != null} mdMarkers=${filteredMdMarkers?.size ?: 0} ogp=${ogpMarker != null} hashtags=${hashtags?.size ?: 0}")
+        Log.d(TAG, "sendMessage channelId=$channelId clanId=$clanId channelType=$channelType isPrivate=$isPrivate textLen=${cleanedText.length} attachments=${outgoingAttachments.size} hasReply=${references != null} mdMarkers=${filteredMdMarkers?.size ?: 0} ogp=${ogpMarker != null} hashtags=${hashtags?.size ?: 0}")
 
-        if (pendingAttachments.isNotEmpty()) {
-            val ctx = getContext() ?: return
+        if (outgoingAttachments.isNotEmpty()) {
+            val ctx = getContext() ?: run {
+                discardUnusedOverride()
+                return
+            }
             val emojiMarkers = buildEmojiMarkers(cleanedText)
             chatController.sendMessageWithAttachments(
                 channelId, clanId, channelType, isPrivate, cleanedText,
-                ArrayList(pendingAttachments),
+                ArrayList(outgoingAttachments),
                 ctx.contentResolver,
                 references,
                 mentions,
@@ -4896,6 +4913,7 @@ open class ChatFragment : BaseFragment() {
                     if (pendingAttachments.any { it.id == item.id }) return
                     pendingAttachments.add(item)
                 } else {
+                    pendingAttachments.filter { it.id == item.id }.forEach { it.deleteOwnedCacheFile() }
                     pendingAttachments.removeAll { it.id == item.id }
                 }
                 updateAttachmentPreview()
@@ -4905,6 +4923,26 @@ open class ChatFragment : BaseFragment() {
             override fun onFilesRequested() {
                 if (!ensureCanSendMessageOrNotify()) return
                 launchDocumentPicker()
+            }
+
+            override fun canEdit(item: AttachmentPickerItem): Boolean =
+                pendingAttachments.size == 1 &&
+                    !item.isVideo &&
+                    item.mimeType.startsWith("image/", ignoreCase = true)
+
+            override fun onEditRequested(item: AttachmentPickerItem) {
+                val currentIndex = pendingAttachments.indexOfFirst { it.id == item.id }
+                if (currentIndex < 0) return
+                activeImageEditor?.dismiss()
+                val editor = ChatImageEditorDialog(ctx, pendingAttachments[currentIndex]) { edited ->
+                    alert.dismiss()
+                    sendMessage(listOf(edited))
+                }
+                activeImageEditor = editor
+                editor.setOnDismissListener {
+                    if (activeImageEditor === editor) activeImageEditor = null
+                }
+                editor.show()
             }
 
             override fun onCameraRequested() {
@@ -5813,7 +5851,7 @@ open class ChatFragment : BaseFragment() {
                 setBackgroundColor(0x80000000.toInt())
                 setPadding(LayoutHelper.dp(2f), LayoutHelper.dp(2f), LayoutHelper.dp(2f), LayoutHelper.dp(2f))
                 setOnClickListener {
-                    pendingAttachments.removeAt(i)
+                    pendingAttachments.removeAt(i).deleteOwnedCacheFile()
                     updateAttachmentPreview()
                     updateSendButtonState()
                 }

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -5005,8 +5005,7 @@ open class ChatFragment : BaseFragment() {
     private fun openAttachAlert() {
         dismissPasteImagePopup()
         val ctx = getContext() ?: return
-        val preselected = pendingAttachments.filter { !it.isFileType }
-        val alert = ChatAttachAlert(ctx, mediaController, themeColors, preselected)
+        val alert = ChatAttachAlert(ctx, mediaController, themeColors, emptyList())
         cameraSourceAlert = alert
         alert.attachDelegate = object : ChatAttachAlert.ChatAttachAlertDelegate {
             override fun canSelectMore(): Boolean {
@@ -5015,11 +5014,15 @@ open class ChatFragment : BaseFragment() {
 
             override fun onSelectionChanged(item: AttachmentPickerItem, selected: Boolean) {
                 if (selected) {
-                    if (pendingAttachments.any { it.id == item.id }) return
                     pendingAttachments.add(item)
                 } else {
-                    pendingAttachments.filter { it.id == item.id }.forEach { it.deleteOwnedCacheFile() }
-                    pendingAttachments.removeAll { it.id == item.id }
+                    val idx = pendingAttachments.indexOfLast { it.id == item.id }
+                    if (idx >= 0) {
+                        val removed = pendingAttachments.removeAt(idx)
+                        if (pendingAttachments.none { it.id == item.id }) {
+                            removed.deleteOwnedCacheFile()
+                        }
+                    }
                 }
                 updateAttachmentPreview()
                 updateSendButtonState()
@@ -5317,31 +5320,18 @@ open class ChatFragment : BaseFragment() {
             capture.discard()
             return
         }
-        lateinit var review: CameraPhotoReviewDialog
-        review = CameraPhotoReviewDialog(
-            context = ctx,
-            capture = capture,
-            onRetake = {
-                launchCameraPhoto().also { launched ->
-                    if (launched) capture.discard()
-                }
-            },
-            onUsePhoto = {
-                if (activeCameraReview === review) activeCameraReview = null
-                if (pendingAttachments.none { it.id == item.id }) pendingAttachments.add(item)
-                cameraSourceAlert?.dismissWithoutAnimation()
-                updateAttachmentPreview()
-                updateSendButtonState()
-            },
-            onCancelReview = {
-                if (activeCameraReview === review) activeCameraReview = null
-                capture.discard()
-            }
-        )
-        val previousReview = activeCameraReview
-        activeCameraReview = review
-        review.show()
-        previousReview?.dismiss()
+        val editor = ChatImageEditorDialog(ctx, item) { edited ->
+            cameraSourceAlert?.dismissWithoutAnimation()
+            sendMessage(listOf(edited))
+            capture.discard()
+        }
+        activeImageEditor?.dismiss()
+        activeImageEditor = editor
+        editor.setOnDismissListener {
+            if (activeImageEditor === editor) activeImageEditor = null
+            capture.discard()
+        }
+        editor.show()
     }
 
     private fun requestLocationAndSend() {

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatImageEditorDialog.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatImageEditorDialog.kt
@@ -1,0 +1,1027 @@
+package com.mezon.mobile.home.chat
+
+import android.app.Dialog
+import android.content.Context
+import android.content.res.ColorStateList
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Matrix
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.Rect
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.GradientDrawable
+import android.media.ExifInterface
+import android.net.Uri
+import android.text.InputFilter
+import android.text.InputType
+import android.view.Gravity
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import android.view.WindowManager
+import android.widget.FrameLayout
+import android.widget.EditText
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.ProgressBar
+import android.widget.TextView
+import android.widget.Toast
+import androidx.core.content.FileProvider
+import com.mezon.mobile.R
+import com.mezon.mobile.core.AndroidUtilities
+import com.mezon.mobile.core.LayoutHelper
+import com.mezon.mobile.ui.cells.MezonIcon
+import com.mezon.mobile.ui.shared.TransformCanvasView
+import java.io.File
+import java.io.FileOutputStream
+import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.math.max
+
+/** Full-screen, lightweight editor for a single pending chat image. */
+class ChatImageEditorDialog(
+    context: Context,
+    private val item: AttachmentPickerItem,
+    private val onSend: (AttachmentPickerItem) -> Unit,
+) : Dialog(context, android.R.style.Theme_Black_NoTitleBar_Fullscreen) {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val editorCanvas = TransformCanvasView(
+        context = context,
+        outsideDimColor = 0x99000000.toInt(),
+    )
+    private val progress = ProgressBar(context)
+    private var decodeJob: Job? = null
+    private var sourceBitmap: Bitmap? = null
+    @Volatile
+    private var pendingOutputFile: File? = null
+    private var working = false
+    private var hasChanges = false
+    private var selectedColor = 0xFFFF3B30.toInt()
+    private var toolLabelsScheduled = false
+    private var editingTextIndex: Int? = null
+    private var textDeleteTargetHot = false
+    private val textDeleteHitRect = Rect()
+
+    private lateinit var cropButton: LinearLayout
+    private lateinit var drawButton: LinearLayout
+    private lateinit var textButton: LinearLayout
+    private lateinit var undoAction: TextView
+    private lateinit var palette: LinearLayout
+    private lateinit var paletteEraserDivider: View
+    private lateinit var eraserButton: FrameLayout
+    private lateinit var brushSizeSlider: VerticalBrushSizeSlider
+    private lateinit var textDeleteTarget: FrameLayout
+    private lateinit var textDeleteIcon: ImageView
+    private lateinit var textInputOverlay: FrameLayout
+    private lateinit var textInput: EditText
+    private val toolButtons = ArrayList<LinearLayout>()
+    private val toolLabels = ArrayList<TextView>()
+    private var refreshPaletteSelection: (() -> Unit)? = null
+    private val hideToolLabelsRunnable = Runnable { setToolLabelsVisible(false) }
+
+    init {
+        requestWindowFeature(Window.FEATURE_NO_TITLE)
+        window?.apply {
+            setBackgroundDrawable(ColorDrawable(Color.BLACK))
+            statusBarColor = Color.BLACK
+            navigationBarColor = Color.BLACK
+            addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+            setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING)
+        }
+        setContentView(buildContent())
+        setCanceledOnTouchOutside(false)
+        loadSource()
+    }
+
+    override fun show() {
+        super.show()
+        window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+        if (!toolLabelsScheduled) {
+            toolLabelsScheduled = true
+            editorCanvas.postDelayed(hideToolLabelsRunnable, TOOL_LABEL_DURATION_MS)
+        }
+    }
+
+    @Deprecated("Deprecated in Java")
+    override fun onBackPressed() {
+        if (::textInputOverlay.isInitialized && textInputOverlay.visibility == View.VISIBLE) {
+            closeTextInput(addText = false)
+        } else {
+            super.onBackPressed()
+        }
+    }
+
+    private fun buildContent(): View {
+        val root = FrameLayout(context).apply { setBackgroundColor(Color.BLACK) }
+        val statusInset = AndroidUtilities.statusBarHeight
+        val navigationInset = AndroidUtilities.navigationBarHeight
+
+        editorCanvas.apply {
+            setFreeformCropEnabled(true)
+            setCropInsetsDp(left = 16f, top = 76f, right = 16f, bottom = 76f)
+            setBrushWidthDp(6f)
+            setOnEditorChangedListener {
+                if (!hasChanges) {
+                    hasChanges = true
+                    updateModeButtons()
+                }
+            }
+            setOnTextEditRequestedListener { index, text, color ->
+                if (!working) showTextInput(index, text, color)
+            }
+            setOnTextSelectedListener { color ->
+                selectedColor = color
+                setBrushColor(color)
+                refreshPaletteSelection?.invoke()
+            }
+            setOnTextDeleteDragListener(::updateTextDeleteTarget)
+            visibility = View.INVISIBLE
+        }
+        root.addView(
+            editorCanvas,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT,
+            ),
+        )
+
+        root.addView(buildTopOverlay(statusInset), FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            LayoutHelper.dp(64f) + statusInset,
+            Gravity.TOP,
+        ))
+
+        eraserButton = buildEraserButton()
+        palette = buildPalette()
+        root.addView(
+            palette,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                LayoutHelper.dp(48f),
+                Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL,
+            ).apply { bottomMargin = navigationInset + LayoutHelper.dp(80f) },
+        )
+
+        brushSizeSlider = VerticalBrushSizeSlider(context).apply {
+            contentDescription = context.getString(R.string.image_editor_brush_size)
+            elevation = LayoutHelper.dpf(4f)
+            onValueChanged = { editorCanvas.setBrushWidthDp(it) }
+        }
+        root.addView(
+            brushSizeSlider,
+            FrameLayout.LayoutParams(
+                LayoutHelper.dp(44f),
+                LayoutHelper.dp(184f),
+                Gravity.START or Gravity.CENTER_VERTICAL,
+            ).apply { leftMargin = LayoutHelper.dp(10f) },
+        )
+
+        textDeleteTarget = buildTextDeleteTarget()
+        root.addView(
+            textDeleteTarget,
+            FrameLayout.LayoutParams(
+                LayoutHelper.dp(52f),
+                LayoutHelper.dp(52f),
+                Gravity.BOTTOM or Gravity.CENTER_HORIZONTAL,
+            ).apply { bottomMargin = navigationInset + LayoutHelper.dp(16f) },
+        )
+
+        root.addView(
+            buildToolRail(),
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                Gravity.END or Gravity.TOP,
+            ).apply {
+                topMargin = statusInset + LayoutHelper.dp(72f)
+                rightMargin = LayoutHelper.dp(12f)
+            },
+        )
+
+        root.addView(
+            buildSendAction(),
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                LayoutHelper.dp(52f),
+                Gravity.END or Gravity.BOTTOM,
+            ).apply {
+                rightMargin = LayoutHelper.dp(12f)
+                bottomMargin = navigationInset + LayoutHelper.dp(16f)
+            },
+        )
+        updateModeButtons()
+
+        progress.apply {
+            isIndeterminate = true
+            indeterminateTintList = ColorStateList.valueOf(Color.WHITE)
+        }
+        root.addView(
+            progress,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                Gravity.CENTER,
+            ),
+        )
+
+        textInputOverlay = buildTextInputOverlay(statusInset, navigationInset)
+        root.addView(
+            textInputOverlay,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT,
+            ),
+        )
+        return root
+    }
+
+    private fun buildTopOverlay(statusInset: Int): View = FrameLayout(context).apply {
+        setPadding(LayoutHelper.dp(12f), statusInset + LayoutHelper.dp(8f), LayoutHelper.dp(12f), 0)
+
+        undoAction = TextView(context).apply {
+            text = context.getString(R.string.image_editor_undo)
+            textSize = 16f
+            typeface = android.graphics.Typeface.DEFAULT_BOLD
+            setTextColor(Color.WHITE)
+            gravity = Gravity.CENTER
+            setPadding(LayoutHelper.dp(8f), 0, LayoutHelper.dp(8f), 0)
+            setShadowLayer(LayoutHelper.dpf(3f), 0f, LayoutHelper.dpf(1f), Color.BLACK)
+            isClickable = true
+            isFocusable = true
+            visibility = View.GONE
+            setOnClickListener {
+                if (working) return@setOnClickListener
+                editorCanvas.resetEditor()
+                hasChanges = false
+                updateModeButtons()
+            }
+        }
+        addView(
+            undoAction,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                LayoutHelper.dp(48f),
+                Gravity.START or Gravity.TOP,
+            ),
+        )
+    }
+
+    private fun buildToolRail(): View {
+        val tools = LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+            gravity = Gravity.CENTER_HORIZONTAL
+        }
+
+        fun addTool(view: LinearLayout) {
+            tools.addView(
+                view,
+                LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LayoutHelper.dp(46f)).apply {
+                    gravity = Gravity.END
+                    bottomMargin = LayoutHelper.dp(8f)
+                },
+            )
+        }
+
+        drawButton = toolButton(
+            iconRes = R.drawable.ic_image_editor_draw,
+            label = context.getString(R.string.image_editor_draw),
+        ) {
+            editorCanvas.setDrawingMode(true)
+            editorCanvas.setEraserMode(false)
+            updateModeButtons()
+        }
+        addTool(drawButton)
+
+        textButton = toolButton(
+            iconRes = null,
+            label = context.getString(R.string.image_editor_text),
+            textGlyph = "Aa",
+        ) {
+            showTextInput()
+        }
+        addTool(textButton)
+
+        cropButton = toolButton(
+            iconRes = R.drawable.ic_image_editor_crop,
+            label = context.getString(R.string.image_editor_crop),
+        ) {
+            editorCanvas.setDrawingMode(false)
+            updateModeButtons()
+        }
+        addTool(cropButton)
+
+        val rotateButton = toolButton(
+            iconRes = R.drawable.ic_image_editor_rotate,
+            label = context.getString(R.string.image_crop_rotate_left_cd),
+        ) {
+            editorCanvas.setDrawingMode(false)
+            editorCanvas.rotateByDegrees(-90f)
+            updateModeButtons()
+        }
+        addTool(rotateButton)
+
+        return tools
+    }
+
+    private fun buildEraserButton(): FrameLayout = FrameLayout(context).apply {
+        visibility = View.GONE
+        contentDescription = context.getString(R.string.image_editor_eraser)
+        background = toolBackground(active = false)
+        elevation = LayoutHelper.dpf(4f)
+        isClickable = true
+        isFocusable = true
+        setOnClickListener {
+            if (working || !editorCanvas.isDrawingMode()) return@setOnClickListener
+            editorCanvas.setEraserMode(!editorCanvas.isEraserMode())
+            updateModeButtons()
+        }
+        addView(
+            ImageView(context).apply {
+                setImageResource(R.drawable.ic_image_editor_eraser)
+                imageTintList = ColorStateList.valueOf(Color.WHITE)
+                scaleType = ImageView.ScaleType.CENTER_INSIDE
+            },
+            FrameLayout.LayoutParams(LayoutHelper.dp(27f), LayoutHelper.dp(27f), Gravity.CENTER),
+        )
+    }
+
+    private fun toolButton(
+        iconRes: Int?,
+        label: String,
+        textGlyph: String? = null,
+        action: () -> Unit,
+    ): LinearLayout = LinearLayout(context).apply {
+        gravity = Gravity.CENTER
+        minimumWidth = LayoutHelper.dp(46f)
+        setPadding(LayoutHelper.dp(10f), 0, LayoutHelper.dp(13f), 0)
+        contentDescription = label
+        background = toolBackground(active = false)
+        elevation = LayoutHelper.dpf(4f)
+        isClickable = true
+        isFocusable = true
+        setOnClickListener { if (!working) action() }
+
+        val iconView = if (textGlyph != null) {
+            TextView(context).apply {
+                text = textGlyph
+                textSize = 20f
+                typeface = android.graphics.Typeface.DEFAULT_BOLD
+                setTextColor(Color.WHITE)
+                gravity = Gravity.CENTER
+                importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+            }
+        } else {
+            ImageView(context).apply {
+                iconRes?.let(::setImageResource)
+                imageTintList = ColorStateList.valueOf(Color.WHITE)
+                scaleType = ImageView.ScaleType.CENTER_INSIDE
+                importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+            }
+        }
+        addView(iconView, LinearLayout.LayoutParams(LayoutHelper.dp(27f), LayoutHelper.dp(27f)))
+
+        val labelView = TextView(context).apply {
+            text = label
+            textSize = 14f
+            typeface = android.graphics.Typeface.DEFAULT_BOLD
+            setTextColor(Color.WHITE)
+            gravity = Gravity.CENTER_VERTICAL
+        }
+        addView(
+            labelView,
+            LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+                LinearLayout.LayoutParams.MATCH_PARENT,
+            ).apply { leftMargin = LayoutHelper.dp(7f) },
+        )
+        toolButtons.add(this)
+        toolLabels.add(labelView)
+    }
+
+    private fun setToolLabelsVisible(visible: Boolean) {
+        toolLabels.forEach { it.visibility = if (visible) View.VISIBLE else View.GONE }
+        toolButtons.forEach { button ->
+            button.setPadding(
+                if (visible) LayoutHelper.dp(10f) else 0,
+                0,
+                if (visible) LayoutHelper.dp(13f) else 0,
+                0,
+            )
+            button.layoutParams = (button.layoutParams as? LinearLayout.LayoutParams)?.apply {
+                width = if (visible) LinearLayout.LayoutParams.WRAP_CONTENT else LayoutHelper.dp(46f)
+            }
+            button.requestLayout()
+        }
+    }
+
+    private fun buildSendAction(): View = LinearLayout(context).apply {
+        orientation = LinearLayout.HORIZONTAL
+        gravity = Gravity.CENTER
+        setPadding(LayoutHelper.dp(18f), 0, LayoutHelper.dp(20f), 0)
+        background = roundedBackground(Color.WHITE, LayoutHelper.dpf(26f))
+        elevation = LayoutHelper.dpf(5f)
+        isClickable = true
+        isFocusable = true
+        contentDescription = context.getString(R.string.message_send)
+        setOnClickListener { if (!working) sendImage() }
+
+        addView(
+            ImageView(context).apply {
+                setImageResource(MezonIcon.sendMessageIcon.resId)
+                imageTintList = ColorStateList.valueOf(Color.BLACK)
+                scaleType = ImageView.ScaleType.CENTER_INSIDE
+            },
+            LinearLayout.LayoutParams(LayoutHelper.dp(23f), LayoutHelper.dp(23f)),
+        )
+        addView(
+            TextView(context).apply {
+                text = context.getString(R.string.message_send)
+                textSize = 16f
+                typeface = android.graphics.Typeface.DEFAULT_BOLD
+                setTextColor(Color.BLACK)
+                gravity = Gravity.CENTER
+            },
+            LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+                LinearLayout.LayoutParams.MATCH_PARENT,
+            ).apply { leftMargin = LayoutHelper.dp(8f) },
+        )
+    }
+
+    private fun buildPalette(): LinearLayout {
+        val colors = intArrayOf(
+            Color.WHITE,
+            Color.BLACK,
+            0xFFFF3B30.toInt(),
+            0xFFFF9500.toInt(),
+            0xFFFFCC00.toInt(),
+            0xFF34C759.toInt(),
+            0xFF0A84FF.toInt(),
+            0xFFAF52DE.toInt(),
+        )
+        val colorViews = ArrayList<View>(colors.size)
+        editorCanvas.setBrushColor(selectedColor)
+
+        val paletteView = LinearLayout(context).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER
+            setPadding(LayoutHelper.dp(8f), 0, LayoutHelper.dp(4f), 0)
+            background = roundedBackground(0xB3000000.toInt(), LayoutHelper.dpf(24f))
+            elevation = LayoutHelper.dpf(4f)
+            visibility = View.GONE
+        }
+
+        fun updatePalette() {
+            colorViews.forEachIndexed { index, view ->
+                view.background = colorCircle(colors[index], colors[index] == selectedColor)
+            }
+        }
+        refreshPaletteSelection = { updatePalette() }
+
+        colors.forEachIndexed { index, color ->
+            val chip = View(context).apply {
+                contentDescription = context.getString(R.string.image_editor_color_cd, index + 1)
+                isClickable = true
+                isFocusable = true
+                setOnClickListener {
+                    selectedColor = color
+                    editorCanvas.setBrushColor(color)
+                    if (editorCanvas.isDrawingMode()) editorCanvas.setEraserMode(false)
+                    if (editorCanvas.isTextMode()) editorCanvas.setSelectedTextColor(color)
+                    if (::textInput.isInitialized) {
+                        textInput.setTextColor(color)
+                        textInput.setShadowLayer(
+                            LayoutHelper.dpf(2f),
+                            0f,
+                            LayoutHelper.dpf(1f),
+                            if (color == Color.BLACK) Color.WHITE else Color.BLACK,
+                        )
+                    }
+                    updatePalette()
+                    updateModeButtons()
+                }
+            }
+            colorViews.add(chip)
+            paletteView.addView(
+                chip,
+                LinearLayout.LayoutParams(LayoutHelper.dp(25f), LayoutHelper.dp(25f)).apply {
+                    leftMargin = LayoutHelper.dp(2f)
+                    rightMargin = LayoutHelper.dp(2f)
+                },
+            )
+        }
+        paletteEraserDivider = View(context).apply { setBackgroundColor(0x33FFFFFF) }
+        paletteView.addView(
+            paletteEraserDivider,
+            LinearLayout.LayoutParams(LayoutHelper.dp(1f), LayoutHelper.dp(26f)).apply {
+                leftMargin = LayoutHelper.dp(6f)
+                rightMargin = LayoutHelper.dp(4f)
+            },
+        )
+        paletteView.addView(
+            eraserButton,
+            LinearLayout.LayoutParams(LayoutHelper.dp(40f), LayoutHelper.dp(40f)),
+        )
+        updatePalette()
+        return paletteView
+    }
+
+    private fun buildTextInputOverlay(statusInset: Int, navigationInset: Int): FrameLayout =
+        FrameLayout(context).apply {
+            visibility = View.GONE
+            isClickable = true
+            isFocusable = true
+            setBackgroundColor(0xE6000000.toInt())
+
+            textInput = EditText(context).apply {
+                textSize = 32f
+                setTextColor(selectedColor)
+                setShadowLayer(LayoutHelper.dpf(2f), 0f, LayoutHelper.dpf(1f), Color.BLACK)
+                setHintTextColor(0x66FFFFFF)
+                hint = context.getString(R.string.image_editor_text_hint)
+                gravity = Gravity.CENTER
+                background = null
+                inputType = InputType.TYPE_CLASS_TEXT or
+                    InputType.TYPE_TEXT_FLAG_MULTI_LINE or
+                    InputType.TYPE_TEXT_FLAG_CAP_SENTENCES
+                setSingleLine(false)
+                maxLines = 6
+                filters = arrayOf(InputFilter.LengthFilter(MAX_TEXT_LENGTH))
+                setPadding(LayoutHelper.dp(24f), LayoutHelper.dp(24f), LayoutHelper.dp(24f), LayoutHelper.dp(24f))
+            }
+            addView(
+                textInput,
+                FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                ).apply {
+                    topMargin = statusInset + LayoutHelper.dp(64f)
+                    bottomMargin = navigationInset + LayoutHelper.dp(64f)
+                },
+            )
+
+            fun action(label: String, bold: Boolean, onClick: () -> Unit): TextView =
+                TextView(context).apply {
+                    text = label
+                    textSize = 16f
+                    typeface = if (bold) android.graphics.Typeface.DEFAULT_BOLD else android.graphics.Typeface.DEFAULT
+                    setTextColor(Color.WHITE)
+                    gravity = Gravity.CENTER
+                    setPadding(LayoutHelper.dp(12f), 0, LayoutHelper.dp(12f), 0)
+                    setOnClickListener { onClick() }
+                }
+
+            addView(
+                action(context.getString(R.string.common_cancel), bold = false) {
+                    closeTextInput(addText = false)
+                },
+                FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.WRAP_CONTENT,
+                    LayoutHelper.dp(48f),
+                    Gravity.START or Gravity.TOP,
+                ).apply {
+                    leftMargin = LayoutHelper.dp(8f)
+                    topMargin = statusInset + LayoutHelper.dp(8f)
+                },
+            )
+            addView(
+                action(context.getString(R.string.image_editor_text_done), bold = true) {
+                    closeTextInput(addText = true)
+                },
+                FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.WRAP_CONTENT,
+                    LayoutHelper.dp(48f),
+                    Gravity.END or Gravity.TOP,
+                ).apply {
+                    rightMargin = LayoutHelper.dp(8f)
+                    topMargin = statusInset + LayoutHelper.dp(8f)
+                },
+            )
+        }
+
+    private fun showTextInput(
+        editIndex: Int? = null,
+        initialText: String = "",
+        initialColor: Int = selectedColor,
+    ) {
+        editingTextIndex = editIndex
+        selectedColor = initialColor
+        refreshPaletteSelection?.invoke()
+        editorCanvas.setTextMode(true)
+        updateModeButtons()
+        textInput.setText(initialText)
+        textInput.setSelection(textInput.text?.length ?: 0)
+        textInput.setTextColor(selectedColor)
+        textInput.setShadowLayer(
+            LayoutHelper.dpf(2f),
+            0f,
+            LayoutHelper.dpf(1f),
+            if (selectedColor == Color.BLACK) Color.WHITE else Color.BLACK,
+        )
+        textInputOverlay.visibility = View.VISIBLE
+        textInputOverlay.bringToFront()
+        textInput.requestFocus()
+        textInput.postDelayed({ AndroidUtilities.showKeyboard(textInput) }, 100L)
+    }
+
+    private fun closeTextInput(addText: Boolean) {
+        if (!::textInputOverlay.isInitialized || textInputOverlay.visibility != View.VISIBLE) return
+        val content = textInput.text?.toString().orEmpty()
+        AndroidUtilities.hideKeyboard(textInput)
+        textInput.clearFocus()
+        textInputOverlay.visibility = View.GONE
+        if (addText) {
+            val editIndex = editingTextIndex
+            if (editIndex == null) {
+                if (content.isNotBlank()) editorCanvas.addText(content, selectedColor)
+            } else {
+                editorCanvas.updateText(editIndex, content, selectedColor)
+            }
+        }
+        editingTextIndex = null
+        textInput.text?.clear()
+        updateModeButtons()
+    }
+
+    private fun buildTextDeleteTarget(): FrameLayout = FrameLayout(context).apply {
+        visibility = View.GONE
+        contentDescription = context.getString(R.string.common_delete)
+        background = textDeleteBackground(active = false)
+        elevation = LayoutHelper.dpf(5f)
+        textDeleteIcon = ImageView(context).apply {
+            setImageResource(MezonIcon.trashIcon.resId)
+            imageTintList = ColorStateList.valueOf(Color.BLACK)
+            scaleType = ImageView.ScaleType.CENTER_INSIDE
+        }
+        addView(textDeleteIcon, FrameLayout.LayoutParams(LayoutHelper.dp(23f), LayoutHelper.dp(23f), Gravity.CENTER))
+    }
+
+    private fun updateTextDeleteTarget(active: Boolean, x: Float, y: Float): Boolean {
+        if (!::textDeleteTarget.isInitialized) return false
+        if (!active) {
+            textDeleteTarget.animate().cancel()
+            textDeleteTarget.visibility = View.GONE
+            textDeleteTarget.alpha = 1f
+            textDeleteTargetHot = false
+            textDeleteTarget.scaleX = 1f
+            textDeleteTarget.scaleY = 1f
+            textDeleteTarget.background = textDeleteBackground(active = false)
+            textDeleteIcon.imageTintList = ColorStateList.valueOf(Color.BLACK)
+            updateModeButtons()
+            return false
+        }
+
+        if (textDeleteTarget.visibility != View.VISIBLE) {
+            textDeleteTarget.visibility = View.VISIBLE
+            textDeleteTarget.alpha = 0f
+            textDeleteTarget.scaleX = 0.82f
+            textDeleteTarget.scaleY = 0.82f
+            textDeleteTarget.bringToFront()
+            textDeleteTarget.animate().alpha(1f).scaleX(1f).scaleY(1f).setDuration(140L).start()
+        }
+        palette.visibility = View.GONE
+
+        textDeleteTarget.getHitRect(textDeleteHitRect)
+        val extraHitArea = LayoutHelper.dp(14f)
+        textDeleteHitRect.inset(-extraHitArea, -extraHitArea)
+        val isOverTarget = textDeleteHitRect.contains(x.toInt(), y.toInt())
+        if (isOverTarget != textDeleteTargetHot) {
+            textDeleteTargetHot = isOverTarget
+            textDeleteTarget.background = textDeleteBackground(isOverTarget)
+            textDeleteIcon.imageTintList = ColorStateList.valueOf(if (isOverTarget) Color.WHITE else Color.BLACK)
+            val scale = if (isOverTarget) 1.08f else 1f
+            textDeleteTarget.animate().scaleX(scale).scaleY(scale).setDuration(100L).start()
+        }
+        return isOverTarget
+    }
+
+    private fun textDeleteBackground(active: Boolean): GradientDrawable = GradientDrawable().apply {
+        shape = GradientDrawable.RECTANGLE
+        cornerRadius = LayoutHelper.dpf(26f)
+        setColor(if (active) 0xFFF04444.toInt() else Color.WHITE)
+    }
+
+    private fun updateModeButtons() {
+        val drawing = editorCanvas.isDrawingMode()
+        val texting = editorCanvas.isTextMode()
+        cropButton.background = toolBackground(active = !drawing && !texting)
+        drawButton.background = toolBackground(active = drawing)
+        textButton.background = toolBackground(active = texting)
+        val deletingText = ::textDeleteTarget.isInitialized && textDeleteTarget.visibility == View.VISIBLE
+        palette.visibility = if ((drawing || texting) && !deletingText) View.VISIBLE else View.GONE
+        paletteEraserDivider.visibility = if (drawing) View.VISIBLE else View.GONE
+        eraserButton.visibility = if (drawing) View.VISIBLE else View.GONE
+        eraserButton.background = toolBackground(active = drawing && editorCanvas.isEraserMode())
+        brushSizeSlider.visibility = if (drawing) View.VISIBLE else View.GONE
+        undoAction.visibility = if (hasChanges) View.VISIBLE else View.GONE
+    }
+
+    private fun toolBackground(active: Boolean): GradientDrawable = GradientDrawable().apply {
+        shape = GradientDrawable.RECTANGLE
+        cornerRadius = LayoutHelper.dpf(23f)
+        setColor(if (active) 0xE60A84FF.toInt() else 0xB3000000.toInt())
+        setStroke(LayoutHelper.dp(1f), if (active) 0xFF66B5FF.toInt() else 0x33777777)
+    }
+
+    private fun roundedBackground(color: Int, radius: Float): GradientDrawable = GradientDrawable().apply {
+        cornerRadius = radius
+        setColor(color)
+    }
+
+    private fun colorCircle(color: Int, selected: Boolean): GradientDrawable = GradientDrawable().apply {
+        shape = GradientDrawable.OVAL
+        setColor(color)
+        setStroke(LayoutHelper.dp(if (selected) 3f else 1f), if (selected) Color.WHITE else 0xFF777777.toInt())
+    }
+
+    private fun loadSource() {
+        decodeJob = scope.launch {
+            val decoded = withContext(Dispatchers.IO) {
+                decodeOrientedBitmap(context, item.uri, item.mimeType, MAX_EDITOR_EDGE)
+            }
+            progress.visibility = View.GONE
+            if (decoded == null) {
+                Toast.makeText(context, R.string.image_editor_failed, Toast.LENGTH_SHORT).show()
+                dismiss()
+                return@launch
+            }
+            sourceBitmap = decoded
+            editorCanvas.setImageBitmap(decoded)
+            editorCanvas.visibility = View.VISIBLE
+        }
+    }
+
+    private fun sendImage() {
+        if (working || sourceBitmap == null) return
+        if (!hasChanges) {
+            onSend(item)
+            dismiss()
+            return
+        }
+        val (outWidth, outHeight) = editorCanvas.suggestedOutputSize(MAX_EDITOR_EDGE)
+        val rendered = editorCanvas.renderCropped(outWidth, outHeight) ?: return
+        working = true
+        progress.visibility = View.VISIBLE
+        scope.launch {
+            val result = withContext(Dispatchers.IO) { writeEditedFile(rendered, outWidth, outHeight) }
+            rendered.recycle()
+            progress.visibility = View.GONE
+            working = false
+            if (result == null) {
+                Toast.makeText(context, R.string.image_editor_failed, Toast.LENGTH_SHORT).show()
+                return@launch
+            }
+            onSend(result)
+            pendingOutputFile = null
+            dismiss()
+        }
+    }
+
+    private fun writeEditedFile(bitmap: Bitmap, width: Int, height: Int): AttachmentPickerItem? {
+        val preservePng = item.mimeType.equals("image/png", ignoreCase = true)
+        val extension = if (preservePng) "png" else "jpg"
+        val mimeType = if (preservePng) "image/png" else "image/jpeg"
+        val directory = File(context.cacheDir, "chat_image_edits").apply { mkdirs() }
+        val file = File(directory, "edited-${UUID.randomUUID()}.$extension")
+        pendingOutputFile = file
+        return try {
+            val wrote = FileOutputStream(file).use { output ->
+                val format = if (preservePng) Bitmap.CompressFormat.PNG else Bitmap.CompressFormat.JPEG
+                bitmap.compress(format, if (preservePng) 100 else 90, output)
+            }
+            if (!wrote || file.length() <= 0L) {
+                file.delete()
+                if (pendingOutputFile === file) pendingOutputFile = null
+                return null
+            }
+            val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
+            item.copy(
+                uri = uri,
+                path = file.absolutePath,
+                filename = item.filename.substringBeforeLast('.', item.filename) + ".$extension",
+                mimeType = mimeType,
+                width = width,
+                height = height,
+                size = file.length(),
+                duration = 0,
+                isVideo = false,
+                ownedCachePath = file.absolutePath,
+            )
+        } catch (_: Throwable) {
+            file.delete()
+            if (pendingOutputFile === file) pendingOutputFile = null
+            null
+        }
+    }
+
+    override fun dismiss() {
+        decodeJob?.cancel()
+        decodeJob = null
+        editorCanvas.removeCallbacks(hideToolLabelsRunnable)
+        if (::textInput.isInitialized) AndroidUtilities.hideKeyboard(textInput)
+        editorCanvas.setOnEditorChangedListener(null)
+        editorCanvas.setOnTextEditRequestedListener(null)
+        editorCanvas.setOnTextSelectedListener(null)
+        editorCanvas.setOnTextDeleteDragListener(null)
+        editorCanvas.setImageBitmap(null)
+        pendingOutputFile?.delete()
+        pendingOutputFile = null
+        sourceBitmap?.recycle()
+        sourceBitmap = null
+        scope.cancel()
+        super.dismiss()
+    }
+
+    companion object {
+        private const val MAX_EDITOR_EDGE = 2560
+        private const val MAX_TEXT_LENGTH = 200
+        private const val TOOL_LABEL_DURATION_MS = 5_000L
+
+        private fun decodeOrientedBitmap(context: Context, uri: Uri, mimeType: String, maxEdge: Int): Bitmap? {
+            val resolver = context.contentResolver
+            return try {
+                val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+                resolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, bounds) }
+                if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null
+
+                var sample = 1
+                while (bounds.outWidth / (sample * 2) >= maxEdge || bounds.outHeight / (sample * 2) >= maxEdge) {
+                    sample *= 2
+                }
+                var bitmap = resolver.openInputStream(uri)?.use {
+                    BitmapFactory.decodeStream(it, null, BitmapFactory.Options().apply {
+                        inSampleSize = sample
+                        inPreferredConfig = Bitmap.Config.ARGB_8888
+                    })
+                } ?: return null
+
+                bitmap = applyOrientation(bitmap, readOrientation(context, uri, mimeType))
+                val longest = max(bitmap.width, bitmap.height)
+                if (longest > maxEdge) {
+                    val scale = maxEdge.toFloat() / longest
+                    val scaled = Bitmap.createScaledBitmap(
+                        bitmap,
+                        (bitmap.width * scale).toInt().coerceAtLeast(1),
+                        (bitmap.height * scale).toInt().coerceAtLeast(1),
+                        true,
+                    )
+                    if (scaled !== bitmap) bitmap.recycle()
+                    bitmap = scaled
+                }
+                bitmap
+            } catch (_: Throwable) {
+                null
+            }
+        }
+
+        private fun readOrientation(context: Context, uri: Uri, mimeType: String): Int {
+            val supportsExif = mimeType.equals("image/jpeg", true) ||
+                mimeType.equals("image/jpg", true) ||
+                mimeType.equals("image/heic", true) ||
+                mimeType.equals("image/heif", true)
+            if (!supportsExif) return ExifInterface.ORIENTATION_NORMAL
+            return runCatching {
+                context.contentResolver.openInputStream(uri)?.use {
+                    ExifInterface(it).getAttributeInt(
+                        ExifInterface.TAG_ORIENTATION,
+                        ExifInterface.ORIENTATION_NORMAL,
+                    )
+                } ?: ExifInterface.ORIENTATION_NORMAL
+            }.getOrDefault(ExifInterface.ORIENTATION_NORMAL)
+        }
+
+        private fun applyOrientation(bitmap: Bitmap, orientation: Int): Bitmap {
+            val matrix = Matrix()
+            when (orientation) {
+                ExifInterface.ORIENTATION_ROTATE_90 -> matrix.postRotate(90f)
+                ExifInterface.ORIENTATION_ROTATE_180 -> matrix.postRotate(180f)
+                ExifInterface.ORIENTATION_ROTATE_270 -> matrix.postRotate(270f)
+                ExifInterface.ORIENTATION_FLIP_HORIZONTAL -> matrix.postScale(-1f, 1f)
+                ExifInterface.ORIENTATION_FLIP_VERTICAL -> matrix.postScale(1f, -1f)
+                ExifInterface.ORIENTATION_TRANSPOSE -> {
+                    matrix.postRotate(90f)
+                    matrix.postScale(-1f, 1f)
+                }
+                ExifInterface.ORIENTATION_TRANSVERSE -> {
+                    matrix.postRotate(270f)
+                    matrix.postScale(-1f, 1f)
+                }
+                else -> return bitmap
+            }
+            val oriented = Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+            if (oriented !== bitmap) bitmap.recycle()
+            return oriented
+        }
+    }
+}
+
+private class VerticalBrushSizeSlider(context: Context) : View(context) {
+    var onValueChanged: ((Float) -> Unit)? = null
+
+    private val minValue = 3f
+    private val maxValue = 16f
+    private var value = 6f
+    private val trapezoidPath = Path()
+    private val activePath = Path()
+    private val trackPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = 0x59FFFFFF }
+    private val activePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = 0xFF0A84FF.toInt()
+    }
+    private val thumbPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.WHITE }
+    private val previewPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = 0xFF0A84FF.toInt() }
+
+    init {
+        isClickable = true
+        isFocusable = true
+        background = GradientDrawable().apply {
+            cornerRadius = LayoutHelper.dpf(22f)
+            setColor(0xCC111216.toInt())
+            setStroke(LayoutHelper.dp(1f), 0x40FFFFFF)
+        }
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        val top = LayoutHelper.dpf(22f)
+        val bottom = height - LayoutHelper.dpf(22f)
+        val centerX = width / 2f
+        val fraction = (value - minValue) / (maxValue - minValue)
+        val thumbY = bottom - fraction * (bottom - top)
+        val topHalfWidth = LayoutHelper.dpf(9f)
+        val bottomHalfWidth = LayoutHelper.dpf(1.5f)
+        val thumbHalfWidth = bottomHalfWidth + (topHalfWidth - bottomHalfWidth) * fraction
+
+        trapezoidPath.reset()
+        trapezoidPath.moveTo(centerX - topHalfWidth, top)
+        trapezoidPath.lineTo(centerX + topHalfWidth, top)
+        trapezoidPath.lineTo(centerX + bottomHalfWidth, bottom)
+        trapezoidPath.lineTo(centerX - bottomHalfWidth, bottom)
+        trapezoidPath.close()
+        canvas.drawPath(trapezoidPath, trackPaint)
+
+        activePath.reset()
+        activePath.moveTo(centerX - bottomHalfWidth, bottom)
+        activePath.lineTo(centerX + bottomHalfWidth, bottom)
+        activePath.lineTo(centerX + thumbHalfWidth, thumbY)
+        activePath.lineTo(centerX - thumbHalfWidth, thumbY)
+        activePath.close()
+        canvas.drawPath(activePath, activePaint)
+
+        canvas.drawCircle(centerX, thumbY, LayoutHelper.dpf(9f), thumbPaint)
+        val previewRadius = LayoutHelper.dpf(2f) + fraction * LayoutHelper.dpf(4f)
+        canvas.drawCircle(centerX, thumbY, previewRadius, previewPaint)
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                parent?.requestDisallowInterceptTouchEvent(true)
+                updateValue(event.y)
+                return true
+            }
+            MotionEvent.ACTION_MOVE -> {
+                updateValue(event.y)
+                return true
+            }
+            MotionEvent.ACTION_UP -> {
+                updateValue(event.y)
+                parent?.requestDisallowInterceptTouchEvent(false)
+                performClick()
+                return true
+            }
+            MotionEvent.ACTION_CANCEL -> {
+                parent?.requestDisallowInterceptTouchEvent(false)
+                return true
+            }
+        }
+        return super.onTouchEvent(event)
+    }
+
+    override fun performClick(): Boolean {
+        super.performClick()
+        return true
+    }
+
+    private fun updateValue(touchY: Float) {
+        val top = LayoutHelper.dpf(22f)
+        val bottom = height - LayoutHelper.dpf(22f)
+        if (bottom <= top) return
+        val fraction = (1f - (touchY - top) / (bottom - top)).coerceIn(0f, 1f)
+        val newValue = minValue + fraction * (maxValue - minValue)
+        if (kotlin.math.abs(newValue - value) < 0.05f) return
+        value = newValue
+        invalidate()
+        onValueChanged?.invoke(value)
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/home/chat/thread/CreateThreadFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/thread/CreateThreadFragment.kt
@@ -1078,8 +1078,7 @@ class CreateThreadFragment : BaseFragment() {
     private fun openAttachAlert() {
         dismissPasteImagePopup()
         val ctx = getContext() ?: return
-        val preselected = pendingAttachments.filter { !it.isFileType }
-        val alert = ChatAttachAlert(ctx, mediaController, themeColors, preselected)
+        val alert = ChatAttachAlert(ctx, mediaController, themeColors, emptyList())
         cameraSourceAlert = alert
         alert.attachDelegate = object : ChatAttachAlert.ChatAttachAlertDelegate {
             override fun canSelectMore(): Boolean {
@@ -1088,11 +1087,15 @@ class CreateThreadFragment : BaseFragment() {
 
             override fun onSelectionChanged(item: AttachmentPickerItem, selected: Boolean) {
                 if (selected) {
-                    if (pendingAttachments.any { it.id == item.id }) return
                     pendingAttachments.add(item)
                 } else {
-                    pendingAttachments.filter { it.id == item.id }.forEach { it.deleteOwnedCacheFile() }
-                    pendingAttachments.removeAll { it.id == item.id }
+                    val idx = pendingAttachments.indexOfLast { it.id == item.id }
+                    if (idx >= 0) {
+                        val removed = pendingAttachments.removeAt(idx)
+                        if (pendingAttachments.none { it.id == item.id }) {
+                            removed.deleteOwnedCacheFile()
+                        }
+                    }
                 }
                 updateAttachmentPreview()
                 updateSendButtonState()
@@ -1242,31 +1245,18 @@ class CreateThreadFragment : BaseFragment() {
             capture.discard()
             return
         }
-        lateinit var review: CameraPhotoReviewDialog
-        review = CameraPhotoReviewDialog(
-            context = ctx,
-            capture = capture,
-            onRetake = {
-                launchCameraPhoto().also { launched ->
-                    if (launched) capture.discard()
-                }
-            },
-            onUsePhoto = {
-                if (activeCameraReview === review) activeCameraReview = null
-                if (pendingAttachments.none { it.id == item.id }) pendingAttachments.add(item)
-                cameraSourceAlert?.dismissWithoutAnimation()
-                updateAttachmentPreview()
-                updateSendButtonState()
-            },
-            onCancelReview = {
-                if (activeCameraReview === review) activeCameraReview = null
-                capture.discard()
-            }
-        )
-        val previousReview = activeCameraReview
-        activeCameraReview = review
-        review.show()
-        previousReview?.dismiss()
+        val editor = ChatImageEditorDialog(ctx, item) { edited ->
+            cameraSourceAlert?.dismissWithoutAnimation()
+            trySubmit(edited)
+            capture.discard()
+        }
+        activeImageEditor?.dismiss()
+        activeImageEditor = editor
+        editor.setOnDismissListener {
+            if (activeImageEditor === editor) activeImageEditor = null
+            capture.discard()
+        }
+        editor.show()
     }
 
     override fun onRequestPermissionsResult(

--- a/app/src/main/java/com/mezon/mobile/home/chat/thread/CreateThreadFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/thread/CreateThreadFragment.kt
@@ -60,6 +60,7 @@ import com.mezon.mobile.home.chat.input.VoiceRecordingOverlay
 import com.mezon.mobile.home.chat.ChatAttachAlert
 import com.mezon.mobile.home.chat.CameraPhotoCapture
 import com.mezon.mobile.home.chat.CameraPhotoReviewDialog
+import com.mezon.mobile.home.chat.ChatImageEditorDialog
 import com.mezon.mobile.home.chat.CameraPermissionPrompt
 import com.mezon.mobile.home.chat.EmojiItem
 import com.mezon.mobile.home.chat.emoji.EmojiView
@@ -201,6 +202,7 @@ class CreateThreadFragment : BaseFragment() {
     private var pendingCameraCapture: CameraPhotoCapture? = null
     private var cameraSourceAlert: ChatAttachAlert? = null
     private var activeCameraReview: CameraPhotoReviewDialog? = null
+    private var activeImageEditor: ChatImageEditorDialog? = null
     private val pendingAttachmentThumbTasks = ArrayList<Runnable?>()
     private val mentionTrackers = mutableListOf<MentionData>()
     private val hashtagTrackers = mutableListOf<HashtagData>()
@@ -1089,6 +1091,7 @@ class CreateThreadFragment : BaseFragment() {
                     if (pendingAttachments.any { it.id == item.id }) return
                     pendingAttachments.add(item)
                 } else {
+                    pendingAttachments.filter { it.id == item.id }.forEach { it.deleteOwnedCacheFile() }
                     pendingAttachments.removeAll { it.id == item.id }
                 }
                 updateAttachmentPreview()
@@ -1097,6 +1100,26 @@ class CreateThreadFragment : BaseFragment() {
 
             override fun onFilesRequested() {
                 launchDocumentPicker()
+            }
+
+            override fun canEdit(item: AttachmentPickerItem): Boolean =
+                pendingAttachments.size == 1 &&
+                    !item.isVideo &&
+                    item.mimeType.startsWith("image/", ignoreCase = true)
+
+            override fun onEditRequested(item: AttachmentPickerItem) {
+                val currentIndex = pendingAttachments.indexOfFirst { it.id == item.id }
+                if (currentIndex < 0) return
+                activeImageEditor?.dismiss()
+                val editor = ChatImageEditorDialog(ctx, pendingAttachments[currentIndex]) { edited ->
+                    alert.dismiss()
+                    trySubmit(edited)
+                }
+                activeImageEditor = editor
+                editor.setOnDismissListener {
+                    if (activeImageEditor === editor) activeImageEditor = null
+                }
+                editor.show()
             }
 
             override fun onCameraRequested() {
@@ -1308,7 +1331,7 @@ class CreateThreadFragment : BaseFragment() {
                 setBackgroundColor(0x80000000.toInt())
                 setPadding(LayoutHelper.dp(2f), LayoutHelper.dp(2f), LayoutHelper.dp(2f), LayoutHelper.dp(2f))
                 setOnClickListener {
-                    pendingAttachments.removeAt(i)
+                    pendingAttachments.removeAt(i).deleteOwnedCacheFile()
                     updateAttachmentPreview()
                     updateSendButtonState()
                 }
@@ -1918,12 +1941,14 @@ class CreateThreadFragment : BaseFragment() {
 
     private fun sendComposerToThread(
         threadChannelId: Long,
-        threadPrivate: Boolean
+        threadPrivate: Boolean,
+        attachmentOverride: List<AttachmentPickerItem>? = null,
     ) {
+        val outgoingAttachments = attachmentOverride ?: pendingAttachments
         val rawInput = composerField.text?.toString() ?: ""
         val text = rawInput.trim()
         val ctx = getContext() ?: return
-        if (text.isBlank() && pendingAttachments.isEmpty()) {
+        if (text.isBlank() && outgoingAttachments.isEmpty()) {
             pendingStickerSend?.let { st ->
                 chatController.sendDirectAttachment(
                     threadChannelId, clanId, CHANNEL_TYPE_THREAD, threadPrivate,
@@ -1957,10 +1982,10 @@ class CreateThreadFragment : BaseFragment() {
         }
         val hashtags = hashtagsFromTrackers.ifEmpty { null }
         val emojiMarkers = buildEmojiMarkers(cleanedText)
-        if (pendingAttachments.isNotEmpty()) {
+        if (outgoingAttachments.isNotEmpty()) {
             chatController.sendMessageWithAttachments(
                 threadChannelId, clanId, CHANNEL_TYPE_THREAD, threadPrivate, cleanedText,
-                ArrayList(pendingAttachments),
+                ArrayList(outgoingAttachments),
                 ctx.contentResolver,
                 null,
                 mentions,
@@ -2094,15 +2119,16 @@ class CreateThreadFragment : BaseFragment() {
         }
     }
 
-    private fun captureTopicComposerPayload(): TopicComposerPayload? {
+    private fun captureTopicComposerPayload(attachmentOverride: AttachmentPickerItem? = null): TopicComposerPayload? {
         val rawInput = composerField.text?.toString() ?: ""
         val text = rawInput.trim()
-        val hasAttachments = pendingAttachments.isNotEmpty()
+        val outgoingAttachments = attachmentOverride?.let { arrayListOf(it) } ?: ArrayList(pendingAttachments)
+        val hasAttachments = outgoingAttachments.isNotEmpty()
         val hasSticker = pendingStickerSend != null
         if (text.isBlank() && !hasAttachments && !hasSticker) return null
         return TopicComposerPayload(
             rawInput = rawInput,
-            attachments = ArrayList(pendingAttachments),
+            attachments = outgoingAttachments,
             sticker = pendingStickerSend,
             mentions = ArrayList(mentionTrackers),
             hashtags = ArrayList(hashtagTrackers),
@@ -2142,13 +2168,23 @@ class CreateThreadFragment : BaseFragment() {
         }
     }
 
-    private fun trySubmit() {
-        if (isSubmitting) return
+    private fun trySubmit(attachmentOverride: AttachmentPickerItem? = null) {
+        fun discardUnusedOverride() {
+            if (attachmentOverride != null && pendingAttachments.none { it.uri == attachmentOverride.uri }) {
+                attachmentOverride.deleteOwnedCacheFile()
+            }
+        }
+        if (isSubmitting) {
+            discardUnusedOverride()
+            return
+        }
         if (fromTopicFlow && anonymousController.isAnonymous(clanId)) {
+            discardUnusedOverride()
             MezonToast.show(this, ToastOverlay.ToastType.ERROR, getString(R.string.channel_permissions_no_access))
             return
         }
         if (!canCreateThreadForCurrentFlow()) {
+            discardUnusedOverride()
             MezonToast.show(this, ToastOverlay.ToastType.ERROR, getString(R.string.channel_permissions_no_access))
             return
         }
@@ -2156,6 +2192,7 @@ class CreateThreadFragment : BaseFragment() {
         if (!fromTopicFlow) {
             val nameErr = validateThreadName(nameField?.text?.toString().orEmpty())
             if (nameErr.isNotEmpty()) {
+                discardUnusedOverride()
                 errorText?.text = nameErr
                 nameErrorRow?.visibility = View.VISIBLE
                 MezonToast.show(this, ToastOverlay.ToastType.ERROR, nameErr)
@@ -2167,6 +2204,7 @@ class CreateThreadFragment : BaseFragment() {
         isSubmitting = true
         sendButton?.isEnabled = false
         attachButton?.isEnabled = false
+        var attachmentHandedOff = false
 
         fragmentScope.launch {
             try {
@@ -2188,7 +2226,7 @@ class CreateThreadFragment : BaseFragment() {
                         )
                     } ?: throw IllegalStateException("create topic failed")
                     val topicRootMessageId = createdTopic.messageId.takeIf { it != 0L } ?: seedMessageId
-                    val composerPayload = captureTopicComposerPayload()
+                    val composerPayload = captureTopicComposerPayload(attachmentOverride)
                     withContext(mainDispatcher) {
                         submitProgress?.visibility = View.GONE
                         isSubmitting = false
@@ -2196,6 +2234,7 @@ class CreateThreadFragment : BaseFragment() {
                         attachButton?.isEnabled = true
                         if (composerPayload != null) {
                             sendComposerToTopic(createdTopic.id, composerPayload)
+                            if (attachmentOverride != null) attachmentHandedOff = true
                             composerField.text?.clear()
                             emojiObjPicked.clear()
                             mentionTrackers.clear()
@@ -2264,7 +2303,12 @@ class CreateThreadFragment : BaseFragment() {
                     delay(80)
                 }
                 withContext(mainDispatcher) {
-                    sendComposerToThread(desc.channelId, threadPrivate)
+                    sendComposerToThread(
+                        desc.channelId,
+                        threadPrivate,
+                        attachmentOverride?.let(::listOf),
+                    )
+                    if (attachmentOverride != null) attachmentHandedOff = true
                 }
                 delay(80)
                 withContext(mainDispatcher) {
@@ -2291,6 +2335,11 @@ class CreateThreadFragment : BaseFragment() {
                 }
             } catch (_: Exception) {
                 withContext(mainDispatcher) {
+                    if (!attachmentHandedOff && attachmentOverride != null &&
+                        pendingAttachments.none { it.uri == attachmentOverride.uri }
+                    ) {
+                        attachmentOverride.deleteOwnedCacheFile()
+                    }
                     submitProgress?.visibility = View.GONE
                     isSubmitting = false
                     sendButton?.isEnabled = true
@@ -2516,6 +2565,9 @@ class CreateThreadFragment : BaseFragment() {
     }
 
     override fun onFragmentDestroy() {
+        activeImageEditor?.setOnDismissListener(null)
+        activeImageEditor?.dismiss()
+        activeImageEditor = null
         waitingForKeyboardOpen = false
         mainHandler.removeCallbacks(voiceLongPressRunnable)
         voiceCompleteRunnable?.let { mainHandler.removeCallbacks(it) }
@@ -2527,6 +2579,7 @@ class CreateThreadFragment : BaseFragment() {
         dismissPasteImagePopup()
         for (t in pendingAttachmentThumbTasks) ThumbnailCache.cancel(t)
         pendingAttachmentThumbTasks.clear()
+        pendingAttachments.forEach { it.deleteOwnedCacheFile() }
         pendingAttachments.clear()
         mentionTrackers.clear()
         hashtagTrackers.clear()

--- a/app/src/main/java/com/mezon/mobile/ui/shared/ImageTransformFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/shared/ImageTransformFragment.kt
@@ -42,7 +42,9 @@ class TransformCanvasView(
     private val outsideColor: Int = Color.BLACK,
     private val cropChromeColor: Int = Color.WHITE,
     private val outsideDimColor: Int = outsideColor,
-) : View(context) {
+) : FrameLayout(context) {
+
+
 
     private var bitmap: Bitmap? = null
 
@@ -96,7 +98,7 @@ class TransformCanvasView(
         var color: Int,
         var centerX: Float,
         var centerY: Float,
-        val textSizeInViewPx: Float,
+        var textSizeInViewPx: Float,
     )
 
     private enum class CropTouchTarget {
@@ -168,6 +170,68 @@ class TransformCanvasView(
         private const val MAX_COVER_ITERATIONS = 28
         private const val MAX_ZOOM_ITERATIONS = 14
         private const val MAX_ZOOM_FACTOR = 8f
+    }
+
+    private val imageContainerView = object : View(context) {
+        override fun onDraw(canvas: Canvas) {
+            val bmp = bitmap ?: return
+            canvas.save()
+            canvas.concat(imageMatrix)
+            canvas.drawBitmap(bmp, 0f, 0f, bitmapPaint)
+            canvas.restore()
+
+            canvas.save()
+            canvas.clipRect(cropRect)
+            canvas.concat(imageMatrix)
+            fun draw(stroke: DrawStroke) {
+                strokePaint.color = stroke.color
+                strokePaint.strokeWidth = stroke.widthInBitmapPx
+                canvas.drawPath(stroke.path, strokePaint)
+            }
+            strokes.forEach(::draw)
+            currentStroke?.let(::draw)
+            canvas.restore()
+        }
+    }
+
+    private val textContainerView = object : View(context) {
+        override fun onDraw(canvas: Canvas) {
+            drawTextOverlays(canvas, transform = null, clipToCrop = true)
+        }
+    }
+
+    private val cropMaskView = object : View(context) {
+        init {
+            dimPaint.style = Paint.Style.FILL
+        }
+        override fun onDraw(canvas: Canvas) {
+            val w = width.toFloat()
+            val h = height.toFloat()
+            
+            // Draw 4 rectangles around the cropRect to create a dimming mask
+            canvas.drawRect(0f, 0f, w, cropRect.top, dimPaint) // Top
+            canvas.drawRect(0f, cropRect.bottom, w, h, dimPaint) // Bottom
+            canvas.drawRect(0f, cropRect.top, cropRect.left, cropRect.bottom, dimPaint) // Left
+            canvas.drawRect(cropRect.right, cropRect.top, w, cropRect.bottom, dimPaint) // Right
+
+            canvas.drawRect(cropRect, framePaint)
+            if (!drawingMode && !textMode) drawCornerBrackets(canvas)
+        }
+    }
+
+    init {
+        setBackgroundColor(outsideColor)
+        setWillNotDraw(false)
+        addView(imageContainerView, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT))
+        addView(textContainerView, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT))
+        addView(cropMaskView, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT))
+    }
+
+    override fun invalidate() {
+        super.invalidate()
+        imageContainerView.invalidate()
+        textContainerView.invalidate()
+        cropMaskView.invalidate()
     }
 
     fun setFreeformCropEnabled(enabled: Boolean) {
@@ -540,25 +604,7 @@ class TransformCanvasView(
         canvas.drawPath(cornerPath, p)
     }
 
-    override fun onDraw(canvas: Canvas) {
-        super.onDraw(canvas)
-        canvas.drawColor(outsideColor)
-        val bmp = bitmap ?: return
 
-        canvas.drawBitmap(bmp, imageMatrix, bitmapPaint)
-        drawStrokes(canvas, imageMatrix)
-        drawTextOverlays(canvas, transform = null, clipToCrop = true)
-
-        overlayPath.reset()
-        overlayPath.addRect(0f, 0f, width.toFloat(), height.toFloat(), Path.Direction.CW)
-        holePath.reset()
-        holePath.addRect(cropRect, Path.Direction.CW)
-        overlayPath.op(holePath, Path.Op.DIFFERENCE)
-        canvas.drawPath(overlayPath, dimPaint)
-
-        canvas.drawRect(cropRect, framePaint)
-        if (!drawingMode && !textMode) drawCornerBrackets(canvas)
-    }
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
         scaleDetector.onTouchEvent(event)
@@ -842,20 +888,7 @@ class TransformCanvasView(
         return false
     }
 
-    private fun drawStrokes(canvas: Canvas, matrix: Matrix) {
-        if (strokes.isEmpty() && currentStroke == null) return
-        canvas.save()
-        canvas.clipRect(cropRect)
-        canvas.concat(matrix)
-        fun draw(stroke: DrawStroke) {
-            strokePaint.color = stroke.color
-            strokePaint.strokeWidth = stroke.widthInBitmapPx
-            canvas.drawPath(stroke.path, strokePaint)
-        }
-        strokes.forEach(::draw)
-        currentStroke?.let(::draw)
-        canvas.restore()
-    }
+
 
     private fun drawTextOverlays(canvas: Canvas, transform: Matrix?, clipToCrop: Boolean) {
         if (textOverlays.isEmpty()) return
@@ -871,15 +904,11 @@ class TransformCanvasView(
         textPaint.textSize = overlay.textSizeInViewPx
         textPaint.color = overlay.color
         textPaint.style = Paint.Style.FILL
-        textOutlinePaint.textSize = overlay.textSizeInViewPx
-        textOutlinePaint.color = if (overlay.color == Color.BLACK) Color.WHITE else Color.BLACK
-        textOutlinePaint.strokeWidth = overlay.textSizeInViewPx * 0.12f
         val metrics = textPaint.fontMetrics
         val lineHeight = (metrics.descent - metrics.ascent) * 1.08f
         var baseline = overlay.centerY - lineHeight * lines.size / 2f - metrics.ascent
         lines.forEach { line ->
             val x = overlay.centerX - textPaint.measureText(line) / 2f
-            canvas.drawText(line, x, baseline, textOutlinePaint)
             canvas.drawText(line, x, baseline, textPaint)
             baseline += lineHeight
         }
@@ -999,8 +1028,39 @@ class TransformCanvasView(
     fun renderCroppedSquare(outSize: Int): Bitmap? = renderCropped(outSize, outSize)
 
     private inner class ScaleListener : ScaleGestureDetector.SimpleOnScaleGestureListener() {
+        private var zoomTextIndex = -1
+
+        override fun onScaleBegin(detector: ScaleGestureDetector): Boolean {
+            zoomTextIndex = -1
+            if (textMode && textOverlays.isNotEmpty()) {
+                var minDistance = Float.MAX_VALUE
+                textOverlays.forEachIndexed { index, overlay ->
+                    val dx = overlay.centerX - detector.focusX
+                    val dy = overlay.centerY - detector.focusY
+                    val dist = dx * dx + dy * dy
+                    if (dist < minDistance) {
+                        minDistance = dist
+                        zoomTextIndex = index
+                    }
+                }
+            }
+            return super.onScaleBegin(detector)
+        }
+
         override fun onScale(detector: ScaleGestureDetector): Boolean {
-            imageMatrix.postScale(detector.scaleFactor, detector.scaleFactor, detector.focusX, detector.focusY)
+            val scaleFactor = detector.scaleFactor
+            if (scaleFactor.isNaN() || scaleFactor.isInfinite()) return false
+            if (textMode) {
+                if (zoomTextIndex >= 0) {
+                    val overlay = textOverlays[zoomTextIndex]
+                    overlay.textSizeInViewPx = (overlay.textSizeInViewPx * scaleFactor)
+                        .coerceIn(LayoutHelper.dpf(12f), LayoutHelper.dpf(120f))
+                    textContainerView.invalidate()
+                }
+                return true
+            }
+            if (drawingMode) return true
+            imageMatrix.postScale(scaleFactor, scaleFactor, detector.focusX, detector.focusY)
             clampAfterTransform()
             invalidate()
             onEditorChanged?.invoke()

--- a/app/src/main/java/com/mezon/mobile/ui/shared/ImageTransformFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/shared/ImageTransformFragment.kt
@@ -9,6 +9,7 @@ import android.graphics.Color
 import android.graphics.Matrix
 import android.graphics.Paint
 import android.graphics.Path
+import android.graphics.PathMeasure
 import android.graphics.RectF
 import android.graphics.Typeface
 import android.net.Uri
@@ -17,6 +18,7 @@ import android.view.Gravity
 import android.view.MotionEvent
 import android.view.ScaleGestureDetector
 import android.view.View
+import android.view.ViewConfiguration
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
@@ -32,12 +34,14 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
+import kotlin.math.hypot
 import kotlin.math.max
 
 class TransformCanvasView(
     context: Context,
     private val outsideColor: Int = Color.BLACK,
     private val cropChromeColor: Int = Color.WHITE,
+    private val outsideDimColor: Int = outsideColor,
 ) : View(context) {
 
     private var bitmap: Bitmap? = null
@@ -45,7 +49,7 @@ class TransformCanvasView(
     private val imageMatrix = Matrix()
     private val bitmapPaint = Paint(Paint.ANTI_ALIAS_FLAG or Paint.FILTER_BITMAP_FLAG)
 
-    private val dimPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = outsideColor }
+    private val dimPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = outsideDimColor }
 
     private val framePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         style = Paint.Style.STROKE
@@ -66,9 +70,90 @@ class TransformCanvasView(
     private val holePath = Path()
 
     private val cropRect = RectF()
+    private val initialCropRect = RectF()
+    private var rotationCropFitScale = 1f
 
     private var cropAspectW = 1f
     private var cropAspectH = 1f
+    private var cropInsetLeft = LayoutHelper.dpf(24f)
+    private var cropInsetTop = LayoutHelper.dpf(24f)
+    private var cropInsetRight = LayoutHelper.dpf(24f)
+    private var cropInsetBottom = LayoutHelper.dpf(24f)
+    private var freeformCropEnabled = false
+    private var drawingMode = false
+    private var eraserMode = false
+    private var textMode = false
+    private var onEditorChanged: (() -> Unit)? = null
+
+    private data class DrawStroke(
+        val path: Path,
+        val color: Int,
+        val widthInBitmapPx: Float,
+    )
+
+    private data class TextOverlay(
+        var text: String,
+        var color: Int,
+        var centerX: Float,
+        var centerY: Float,
+        val textSizeInViewPx: Float,
+    )
+
+    private enum class CropTouchTarget {
+        TOP_LEFT,
+        TOP_RIGHT,
+        BOTTOM_LEFT,
+        BOTTOM_RIGHT,
+        LEFT,
+        TOP,
+        RIGHT,
+        BOTTOM,
+        PAN_IMAGE,
+        IMAGE,
+        NONE,
+    }
+
+    private val strokes = ArrayList<DrawStroke>()
+    private var currentStroke: DrawStroke? = null
+    private var brushColor = Color.RED
+    private var brushWidthViewPx = LayoutHelper.dpf(5f)
+    private val strokePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeCap = Paint.Cap.ROUND
+        strokeJoin = Paint.Join.ROUND
+    }
+    private val inverseImageMatrix = Matrix()
+    private val mappedTouchPoint = FloatArray(2)
+    private var lastBitmapTouchX = 0f
+    private var lastBitmapTouchY = 0f
+    private val strokePathMeasure = PathMeasure()
+    private val strokeMeasurePosition = FloatArray(2)
+
+    private val textOverlays = ArrayList<TextOverlay>()
+    private val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        textAlign = Paint.Align.LEFT
+        typeface = Typeface.DEFAULT_BOLD
+    }
+    private val textOutlinePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        textAlign = Paint.Align.LEFT
+        typeface = Typeface.DEFAULT_BOLD
+        style = Paint.Style.STROKE
+        color = Color.BLACK
+        strokeJoin = Paint.Join.ROUND
+    }
+    private val textBounds = RectF()
+    private var selectedTextIndex = -1
+    private var textTouchIndex = -1
+    private var textDragOffsetX = 0f
+    private var textDragOffsetY = 0f
+    private var textTouchDownX = 0f
+    private var textTouchDownY = 0f
+    private var textPointerDown = false
+    private var textTouchMoved = false
+    private val textTouchSlop = ViewConfiguration.get(context).scaledTouchSlop.toFloat()
+    private var onTextEditRequested: ((index: Int, text: String, color: Int) -> Unit)? = null
+    private var onTextSelected: ((color: Int) -> Unit)? = null
+    private var onTextDeleteDrag: ((active: Boolean, x: Float, y: Float) -> Boolean)? = null
 
     private val initialMatrix = Matrix()
 
@@ -77,6 +162,7 @@ class TransformCanvasView(
     private var lastTouchX = 0f
     private var lastTouchY = 0f
     private var dragMode = false
+    private var cropTouchTarget = CropTouchTarget.NONE
 
     companion object {
         private const val MAX_COVER_ITERATIONS = 28
@@ -84,23 +170,204 @@ class TransformCanvasView(
         private const val MAX_ZOOM_FACTOR = 8f
     }
 
+    fun setFreeformCropEnabled(enabled: Boolean) {
+        if (freeformCropEnabled == enabled) return
+        freeformCropEnabled = enabled
+        if (measuredWidth > 0 && measuredHeight > 0) {
+            layoutCropRect(measuredWidth, measuredHeight)
+            bitmap?.let { resetTransform() }
+        }
+        invalidate()
+    }
+
+    fun setCropInsetsDp(left: Float, top: Float, right: Float, bottom: Float) {
+        cropInsetLeft = LayoutHelper.dpf(left.coerceAtLeast(0f))
+        cropInsetTop = LayoutHelper.dpf(top.coerceAtLeast(0f))
+        cropInsetRight = LayoutHelper.dpf(right.coerceAtLeast(0f))
+        cropInsetBottom = LayoutHelper.dpf(bottom.coerceAtLeast(0f))
+        if (measuredWidth > 0 && measuredHeight > 0) {
+            layoutCropRect(measuredWidth, measuredHeight)
+            bitmap?.let { resetTransform() }
+        }
+        invalidate()
+    }
+
+    fun setOnEditorChangedListener(listener: (() -> Unit)?) {
+        onEditorChanged = listener
+    }
+
+    fun setOnTextEditRequestedListener(listener: ((index: Int, text: String, color: Int) -> Unit)?) {
+        onTextEditRequested = listener
+    }
+
+    fun setOnTextSelectedListener(listener: ((color: Int) -> Unit)?) {
+        onTextSelected = listener
+    }
+
+    fun setOnTextDeleteDragListener(listener: ((active: Boolean, x: Float, y: Float) -> Boolean)?) {
+        onTextDeleteDrag = listener
+    }
+
+    fun setDrawingMode(enabled: Boolean) {
+        if ((enabled && drawingMode) || (!enabled && !drawingMode && !textMode)) return
+        if (textMode) cancelTextInteraction()
+        commitCurrentStroke()
+        drawingMode = enabled
+        if (!enabled) eraserMode = false
+        textMode = false
+        cropTouchTarget = CropTouchTarget.NONE
+        dragMode = false
+        invalidate()
+    }
+
+    fun isDrawingMode(): Boolean = drawingMode
+
+    fun setEraserMode(enabled: Boolean) {
+        commitCurrentStroke()
+        eraserMode = enabled && drawingMode
+        invalidate()
+    }
+
+    fun isEraserMode(): Boolean = eraserMode
+
+    fun setTextMode(enabled: Boolean) {
+        if ((enabled && textMode) || (!enabled && !textMode && !drawingMode)) return
+        cancelTextInteraction()
+        commitCurrentStroke()
+        textMode = enabled
+        drawingMode = false
+        eraserMode = false
+        cropTouchTarget = CropTouchTarget.NONE
+        dragMode = false
+        invalidate()
+    }
+
+    fun isTextMode(): Boolean = textMode
+
+    fun setBrushColor(color: Int) {
+        brushColor = color
+    }
+
+    fun setBrushWidthDp(widthDp: Float) {
+        brushWidthViewPx = LayoutHelper.dpf(widthDp.coerceAtLeast(1f))
+    }
+
+    fun addText(text: String, color: Int): Boolean {
+        val content = text.trim()
+        if (content.isEmpty()) return false
+        textOverlays.add(
+            TextOverlay(
+                text = content,
+                color = color,
+                centerX = cropRect.centerX(),
+                centerY = cropRect.centerY(),
+                textSizeInViewPx = LayoutHelper.dpf(32f),
+            ),
+        )
+        selectedTextIndex = textOverlays.lastIndex
+        invalidate()
+        onEditorChanged?.invoke()
+        return true
+    }
+
+    fun updateText(index: Int, text: String, color: Int): Boolean {
+        val overlay = textOverlays.getOrNull(index) ?: return false
+        val content = text.trim()
+        if (content.isEmpty()) {
+            removeTextAt(index)
+            return true
+        } else {
+            overlay.text = content
+            overlay.color = color
+            selectedTextIndex = index
+        }
+        invalidate()
+        onEditorChanged?.invoke()
+        return true
+    }
+
+    fun setSelectedTextColor(color: Int) {
+        val overlay = textOverlays.getOrNull(selectedTextIndex) ?: return
+        if (overlay.color == color) return
+        overlay.color = color
+        postInvalidateOnAnimation()
+        onEditorChanged?.invoke()
+    }
+
+    private fun clearEdits() {
+        cancelTextInteraction()
+        currentStroke = null
+        strokes.clear()
+        textOverlays.clear()
+        selectedTextIndex = -1
+        textTouchIndex = -1
+    }
+
     fun setImageBitmap(b: Bitmap?) {
         bitmap = b
         if (width > 0 && height > 0 && b != null) {
+            layoutCropRect(width, height)
             resetTransform()
         }
         invalidate()
     }
 
     fun resetToInitial() {
+        if (!initialCropRect.isEmpty) cropRect.set(initialCropRect)
+        rotationCropFitScale = 1f
         imageMatrix.set(initialMatrix)
         invalidate()
     }
 
+    fun resetEditor() {
+        if (!initialCropRect.isEmpty) cropRect.set(initialCropRect)
+        bitmap?.let { resetTransform() }
+        clearEdits()
+        invalidate()
+    }
+
     fun rotateByDegrees(delta: Float) {
-        imageMatrix.postRotate(delta, cropRect.centerX(), cropRect.centerY())
+        val pivotX = cropRect.centerX()
+        val pivotY = cropRect.centerY()
+        imageMatrix.postRotate(delta, pivotX, pivotY)
+        if (freeformCropEnabled && kotlin.math.abs((delta / 90f).toInt()) % 2 == 1) {
+            rotateFreeformCropRect(pivotX, pivotY)
+        }
         clampAfterTransform()
         invalidate()
+        onEditorChanged?.invoke()
+    }
+
+    private fun rotateFreeformCropRect(pivotX: Float, pivotY: Float) {
+        val allowedLeft = cropInsetLeft
+        val allowedTop = cropInsetTop
+        val allowedRight = width - cropInsetRight
+        val allowedBottom = height - cropInsetBottom
+        val allowedWidth = (allowedRight - allowedLeft).coerceAtLeast(1f)
+        val allowedHeight = (allowedBottom - allowedTop).coerceAtLeast(1f)
+        val currentFit = rotationCropFitScale.coerceAtLeast(1e-4f)
+        val unscaledRotatedWidth = cropRect.height() / currentFit
+        val unscaledRotatedHeight = cropRect.width() / currentFit
+        val newFit = minOf(
+            1f,
+            allowedWidth / unscaledRotatedWidth,
+            allowedHeight / unscaledRotatedHeight,
+        )
+        val scaleChange = newFit / currentFit
+        val newWidth = unscaledRotatedWidth * newFit
+        val newHeight = unscaledRotatedHeight * newFit
+        val newCenterX = pivotX.coerceIn(allowedLeft + newWidth / 2f, allowedRight - newWidth / 2f)
+        val newCenterY = pivotY.coerceIn(allowedTop + newHeight / 2f, allowedBottom - newHeight / 2f)
+
+        imageMatrix.postScale(scaleChange, scaleChange, pivotX, pivotY)
+        imageMatrix.postTranslate(newCenterX - pivotX, newCenterY - pivotY)
+        cropRect.set(
+            newCenterX - newWidth / 2f,
+            newCenterY - newHeight / 2f,
+            newCenterX + newWidth / 2f,
+            newCenterY + newHeight / 2f,
+        )
+        rotationCropFitScale = newFit
     }
 
     fun setCropAspectRatio(width: Float, height: Float) {
@@ -120,23 +387,43 @@ class TransformCanvasView(
     }
 
     private fun layoutCropRect(w: Int, h: Int) {
-        val pad = LayoutHelper.dp(24f)
-        val maxW = (w - pad * 2).toFloat().coerceAtLeast(LayoutHelper.dp(120f).toFloat())
-        val maxH = (h - pad * 2).toFloat().coerceAtLeast(LayoutHelper.dp(120f).toFloat())
-        val aspect = cropAspectW / cropAspectH
-        var cropW = maxW
-        var cropH = cropW / aspect
-        if (cropH > maxH) {
-            cropH = maxH
-            cropW = cropH * aspect
+        val maxW = (w - cropInsetLeft - cropInsetRight).coerceAtLeast(LayoutHelper.dpf(120f))
+        val maxH = (h - cropInsetTop - cropInsetBottom).coerceAtLeast(LayoutHelper.dpf(120f))
+        if (freeformCropEnabled) {
+            val bmp = bitmap
+            if (bmp == null) {
+                cropRect.set(cropInsetLeft, cropInsetTop, cropInsetLeft + maxW, cropInsetTop + maxH)
+            } else {
+                val aspect = bmp.width.toFloat() / bmp.height.coerceAtLeast(1)
+                var cropW = maxW
+                var cropH = cropW / aspect
+                if (cropH > maxH) {
+                    cropH = maxH
+                    cropW = cropH * aspect
+                }
+                val left = cropInsetLeft + (maxW - cropW) / 2f
+                val top = cropInsetTop + (maxH - cropH) / 2f
+                cropRect.set(left, top, left + cropW, top + cropH)
+            }
+        } else {
+            val aspect = cropAspectW / cropAspectH
+            var cropW = maxW
+            var cropH = cropW / aspect
+            if (cropH > maxH) {
+                cropH = maxH
+                cropW = cropH * aspect
+            }
+            val left = cropInsetLeft + (maxW - cropW) / 2f
+            val top = cropInsetTop + (maxH - cropH) / 2f
+            cropRect.set(left, top, left + cropW, top + cropH)
         }
-        val left = (w - cropW) / 2f
-        val top = (h - cropH) / 2f
-        cropRect.set(left, top, left + cropW, top + cropH)
+        initialCropRect.set(cropRect)
+        rotationCropFitScale = 1f
     }
 
     private fun resetTransform() {
         val bmp = bitmap ?: return
+        rotationCropFitScale = 1f
         imageMatrix.reset()
         val s = max(cropRect.width() / bmp.width, cropRect.height() / bmp.height)
         imageMatrix.postScale(s, s)
@@ -259,6 +546,8 @@ class TransformCanvasView(
         val bmp = bitmap ?: return
 
         canvas.drawBitmap(bmp, imageMatrix, bitmapPaint)
+        drawStrokes(canvas, imageMatrix)
+        drawTextOverlays(canvas, transform = null, clipToCrop = true)
 
         overlayPath.reset()
         overlayPath.addRect(0f, 0f, width.toFloat(), height.toFloat(), Path.Direction.CW)
@@ -268,32 +557,393 @@ class TransformCanvasView(
         canvas.drawPath(overlayPath, dimPaint)
 
         canvas.drawRect(cropRect, framePaint)
-        drawCornerBrackets(canvas)
+        if (!drawingMode && !textMode) drawCornerBrackets(canvas)
     }
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
         scaleDetector.onTouchEvent(event)
         when (event.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
-                dragMode = true
                 lastTouchX = event.x
                 lastTouchY = event.y
+                if (drawingMode) {
+                    dragMode = false
+                    if (cropRect.contains(event.x, event.y)) {
+                        if (eraserMode) eraseStrokesAt(event.x, event.y) else startStroke(event.x, event.y)
+                    }
+                } else if (textMode) {
+                    dragMode = false
+                    textTouchIndex = findTextOverlay(event.x, event.y)
+                    textPointerDown = textTouchIndex >= 0
+                    textTouchMoved = false
+                    textTouchDownX = event.x
+                    textTouchDownY = event.y
+                    if (textPointerDown) {
+                        selectedTextIndex = textTouchIndex
+                        val overlay = textOverlays[textTouchIndex]
+                        onTextSelected?.invoke(overlay.color)
+                        textDragOffsetX = overlay.centerX - event.x
+                        textDragOffsetY = overlay.centerY - event.y
+                    }
+                    invalidate()
+                } else {
+                    cropTouchTarget = if (freeformCropEnabled) {
+                        findCropTouchTarget(event.x, event.y)
+                    } else {
+                        CropTouchTarget.IMAGE
+                    }
+                    dragMode = cropTouchTarget != CropTouchTarget.NONE
+                }
             }
-            MotionEvent.ACTION_POINTER_DOWN -> dragMode = false
+            MotionEvent.ACTION_POINTER_DOWN -> {
+                commitCurrentStroke()
+                cropTouchTarget = CropTouchTarget.NONE
+                dragMode = false
+                cancelTextInteraction()
+            }
             MotionEvent.ACTION_MOVE -> {
-                if (dragMode && !scaleDetector.isInProgress && event.pointerCount == 1) {
+                if (textMode && textPointerDown && event.pointerCount == 1 && !scaleDetector.isInProgress) {
+                    if (!textTouchMoved &&
+                        hypot(event.x - textTouchDownX, event.y - textTouchDownY) > textTouchSlop
+                    ) {
+                        textTouchMoved = true
+                    }
+                    if (textTouchMoved) {
+                        moveTouchedText(event.x, event.y)
+                        onTextDeleteDrag?.invoke(true, event.x, event.y)
+                    }
+                } else if (drawingMode && event.pointerCount == 1 && !scaleDetector.isInProgress) {
+                    if (eraserMode) eraseStrokesAt(event.x, event.y) else appendStrokePoint(event.x, event.y)
+                } else if (dragMode && !scaleDetector.isInProgress && event.pointerCount == 1) {
                     val dx = event.x - lastTouchX
                     val dy = event.y - lastTouchY
-                    imageMatrix.postTranslate(dx, dy)
-                    clampAfterTransform()
+                    if (freeformCropEnabled) {
+                        when (cropTouchTarget) {
+                            CropTouchTarget.IMAGE -> moveCropRect(dx, dy)
+                            CropTouchTarget.PAN_IMAGE -> {
+                                imageMatrix.postTranslate(dx, dy)
+                                clampAfterTransform()
+                                onEditorChanged?.invoke()
+                            }
+                            else -> resizeCropRect(cropTouchTarget, dx, dy)
+                        }
+                    } else {
+                        imageMatrix.postTranslate(dx, dy)
+                        clampAfterTransform()
+                        onEditorChanged?.invoke()
+                    }
                     lastTouchX = event.x
                     lastTouchY = event.y
                     invalidate()
                 }
             }
-            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> dragMode = false
+            MotionEvent.ACTION_UP -> {
+                commitCurrentStroke()
+                cropTouchTarget = CropTouchTarget.NONE
+                dragMode = false
+                if (textMode && textPointerDown) {
+                    if (textTouchMoved) {
+                        val deleteText = onTextDeleteDrag?.invoke(true, event.x, event.y) == true
+                        onTextDeleteDrag?.invoke(false, event.x, event.y)
+                        if (deleteText) removeTextAt(textTouchIndex)
+                    } else {
+                        textOverlays.getOrNull(textTouchIndex)?.let { overlay ->
+                            onTextEditRequested?.invoke(textTouchIndex, overlay.text, overlay.color)
+                        }
+                    }
+                }
+                resetTextTouchState()
+            }
+            MotionEvent.ACTION_CANCEL -> {
+                commitCurrentStroke()
+                cropTouchTarget = CropTouchTarget.NONE
+                dragMode = false
+                cancelTextInteraction()
+            }
         }
         return true
+    }
+
+    override fun performClick(): Boolean {
+        super.performClick()
+        return true
+    }
+
+    private fun findCropTouchTarget(x: Float, y: Float): CropTouchTarget {
+        val radius = LayoutHelper.dpf(28f)
+        val nearLeft = kotlin.math.abs(x - cropRect.left) <= radius
+        val nearRight = kotlin.math.abs(x - cropRect.right) <= radius
+        val nearTop = kotlin.math.abs(y - cropRect.top) <= radius
+        val nearBottom = kotlin.math.abs(y - cropRect.bottom) <= radius
+        val inExpandedX = x in (cropRect.left - radius)..(cropRect.right + radius)
+        val inExpandedY = y in (cropRect.top - radius)..(cropRect.bottom + radius)
+        return when {
+            nearLeft && nearTop -> CropTouchTarget.TOP_LEFT
+            nearRight && nearTop -> CropTouchTarget.TOP_RIGHT
+            nearLeft && nearBottom -> CropTouchTarget.BOTTOM_LEFT
+            nearRight && nearBottom -> CropTouchTarget.BOTTOM_RIGHT
+            nearLeft && inExpandedY -> CropTouchTarget.LEFT
+            nearRight && inExpandedY -> CropTouchTarget.RIGHT
+            nearTop && inExpandedX -> CropTouchTarget.TOP
+            nearBottom && inExpandedX -> CropTouchTarget.BOTTOM
+            cropRect.contains(x, y) -> CropTouchTarget.IMAGE
+            canPanImage() && isPointOnImage(x, y) -> CropTouchTarget.PAN_IMAGE
+            else -> CropTouchTarget.NONE
+        }
+    }
+
+    private fun canPanImage(): Boolean {
+        if (bitmap == null) return false
+        val bounds = mapBitmapBounds()
+        val tolerance = LayoutHelper.dpf(1f)
+        return bounds.width() > cropRect.width() + tolerance ||
+            bounds.height() > cropRect.height() + tolerance
+    }
+
+    private fun isPointOnImage(viewX: Float, viewY: Float): Boolean {
+        val bmp = bitmap ?: return false
+        if (!mapViewPointToBitmap(viewX, viewY)) return false
+        return mappedTouchPoint[0] in 0f..bmp.width.toFloat() &&
+            mappedTouchPoint[1] in 0f..bmp.height.toFloat()
+    }
+
+    private fun resizeCropRect(target: CropTouchTarget, dx: Float, dy: Float) {
+        val minSize = LayoutHelper.dpf(80f)
+        val imageBounds = mapBitmapBounds()
+        val minLeft = maxOf(cropInsetLeft, imageBounds.left)
+        val maxRight = minOf(width - cropInsetRight, imageBounds.right)
+        val minTop = maxOf(cropInsetTop, imageBounds.top)
+        val maxBottom = minOf(height - cropInsetBottom, imageBounds.bottom)
+        when (target) {
+            CropTouchTarget.TOP_LEFT -> {
+                cropRect.left = (cropRect.left + dx).coerceIn(minLeft, cropRect.right - minSize)
+                cropRect.top = (cropRect.top + dy).coerceIn(minTop, cropRect.bottom - minSize)
+            }
+            CropTouchTarget.TOP_RIGHT -> {
+                cropRect.right = (cropRect.right + dx).coerceIn(cropRect.left + minSize, maxRight)
+                cropRect.top = (cropRect.top + dy).coerceIn(minTop, cropRect.bottom - minSize)
+            }
+            CropTouchTarget.BOTTOM_LEFT -> {
+                cropRect.left = (cropRect.left + dx).coerceIn(minLeft, cropRect.right - minSize)
+                cropRect.bottom = (cropRect.bottom + dy).coerceIn(cropRect.top + minSize, maxBottom)
+            }
+            CropTouchTarget.BOTTOM_RIGHT -> {
+                cropRect.right = (cropRect.right + dx).coerceIn(cropRect.left + minSize, maxRight)
+                cropRect.bottom = (cropRect.bottom + dy).coerceIn(cropRect.top + minSize, maxBottom)
+            }
+            CropTouchTarget.LEFT ->
+                cropRect.left = (cropRect.left + dx).coerceIn(minLeft, cropRect.right - minSize)
+            CropTouchTarget.TOP ->
+                cropRect.top = (cropRect.top + dy).coerceIn(minTop, cropRect.bottom - minSize)
+            CropTouchTarget.RIGHT ->
+                cropRect.right = (cropRect.right + dx).coerceIn(cropRect.left + minSize, maxRight)
+            CropTouchTarget.BOTTOM ->
+                cropRect.bottom = (cropRect.bottom + dy).coerceIn(cropRect.top + minSize, maxBottom)
+            else -> return
+        }
+        rotationCropFitScale = 1f
+        onEditorChanged?.invoke()
+    }
+
+    private fun moveCropRect(dx: Float, dy: Float) {
+        val imageBounds = mapBitmapBounds()
+        val minLeft = maxOf(cropInsetLeft, imageBounds.left)
+        val maxRight = minOf(width - cropInsetRight, imageBounds.right)
+        val minTop = maxOf(cropInsetTop, imageBounds.top)
+        val maxBottom = minOf(height - cropInsetBottom, imageBounds.bottom)
+        val moveX = dx.coerceIn(minLeft - cropRect.left, maxRight - cropRect.right)
+        val moveY = dy.coerceIn(minTop - cropRect.top, maxBottom - cropRect.bottom)
+        if (moveX == 0f && moveY == 0f) return
+        cropRect.offset(moveX, moveY)
+        onEditorChanged?.invoke()
+    }
+
+    private fun imageScale(): Float {
+        val values = FloatArray(9)
+        imageMatrix.getValues(values)
+        return hypot(values[Matrix.MSCALE_X], values[Matrix.MSKEW_Y]).coerceAtLeast(1e-4f)
+    }
+
+    private fun mapViewPointToBitmap(x: Float, y: Float): Boolean {
+        if (!imageMatrix.invert(inverseImageMatrix)) return false
+        mappedTouchPoint[0] = x
+        mappedTouchPoint[1] = y
+        inverseImageMatrix.mapPoints(mappedTouchPoint)
+        return true
+    }
+
+    private fun startStroke(viewX: Float, viewY: Float) {
+        if (!mapViewPointToBitmap(viewX, viewY)) return
+        val path = Path().apply { moveTo(mappedTouchPoint[0], mappedTouchPoint[1]) }
+        lastBitmapTouchX = mappedTouchPoint[0]
+        lastBitmapTouchY = mappedTouchPoint[1]
+        currentStroke = DrawStroke(path, brushColor, brushWidthViewPx / imageScale())
+        invalidate()
+    }
+
+    private fun appendStrokePoint(viewX: Float, viewY: Float) {
+        val stroke = currentStroke ?: return
+        if (!mapViewPointToBitmap(viewX, viewY)) return
+        val x = mappedTouchPoint[0]
+        val y = mappedTouchPoint[1]
+        stroke.path.quadTo(lastBitmapTouchX, lastBitmapTouchY, (lastBitmapTouchX + x) / 2f, (lastBitmapTouchY + y) / 2f)
+        lastBitmapTouchX = x
+        lastBitmapTouchY = y
+        invalidate()
+    }
+
+    private fun commitCurrentStroke() {
+        val stroke = currentStroke ?: return
+        stroke.path.lineTo(lastBitmapTouchX, lastBitmapTouchY)
+        strokes.add(stroke)
+        currentStroke = null
+        invalidate()
+        onEditorChanged?.invoke()
+    }
+
+    private fun eraseStrokesAt(viewX: Float, viewY: Float) {
+        if (!cropRect.contains(viewX, viewY) || !mapViewPointToBitmap(viewX, viewY)) return
+        val x = mappedTouchPoint[0]
+        val y = mappedTouchPoint[1]
+        val eraserRadius = LayoutHelper.dpf(14f) / imageScale()
+        var removed = false
+        for (index in strokes.lastIndex downTo 0) {
+            if (strokeContainsPoint(strokes[index], x, y, eraserRadius)) {
+                strokes.removeAt(index)
+                removed = true
+            }
+        }
+        if (!removed) return
+        invalidate()
+        onEditorChanged?.invoke()
+    }
+
+    private fun strokeContainsPoint(stroke: DrawStroke, x: Float, y: Float, eraserRadius: Float): Boolean {
+        strokePathMeasure.setPath(stroke.path, false)
+        val hitRadius = eraserRadius + stroke.widthInBitmapPx / 2f
+        val sampleStep = (eraserRadius * 0.45f).coerceAtLeast(2f)
+        do {
+            val length = strokePathMeasure.length
+            var distance = 0f
+            while (distance <= length) {
+                if (strokePathMeasure.getPosTan(distance, strokeMeasurePosition, null) &&
+                    hypot(strokeMeasurePosition[0] - x, strokeMeasurePosition[1] - y) <= hitRadius
+                ) {
+                    return true
+                }
+                distance += sampleStep
+            }
+            if (length > 0f && strokePathMeasure.getPosTan(length, strokeMeasurePosition, null) &&
+                hypot(strokeMeasurePosition[0] - x, strokeMeasurePosition[1] - y) <= hitRadius
+            ) {
+                return true
+            }
+        } while (strokePathMeasure.nextContour())
+        return false
+    }
+
+    private fun drawStrokes(canvas: Canvas, matrix: Matrix) {
+        if (strokes.isEmpty() && currentStroke == null) return
+        canvas.save()
+        canvas.clipRect(cropRect)
+        canvas.concat(matrix)
+        fun draw(stroke: DrawStroke) {
+            strokePaint.color = stroke.color
+            strokePaint.strokeWidth = stroke.widthInBitmapPx
+            canvas.drawPath(stroke.path, strokePaint)
+        }
+        strokes.forEach(::draw)
+        currentStroke?.let(::draw)
+        canvas.restore()
+    }
+
+    private fun drawTextOverlays(canvas: Canvas, transform: Matrix?, clipToCrop: Boolean) {
+        if (textOverlays.isEmpty()) return
+        canvas.save()
+        if (clipToCrop) canvas.clipRect(cropRect)
+        transform?.let(canvas::concat)
+        textOverlays.forEach { overlay -> drawTextOverlay(canvas, overlay) }
+        canvas.restore()
+    }
+
+    private fun drawTextOverlay(canvas: Canvas, overlay: TextOverlay) {
+        val lines = overlay.text.lines().ifEmpty { listOf(overlay.text) }
+        textPaint.textSize = overlay.textSizeInViewPx
+        textPaint.color = overlay.color
+        textPaint.style = Paint.Style.FILL
+        textOutlinePaint.textSize = overlay.textSizeInViewPx
+        textOutlinePaint.color = if (overlay.color == Color.BLACK) Color.WHITE else Color.BLACK
+        textOutlinePaint.strokeWidth = overlay.textSizeInViewPx * 0.12f
+        val metrics = textPaint.fontMetrics
+        val lineHeight = (metrics.descent - metrics.ascent) * 1.08f
+        var baseline = overlay.centerY - lineHeight * lines.size / 2f - metrics.ascent
+        lines.forEach { line ->
+            val x = overlay.centerX - textPaint.measureText(line) / 2f
+            canvas.drawText(line, x, baseline, textOutlinePaint)
+            canvas.drawText(line, x, baseline, textPaint)
+            baseline += lineHeight
+        }
+    }
+
+    private fun textOverlayBoundsInView(overlay: TextOverlay, out: RectF) {
+        textPaint.textSize = overlay.textSizeInViewPx
+        val lines = overlay.text.lines().ifEmpty { listOf(overlay.text) }
+        val width = lines.maxOfOrNull { textPaint.measureText(it) } ?: 0f
+        val metrics = textPaint.fontMetrics
+        val height = (metrics.descent - metrics.ascent) * 1.08f * lines.size
+        val padding = overlay.textSizeInViewPx * 0.35f
+        out.set(
+            overlay.centerX - width / 2f - padding,
+            overlay.centerY - height / 2f - padding,
+            overlay.centerX + width / 2f + padding,
+            overlay.centerY + height / 2f + padding,
+        )
+    }
+
+    private fun findTextOverlay(viewX: Float, viewY: Float): Int {
+        for (index in textOverlays.indices.reversed()) {
+            textOverlayBoundsInView(textOverlays[index], textBounds)
+            if (textBounds.contains(viewX, viewY)) return index
+        }
+        return -1
+    }
+
+    private fun moveTouchedText(viewX: Float, viewY: Float) {
+        val overlay = textOverlays.getOrNull(textTouchIndex) ?: return
+        overlay.centerX = (viewX + textDragOffsetX).coerceIn(cropRect.left, cropRect.right)
+        overlay.centerY = (viewY + textDragOffsetY).coerceIn(cropRect.top, cropRect.bottom)
+        invalidate()
+        onEditorChanged?.invoke()
+    }
+
+    private fun removeTextAt(index: Int): Boolean {
+        if (index !in textOverlays.indices) return false
+        textOverlays.removeAt(index)
+        selectedTextIndex = when {
+            selectedTextIndex == index -> -1
+            selectedTextIndex > index -> selectedTextIndex - 1
+            else -> selectedTextIndex
+        }
+        textTouchIndex = -1
+        postInvalidateOnAnimation()
+        onEditorChanged?.invoke()
+        return true
+    }
+
+    private fun cancelTextInteraction() {
+        if (textTouchMoved) onTextDeleteDrag?.invoke(false, 0f, 0f)
+        resetTextTouchState()
+    }
+
+    private fun resetTextTouchState() {
+        textPointerDown = false
+        textTouchMoved = false
+        textTouchIndex = -1
+    }
+
+    override fun onDetachedFromWindow() {
+        cancelTextInteraction()
+        super.onDetachedFromWindow()
     }
 
     fun renderCropped(outWidth: Int, outHeight: Int): Bitmap? {
@@ -313,7 +963,37 @@ class TransformCanvasView(
         val out = Bitmap.createBitmap(outWidth, outHeight, Bitmap.Config.ARGB_8888)
         val canvas = Canvas(out)
         canvas.drawBitmap(bmp, bmpToOutput, bitmapPaint)
+        drawStrokesForExport(canvas, bmpToOutput)
+        drawTextOverlays(canvas, viewToOutput, clipToCrop = false)
         return out
+    }
+
+    private fun drawStrokesForExport(canvas: Canvas, matrix: Matrix) {
+        commitCurrentStroke()
+        if (strokes.isEmpty()) return
+        canvas.save()
+        canvas.concat(matrix)
+        strokes.forEach { stroke ->
+            strokePaint.color = stroke.color
+            strokePaint.strokeWidth = stroke.widthInBitmapPx
+            canvas.drawPath(stroke.path, strokePaint)
+        }
+        canvas.restore()
+    }
+
+    fun suggestedOutputSize(maxEdge: Int): Pair<Int, Int> {
+        val bmp = bitmap ?: return maxEdge to maxEdge
+        val scale = imageScale()
+        var outW = (cropRect.width() / scale).toInt().coerceAtLeast(1)
+        var outH = (cropRect.height() / scale).toInt().coerceAtLeast(1)
+        val sourceLimit = max(bmp.width, bmp.height).coerceAtMost(maxEdge)
+        val currentMax = max(outW, outH)
+        if (currentMax > sourceLimit) {
+            val factor = sourceLimit.toFloat() / currentMax
+            outW = (outW * factor).toInt().coerceAtLeast(1)
+            outH = (outH * factor).toInt().coerceAtLeast(1)
+        }
+        return outW to outH
     }
 
     fun renderCroppedSquare(outSize: Int): Bitmap? = renderCropped(outSize, outSize)
@@ -323,6 +1003,7 @@ class TransformCanvasView(
             imageMatrix.postScale(detector.scaleFactor, detector.scaleFactor, detector.focusX, detector.focusY)
             clampAfterTransform()
             invalidate()
+            onEditorChanged?.invoke()
             return true
         }
     }

--- a/app/src/main/res/drawable/ic_image_editor_crop.xml
+++ b/app/src/main/res/drawable/ic_image_editor_crop.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M6,2 L6,16 C6,17.105 6.895,18 8,18 L22,18 M2,6 L16,6 C17.105,6 18,6.895 18,8 L18,22"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2.2" />
+</vector>

--- a/app/src/main/res/drawable/ic_image_editor_draw.xml
+++ b/app/src/main/res/drawable/ic_image_editor_draw.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M4,19 C8,18 6,12 9,10 C12,8 12,16 15,14 C19,12 16,7 20,5"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2.5" />
+</vector>

--- a/app/src/main/res/drawable/ic_image_editor_eraser.xml
+++ b/app/src/main/res/drawable/ic_image_editor_eraser.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M4.5,13.5 L12.4,5.6 C13.2,4.8 14.4,4.8 15.2,5.6 L19,9.4 C19.8,10.2 19.8,11.4 19,12.2 L11.2,20 L8.4,20 L4.5,16.1 C3.8,15.4 3.8,14.2 4.5,13.5 Z M8,10 L14.5,16.5 M11.2,20 L20.5,20"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2.1" />
+</vector>

--- a/app/src/main/res/drawable/ic_image_editor_rotate.xml
+++ b/app/src/main/res/drawable/ic_image_editor_rotate.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M6,10 L15,10 A2,2 0,0 1,17 12 L17,20 A2,2 0,0 1,15 22 L6,22 A2,2 0,0 1,4 20 L4,12 A2,2 0,0 1,6 10 Z"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2.2" />
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M20,11 L20,9.5 A5,5 0,0 0,15.5 4.5 L10.5,4.5 M13.5,1.5 L10.5,4.5 L13.5,7.5"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2.2" />
+</vector>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -494,6 +494,17 @@
     <string name="image_crop_rotate_left_cd">Xoay trái</string>
     <string name="image_crop_rotate_right_cd">Xoay phải</string>
     <string name="image_crop_reset_cd">Đặt lại</string>
+    <string name="image_editor_edit">Chỉnh sửa</string>
+    <string name="image_editor_crop">Cắt</string>
+    <string name="image_editor_draw">Vẽ</string>
+    <string name="image_editor_eraser">Cục tẩy</string>
+    <string name="image_editor_brush_size">Độ dày nét vẽ</string>
+    <string name="image_editor_text">Văn bản</string>
+    <string name="image_editor_text_hint">Nhập văn bản</string>
+    <string name="image_editor_text_done">Xong</string>
+    <string name="image_editor_undo">Hoàn tác</string>
+    <string name="image_editor_failed">Không thể chỉnh sửa ảnh này</string>
+    <string name="image_editor_color_cd">Màu vẽ %1$d</string>
     <string name="clan_settings_remove_logo">Gỡ biểu tượng clan</string>
     <string name="clan_settings_logo_permission_denied">Bạn không có quyền thay đổi biểu tượng clan.</string>
     <string name="clan_settings_logo_too_large">Ảnh biểu tượng clan tối đa 1 MB.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -565,6 +565,17 @@
     <string name="image_crop_rotate_left_cd">Rotate left</string>
     <string name="image_crop_rotate_right_cd">Rotate right</string>
     <string name="image_crop_reset_cd">Reset</string>
+    <string name="image_editor_edit">Edit</string>
+    <string name="image_editor_crop">Crop</string>
+    <string name="image_editor_draw">Draw</string>
+    <string name="image_editor_eraser">Eraser</string>
+    <string name="image_editor_brush_size">Brush size</string>
+    <string name="image_editor_text">Text</string>
+    <string name="image_editor_text_hint">Enter text</string>
+    <string name="image_editor_text_done">Done</string>
+    <string name="image_editor_undo">Undo</string>
+    <string name="image_editor_failed">Could not edit this image</string>
+    <string name="image_editor_color_cd">Drawing color %1$d</string>
     <string name="clan_settings_remove_logo">Remove clan logo</string>
     <string name="clan_settings_logo_permission_denied">You don\'t have permission to change the clan logo.</string>
     <string name="clan_settings_logo_too_large">Clan logo image must be 1 MB or smaller.</string>


### PR DESCRIPTION
task: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-87
result: 
<img width="392" height="841" alt="image" src="https://github.com/user-attachments/assets/611cc9ad-a13a-49ef-8cc3-80caa3dc4c1b" />

Solution: Synchronized the Android rotate icon with iOS and fixed crop/image transformations so rotation remains reversible without cumulative scaling.
Test cases:
Verify the rotate-left icon is visually consistent on Android and iOS.
Verify the crop area remains movable after rotating the image.
Verify the image remains pannable after rotating and zooming.
Verify the crop area and image return to their original size after four rotations.
Verify rotating preserves the current crop position and image offset.
Verify resizing the crop area works correctly after rotation.
Verify reset restores the original crop area, scale, position, and orientation.
Verify edited images are exported with the expected crop and rotation.