### PR TITLE
260720-ANDROID-Improve create clan duplicate toast

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/clans/ClansController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ClansController.kt
@@ -137,10 +137,19 @@ class ClansController @Inject constructor(
     fun getClanCount(): Int = _clans.value.size
 
     suspend fun isDuplicateClanName(clanName: String): Boolean {
-        if (!mezonSocket.awaitConnected()) {
-            return false
-        }
-        return runCatching { mezonSocket.checkDuplicateClanName(clanName) }.getOrDefault(false)
+        return runCatching {
+            sessionManager.withAutoRefresh { session ->
+                withContext(ioDispatcher) {
+                    api.checkDuplicateName(
+                        apiUrl = session.apiUrl,
+                        token = session.token,
+                        name = clanName,
+                        type = MezonSocket.TYPE_CHECK_CLAN,
+                        conditionId = 0L
+                    )
+                }
+            }
+        }.getOrDefault(false)
     }
 
     suspend fun createClan(

--- a/app/src/main/java/com/mezon/mobile/home/clans/CreateClanCustomizeFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/CreateClanCustomizeFragment.kt
@@ -341,7 +341,12 @@ class CreateClanCustomizeFragment : BaseFragment() {
         clearNameButton = ImageView(context).apply {
             visibility = View.GONE
             scaleType = ImageView.ScaleType.FIT_CENTER
-            setImageDrawable(MezonIcon.circleXIcon.getDrawable(context, Color.WHITE))
+            setImageDrawable(
+                MezonIcon.circleXIcon.getDrawable(
+                    context,
+                    CreateClanRnUiTokens.textDisabled(themeColors)
+                )
+            )
             setOnClickListener {
                 nameInput.setText("")
             }


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-85
Root Cause: The default text field clear button lacked customizable visibility during the loading state, and duplicate clan names were not checked proactively before submission.

Solution: Replaced the default clear button with a custom one controlled by UI states and added an API validation step to check for duplicate clan names.

Test Cases:
Verify that an error toast message is displayed when attempting to create a clan with a name that already exists.