### PR TITLE
260720-ANDROID-Fix bug member count

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/clans/ClansFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ClansFragment.kt
@@ -231,6 +231,9 @@ class ClansFragment : BaseFragment() {
             serverRail.setBackgroundColor(themeColors.serverRailBg)
             serverAdapter.notifyDataSetChanged()
             channelListView.invalidateTheme()
+            if (::memberCountText.isInitialized) {
+                updateMemberCount()
+            }
             updateClanPanelHeaderMode()
         }
 
@@ -724,6 +727,7 @@ class ClansFragment : BaseFragment() {
     override fun onResume() {
         super.onResume()
         ensureVoiceMembersLoaded()
+        updateMemberCount()
     }
 
     override fun onBecomeFullyVisible() {
@@ -883,17 +887,19 @@ class ClansFragment : BaseFragment() {
 
     private fun updateMemberCount() {
         val clanId = clansController.selectedClanId.value
-        if (!userClanController.hasClanMembersCache(clanId)) {
+        val hasCache = userClanController.hasClanMembersCache(clanId)
+        if (!hasCache) {
             memberCountText.visibility = View.INVISIBLE
             return
         }
         val count = userClanController.getClanMemberCount(clanId)
         val isCommunity = renderedIsCommunity == true
-        val key = "$count|$isCommunity"
-        val alreadyShown = memberCountText.visibility == View.VISIBLE && memberCountText.alpha >= 1f
+        val key = "$count|$isCommunity|${themeColors.resolvedMode}"
+        val alreadyShown = memberCountText.visibility == View.VISIBLE
         if (renderedSubtitleKey == key && alreadyShown) return
         val wasHidden = !alreadyShown
         renderedSubtitleKey = key
+        memberCountText.setTextColor(themeColors.textDisabled)
         memberCountText.text = buildSubtitleText(count, isCommunity)
         memberCountText.visibility = View.VISIBLE
         if (wasHidden) {
@@ -907,7 +913,7 @@ class ClansFragment : BaseFragment() {
     }
 
     private fun buildSubtitleText(count: Int, isCommunity: Boolean): CharSequence {
-        val ctx = fragmentView?.context ?: return ""
+        val ctx = memberCountText.context
         val memberWord = if (count == 1) {
             ctx.getString(R.string.common_member)
         } else {


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-72
Root Cause:
During fragment recreation, fragmentView was null, causing buildSubtitleText to cache and display an empty string for the member count.
The text color of the member count was hardcoded at view creation and did not observe theme changes.
Calling onResume while the fade-in animation was still running caused the view to cancel and restart the animation, resulting in a double blink.

Solution:
Changed buildSubtitleText to safely retrieve the context directly from memberCountText.context.
Appended the current theme mode to the subtitle cache key and enforced a color update inside updateMemberCount to guarantee dynamic updates.
Triggered updateMemberCount() in both themeChanged and onResume to cover all lifecycle edge cases.
Removed the strict alpha >= 1f check in updateMemberCount to prevent interrupting the ongoing fade-in animation.

Test Cases:
Verify the member count displays correctly without blinking twice when initially opening the app.
Verify the member count text and community label adapt their colors correctly and do not disappear when switching between Light and Dark themes in Settings.
Verify the member count updates accurately when navigating back and forth between different clans.