### PR TITLE
260724-ANDROID-Update UI image viewer

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -2039,6 +2039,7 @@ open class ChatFragment : BaseFragment() {
 
         adapter = ChatAdapter(themeColors, messages, channelName, cellDelegate = object : ChatMessageCell.ChatMessageCellDelegate {
             override fun didClickMedia(cell: ChatMessageCell, msg: MessageEntity, attachmentIndex: Int) {
+                if (cell.isSticker) return
                 val allMedia = msg.allImageAttachments
                 val att = allMedia.getOrNull(attachmentIndex) ?: allMedia.firstOrNull() ?: return
                 val url = att.url
@@ -2051,7 +2052,7 @@ open class ChatFragment : BaseFragment() {
                     VideoPlayerDialog(context).play(url)
                 } else {
                     val seed = allMedia.filter { !it.filetype.startsWith("video/") && it.url.isNotEmpty() }.map { it.url }
-                    openChannelPhotoViewer(context, url, thumbBmp, seed)
+                    openChannelPhotoViewer(context, url, thumbBmp, seed, msg)
                 }
             }
             override fun didClickFile(cell: ChatMessageCell, msg: MessageEntity) {
@@ -3898,27 +3899,51 @@ open class ChatFragment : BaseFragment() {
         updateVisibleRows(NotificationCenter.UPDATE_MASK_NAME)
     }
 
-    private fun channelGalleryImageUrls(): List<String> =
+    private fun channelGalleryImageItems(): List<PhotoViewer.GalleryItem> =
         channelGalleryController.getItems(channelId)
             .asSequence()
             .filter { !it.isVideo && it.url.isNotEmpty() }
-            .map { it.url }
-            .distinct()
+            .map { mediaItem ->
+                val cachedMsg = messages.find { it.id == mediaItem.messageId }
+                val uploaderId = mediaItem.uploaderId
+                val (senderName, senderAvatarUrl) = resolveGallerySender(
+                    uploaderId,
+                    cachedMsg?.senderName,
+                    cachedMsg?.senderAvatar
+                )
+                PhotoViewer.GalleryItem(
+                    url = mediaItem.url,
+                    senderName = senderName,
+                    senderAvatarUrl = senderAvatarUrl,
+                    timestamp = mediaItem.createTimeSeconds.toLong(),
+                    isVideo = mediaItem.isVideo,
+                    uploaderId = uploaderId
+                )
+            }
+            .distinctBy { it.url }
             .toList()
 
-    private fun buildPhotoViewerUrls(selectedUrl: String, seedUrls: List<String> = emptyList()): List<String> {
-        val base = channelGalleryImageUrls()
+    private fun buildPhotoViewerItems(selectedUrl: String, seedUrls: List<String> = emptyList(), msg: MessageEntity? = null): List<PhotoViewer.GalleryItem> {
+        val base = channelGalleryImageItems()
+        val uploaderId = msg?.senderId ?: 0L
+        val (fallbackSenderName, fallbackSenderAvatar) = resolveGallerySender(
+            uploaderId,
+            msg?.senderName,
+            msg?.senderAvatar
+        )
+        val fallbackTimestamp = msg?.timestampSeconds ?: 0L
+
         if (base.isEmpty()) {
             return when {
-                seedUrls.isNotEmpty() -> seedUrls
+                seedUrls.isNotEmpty() -> seedUrls.map { PhotoViewer.GalleryItem(url = it, senderName = fallbackSenderName, senderAvatarUrl = fallbackSenderAvatar, timestamp = fallbackTimestamp, uploaderId = uploaderId) }
                 selectedUrl.isEmpty() -> emptyList()
-                else -> listOf(selectedUrl)
+                else -> listOf(PhotoViewer.GalleryItem(url = selectedUrl, senderName = fallbackSenderName, senderAvatarUrl = fallbackSenderAvatar, timestamp = fallbackTimestamp, uploaderId = uploaderId))
             }
         }
-        return if (selectedUrl.isEmpty() || base.contains(selectedUrl)) base else listOf(selectedUrl) + base
+        return if (selectedUrl.isEmpty() || base.any { it.url == selectedUrl }) base else listOf(PhotoViewer.GalleryItem(url = selectedUrl, senderName = fallbackSenderName, senderAvatarUrl = fallbackSenderAvatar, timestamp = fallbackTimestamp, uploaderId = uploaderId)) + base
     }
 
-    private fun openChannelPhotoViewer(context: Context, url: String, thumbBmp: Bitmap?, seedUrls: List<String>) {
+    private fun openChannelPhotoViewer(context: Context, url: String, thumbBmp: Bitmap?, seedUrls: List<String>, msg: MessageEntity? = null) {
         val viewer = PhotoViewer(context)
         activePhotoViewer = viewer
         photoViewerSelectedUrl = url
@@ -3927,9 +3952,20 @@ open class ChatFragment : BaseFragment() {
         viewer.setOnDismissListener {
             if (activePhotoViewer === viewer) activePhotoViewer = null
         }
-        val initial = buildPhotoViewerUrls(url, seedUrls)
-        val idx = initial.indexOf(url).coerceAtLeast(0)
-        viewer.show(url, gallery = initial, index = idx, thumbBitmap = thumbBmp)
+        val initial = buildPhotoViewerItems(url, seedUrls, msg)
+        val idx = initial.indexOfFirst { it.url == url }.coerceAtLeast(0)
+        
+        val uploaderId = msg?.senderId ?: 0L
+        val (fallbackSenderName, fallbackSenderAvatar) = resolveGallerySender(
+            uploaderId,
+            msg?.senderName,
+            msg?.senderAvatar
+        )
+        val fallbackTimestamp = msg?.timestampSeconds ?: 0L
+
+        val item = initial.getOrNull(idx) ?: PhotoViewer.GalleryItem(url = url, senderName = fallbackSenderName, senderAvatarUrl = fallbackSenderAvatar, timestamp = fallbackTimestamp, uploaderId = uploaderId)
+        viewer.show(item = item, gallery = initial, index = idx, thumbBitmap = thumbBmp)
+        
         if (channelGalleryController.isInitialLoadFinished(channelId)) {
             refreshActivePhotoViewerGallery()
         } else {
@@ -3939,9 +3975,9 @@ open class ChatFragment : BaseFragment() {
 
     private fun refreshActivePhotoViewerGallery() {
         val viewer = activePhotoViewer ?: return
-        val urls = buildPhotoViewerUrls(photoViewerSelectedUrl)
-        if (urls.isEmpty()) return
-        viewer.updateGallery(urls, photoViewerSelectedUrl)
+        val items = buildPhotoViewerItems(photoViewerSelectedUrl)
+        if (items.isEmpty()) return
+        viewer.updateGallery(items, photoViewerSelectedUrl)
     }
 
     private fun messageListHasPendingUploadKey(key: String): Boolean {
@@ -4308,6 +4344,46 @@ open class ChatFragment : BaseFragment() {
             adapter.welcomeCreatorName = sanitized
             adapter.notifyWelcomeCellChanged()
         }
+    }
+
+    private fun resolveGallerySender(userId: Long, fallbackName: String?, fallbackAvatar: String?): Pair<String, String?> {
+        val member = if (userId != 0L) {
+            if (clanId != 0L) memberResolver.resolveClanScopedMember(userId, clanId, channelId, channelType)
+            else memberResolver.resolveMember(userId, clanId, channelId, channelType)
+        } else null
+
+        val useClanInfo = clanId != 0L && channelType != CHANNEL_TYPE_DM && channelType != CHANNEL_TYPE_GROUP
+
+        var resolvedName: String? = null
+        var resolvedAvatar: String? = null
+
+        if (member != null) {
+            if (useClanInfo) {
+                resolvedName = member.clanNick.takeIf { it.isNotBlank() }
+                resolvedAvatar = member.clanAvatar.takeIf { it.isNotBlank() }
+            }
+            if (resolvedName == null) resolvedName = member.displayName.takeIf { it.isNotBlank() }
+            if (resolvedName == null) resolvedName = member.username.takeIf { it.isNotBlank() }
+            if (resolvedAvatar == null) resolvedAvatar = member.avatarUrl.takeIf { it.isNotBlank() }
+        }
+
+        if (resolvedName == null || resolvedAvatar == null) {
+            if (userId == userController.userId) {
+                if (resolvedName == null) resolvedName = userController.displayName.takeIf { it.isNotBlank() } ?: userController.username.takeIf { it.isNotBlank() }
+                if (resolvedAvatar == null) resolvedAvatar = userController.avatarUrl.takeIf { it.isNotBlank() }
+            } else if (userId != 0L) {
+                val global = userClanController.getUserById(userId)
+                if (global != null) {
+                    if (resolvedName == null) resolvedName = global.displayName.takeIf { it.isNotBlank() } ?: global.username.takeIf { it.isNotBlank() }
+                    if (resolvedAvatar == null) resolvedAvatar = global.avatarUrl.takeIf { it.isNotBlank() }
+                }
+            }
+        }
+
+        return Pair(
+            resolvedName ?: fallbackName?.takeIf { it.isNotBlank() } ?: "User",
+            resolvedAvatar ?: fallbackAvatar?.takeIf { it.isNotBlank() }
+        )
     }
 
     private fun resolveCreatorDisplayName(userId: Long, fallbackName: String): String {

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -4347,6 +4347,10 @@ open class ChatFragment : BaseFragment() {
     }
 
     private fun resolveGallerySender(userId: Long, fallbackName: String?, fallbackAvatar: String?): Pair<String, String?> {
+        if (userId == ANONYMOUS_USER_ID) {
+            return Pair(getString(R.string.advanced_anonymous), null)
+        }
+
         val member = if (userId != 0L) {
             if (clanId != 0L) memberResolver.resolveClanScopedMember(userId, clanId, channelId, channelType)
             else memberResolver.resolveMember(userId, clanId, channelId, channelType)

--- a/app/src/main/java/com/mezon/mobile/home/chat/PhotoViewer.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/PhotoViewer.kt
@@ -2,51 +2,46 @@ package com.mezon.mobile.home.chat
 
 import android.animation.ObjectAnimator
 import android.app.Dialog
-import android.app.DownloadManager
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Color
-import android.graphics.Outline
 import android.graphics.drawable.AnimatedImageDrawable
-import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
-import android.net.Uri
 import android.os.Build
 import android.os.Environment
-import android.util.TypedValue
 import android.view.Gravity
 import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewConfiguration
 import android.view.ViewGroup
-import android.view.ViewOutlineProvider
 import android.view.Window
 import android.view.WindowManager
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.ProgressBar
-import android.widget.Toast
-import androidx.core.content.ContextCompat
+import androidx.core.content.FileProvider
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.widget.ViewPager2
 import com.github.chrisbanes.photoview.PhotoView
 import com.mezon.mobile.R
 import com.mezon.mobile.core.AndroidUtilities
 import com.mezon.mobile.core.LayoutHelper
+import com.mezon.mobile.core.ThemeColors
 import com.mezon.mobile.di.FragmentEntryPoint
+import com.mezon.mobile.ui.cells.BackupImageView
+import com.mezon.mobile.ui.cells.ToastOverlay
 import com.mezon.mobile.util.createImgproxyUrl
 import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.util.Locale
-import com.mezon.mobile.ui.cells.BackupImageView
-import com.mezon.mobile.core.AvatarDrawable
 import java.text.SimpleDateFormat
+import java.util.Calendar
 import java.util.Date
+import java.util.Locale
 
 import kotlin.math.abs
 
@@ -58,6 +53,7 @@ private const val SWIPE_ENABLE_SCALE = 1.01f
 private const val DOUBLE_TAP_SCALE_THRESHOLD = 0.05f
 private const val FLING_DISMISS_SCALE_THRESHOLD = 0.06f
 private const val FLING_DISMISS_MIN_VELOCITY = 800f
+private val ANONYMOUS_USER_ID = com.mezon.mobile.BuildConfig.MEZON_ANONYMOUS_USER_ID.toLongOrNull() ?: 0L
 
 class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Black_NoTitleBar_Fullscreen) {
 
@@ -122,6 +118,7 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
 
         topBar = FrameLayout(context).apply {
             setBackgroundColor(0x99000000.toInt())
+            isClickable = true
         }
         
         val backBtn = ImageView(context).apply {
@@ -186,6 +183,7 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
             gravity = Gravity.CENTER_HORIZONTAL
             setBackgroundColor(0x99000000.toInt())
             setPadding(0, LayoutHelper.dp(12), 0, LayoutHelper.dp(12) + navBarInset)
+            isClickable = true
         }
         
         counterView = android.widget.TextView(context).apply {
@@ -295,7 +293,10 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
 
             override fun onDoubleTapEvent(e: MotionEvent): Boolean = false
 
-            override fun onSingleTapConfirmed(e: MotionEvent): Boolean = false
+            override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
+                toggleToolbar()
+                return true
+            }
         })
     }
 
@@ -430,8 +431,19 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
     private fun toggleToolbar() {
         toolbarVisible = !toolbarVisible
         val targetAlpha = if (toolbarVisible) 1f else 0f
-        topBar.animate().alpha(targetAlpha).setDuration(200).start()
-        bottomBar.animate().alpha(targetAlpha).setDuration(200).start()
+        
+        if (toolbarVisible) {
+            topBar.visibility = View.VISIBLE
+            bottomBar.visibility = View.VISIBLE
+        }
+        
+        topBar.animate().alpha(targetAlpha).setDuration(200).withEndAction {
+            if (!toolbarVisible) topBar.visibility = View.INVISIBLE
+        }.start()
+        
+        bottomBar.animate().alpha(targetAlpha).setDuration(200).withEndAction {
+            if (!toolbarVisible) bottomBar.visibility = View.INVISIBLE
+        }.start()
     }
 
     private fun dismissWithAnimation() {
@@ -444,21 +456,41 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
         viewPager.animate().alpha(0f).setDuration(150).start()
     }
 
-
     private fun updateHeader() {
         val item = currentItem ?: return
         nameLabel?.text = item.senderName.takeIf { it.isNotBlank() } ?: "User"
         
         val ts = item.timestamp
         if (ts > 0) {
-            dateLabel?.text = SimpleDateFormat("MMM d 'at' h:mm a", Locale.US).format(Date(ts * 1000L))
+            val msgCal = Calendar.getInstance().apply { timeInMillis = ts * 1000L }
+            val nowCal = Calendar.getInstance().apply { timeInMillis = System.currentTimeMillis() }
+
+            val msgYear = msgCal.get(Calendar.YEAR)
+            val msgDayOfYear = msgCal.get(Calendar.DAY_OF_YEAR)
+            val nowYear = nowCal.get(Calendar.YEAR)
+            val nowDayOfYear = nowCal.get(Calendar.DAY_OF_YEAR)
+
+            val isToday = msgYear == nowYear && msgDayOfYear == nowDayOfYear
+            val isYesterday = (msgYear == nowYear && msgDayOfYear == nowDayOfYear - 1) ||
+                    (nowDayOfYear == 1 && msgYear == nowYear - 1 &&
+                            msgDayOfYear == msgCal.getActualMaximum(Calendar.DAY_OF_YEAR))
+
+            val timeStr = SimpleDateFormat("h:mm a", Locale.getDefault()).format(Date(ts * 1000L))
+
+            dateLabel?.text = when {
+                isToday -> "${context.getString(R.string.common_today_at)} $timeStr"
+                isYesterday -> "${context.getString(R.string.common_yesterday_at)} $timeStr"
+                else -> SimpleDateFormat("MMM d, h:mm a", Locale.getDefault()).format(Date(ts * 1000L))
+            }
             dateLabel?.visibility = View.VISIBLE
         } else {
             dateLabel?.visibility = View.GONE
         }
 
         avatarView?.let { view ->
-            if (!item.senderAvatarUrl.isNullOrEmpty()) {
+            if (item.uploaderId == ANONYMOUS_USER_ID) {
+                view.setImageDrawable(com.mezon.mobile.ui.cells.MezonIcon.anonymousAvatar.getDrawable(context))
+            } else if (!item.senderAvatarUrl.isNullOrEmpty()) {
                 val proxyUrl = com.mezon.mobile.util.avatarImgproxyUrl(item.senderAvatarUrl, LayoutHelper.dp(40))
                 view.setImage(proxyUrl, item.uploaderId, item.senderName)
             } else {
@@ -474,25 +506,37 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
         }
     }
 
+    private var optionsMenu: com.mezon.mobile.ui.cells.PopupMenu? = null
+    private var lastMenuDismissTime = 0L
+
     private fun showMoreOptions(anchorView: View) {
-        val url = currentUrl
-        val popup = com.mezon.mobile.ui.cells.PopupMenu(context, com.mezon.mobile.core.ThemeColors())
-        popup.addItem("Save Image")
-        popup.addItem("Copy Image")
-        popup.addItem("Share")
-        
-        popup.setOnItemClickListener { index ->
-            when (index) {
-                0 -> downloadUrl(url)
-                1 -> copyImageFromCurrentUrl()
-                2 -> shareUrl(url)
-            }
+        if (System.currentTimeMillis() - lastMenuDismissTime < 200) {
+            return
         }
-        popup.show(anchorView)
+        val url = currentUrl
+        optionsMenu = com.mezon.mobile.ui.cells.PopupMenu(context, ThemeColors.instance).apply {
+            addItem(context.getString(R.string.action_save_media))
+            addItem(context.getString(R.string.action_copy_image))
+            addItem(context.getString(R.string.action_share_image))
+            setOnItemClickListener { index ->
+                when (index) {
+                    0 -> downloadUrl(url)
+                    1 -> copyImageFromCurrentUrl()
+                    2 -> shareUrl(url)
+                }
+            }
+            setOnDismissListener {
+                optionsMenu = null
+                lastMenuDismissTime = System.currentTimeMillis()
+            }
+            show(anchorView)
+        }
     }
 
     private inner class ThumbnailAdapter : RecyclerView.Adapter<ThumbnailAdapter.ThumbViewHolder>() {
-        inner class ThumbViewHolder(val container: FrameLayout, val view: BackupImageView, val borderView: View) : RecyclerView.ViewHolder(container)
+        inner class ThumbViewHolder(val container: FrameLayout, val view: ImageView, val borderView: View) : RecyclerView.ViewHolder(container) {
+            var pendingLoad: MezonImageLoader.Cancellable? = null
+        }
 
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ThumbViewHolder {
             val container = FrameLayout(context).apply {
@@ -500,10 +544,8 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
                     marginEnd = LayoutHelper.dp(2)
                 }
             }
-            val iv = BackupImageView(context).apply {
-                setRoundRadius(0)
-                setAspectFit(false)
-                setAspectFill(true)
+            val iv = ImageView(context).apply {
+                scaleType = ImageView.ScaleType.CENTER_CROP
             }
             container.addView(iv, FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
 
@@ -521,16 +563,53 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
             container.setOnClickListener {
                 val pos = holder.adapterPosition
                 if (pos != RecyclerView.NO_POSITION) {
-                    viewPager.setCurrentItem(pos, true)
+                    val rv = viewPager.getChildAt(0) as? RecyclerView
+                    if (rv != null) {
+                        rv.scrollToPosition(pos)
+                    } else {
+                        viewPager.setCurrentItem(pos, false)
+                    }
                 }
             }
             return holder
         }
 
+        override fun onViewRecycled(holder: ThumbViewHolder) {
+            super.onViewRecycled(holder)
+            holder.pendingLoad?.cancel()
+            holder.pendingLoad = null
+            (holder.view.drawable as? AnimatedImageDrawable)?.stop()
+            holder.view.setImageDrawable(null)
+        }
+
         override fun onBindViewHolder(holder: ThumbViewHolder, position: Int) {
             val item = items[position]
-            val proxyUrl = createImgproxyUrl(item.url, 150, 150, "fill", 150)
-            holder.view.setImage(proxyUrl, "150_150", null as Drawable?)
+
+            holder.pendingLoad?.cancel()
+            holder.pendingLoad = null
+            (holder.view.drawable as? AnimatedImageDrawable)?.stop()
+            holder.view.setImageDrawable(null)
+
+            val loader = MezonImageLoader.getInstance(context)
+            if (urlNeedsAnimatedDrawable(item.url)) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    holder.pendingLoad = loader.loadDrawable(item.url, 150, 150,
+                        onSuccess = { drawable ->
+                            holder.view.setImageDrawable(drawable)
+                            if (drawable is AnimatedImageDrawable) {
+                                drawable.repeatCount = AnimatedImageDrawable.REPEAT_INFINITE
+                                drawable.start()
+                            }
+                        },
+                        onError = {}
+                    )
+                } else {
+                    holder.pendingLoad = loader.load(item.url, 150, 150, onSuccess = { holder.view.setImageBitmap(it) }, onError = {})
+                }
+            } else {
+                val proxyUrl = createImgproxyUrl(item.url, 150, 150, "fill", 150)
+                holder.pendingLoad = loader.load(proxyUrl, 150, 150, onSuccess = { holder.view.setImageBitmap(it) }, onError = {})
+            }
             
             if (position == currentIndex) {
                 holder.view.alpha = 1.0f
@@ -793,27 +872,33 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
             items.getOrNull(position)?.url?.hashCode()?.toLong() ?: RecyclerView.NO_ID
     }
 
+    private val entryPoint: FragmentEntryPoint by lazy {
+        EntryPointAccessors.fromApplication(context.applicationContext, FragmentEntryPoint::class.java)
+    }
+
+    private fun showToast(type: ToastOverlay.ToastType, msgResId: Int) {
+        val parent = window?.decorView as? ViewGroup ?: return
+        ToastOverlay(context, ThemeColors.instance).show(parent, type, context.getString(msgResId))
+    }
 
     private fun copyImageFromCurrentUrl() {
         val url = currentUrl
         if (url.isEmpty()) return
-        val app = context.applicationContext
-        val ep = EntryPointAccessors.fromApplication(app, FragmentEntryPoint::class.java)
-        val coordinator = ep.imageClipboardCoordinator()
-        ep.applicationScope().launch {
+        val coordinator = entryPoint.imageClipboardCoordinator()
+        entryPoint.applicationScope().launch {
             val ok = coordinator.copyRemoteUrlToClipboard(context, url, guessMimeHintForCopy(url))
-            withContext(ep.mainDispatcher()) {
+            withContext(entryPoint.mainDispatcher()) {
                 if (ok) {
-                    Toast.makeText(context, context.getString(R.string.message_toast_copy_image_done), Toast.LENGTH_SHORT).show()
+                    showToast(ToastOverlay.ToastType.SUCCESS, R.string.message_toast_copy_image_done)
                 } else {
-                    Toast.makeText(context, context.getString(R.string.message_toast_copy_image_failed), Toast.LENGTH_SHORT).show()
+                    showToast(ToastOverlay.ToastType.ERROR, R.string.message_toast_copy_image_failed)
                 }
             }
         }
     }
 
     private fun guessMimeHintForCopy(url: String): String {
-        val lower = url.lowercase(Locale.US)
+        val lower = url.lowercase(java.util.Locale.US)
         return when {
             lower.endsWith(".png") -> "image/png"
             lower.endsWith(".webp") -> "image/webp"
@@ -824,27 +909,78 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
     }
 
     private fun downloadUrl(url: String) {
-        try {
-            val filename = url.substringAfterLast('/').substringBefore('?').ifEmpty { "download" }
-            val request = DownloadManager.Request(Uri.parse(url))
-                .setTitle(filename)
-                .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
-                .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, filename)
-            val dm = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
-            dm.enqueue(request)
-            Toast.makeText(context, "Downloading...", Toast.LENGTH_SHORT).show()
-        } catch (_: Exception) {
-            Toast.makeText(context, "Download failed", Toast.LENGTH_SHORT).show()
+        entryPoint.applicationScope().launch(entryPoint.ioDispatcher()) {
+            try {
+                val filename = url.substringAfterLast('/').substringBefore('?').ifEmpty { "download.jpg" }
+                val downloadsDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+                downloadsDir.mkdirs()
+                val destFile = java.io.File(downloadsDir, filename)
+                downloadToFile(url, destFile)
+                android.media.MediaScannerConnection.scanFile(context, arrayOf(destFile.absolutePath), null, null)
+                withContext(entryPoint.mainDispatcher()) {
+                    showToast(ToastOverlay.ToastType.SUCCESS, R.string.message_toast_save_success)
+                }
+            } catch (e: Exception) {
+                withContext(entryPoint.mainDispatcher()) {
+                    showToast(ToastOverlay.ToastType.ERROR, R.string.message_toast_save_failed)
+                }
+            }
+        }
+    }
+
+    private fun downloadToFile(url: String, destFile: java.io.File) {
+        val conn = java.net.URL(url).openConnection() as java.net.HttpURLConnection
+        conn.connect()
+        if (conn.responseCode !in 200..299) {
+            throw Exception("HTTP Error: ${conn.responseCode}")
+        }
+        conn.inputStream.use { input ->
+            java.io.FileOutputStream(destFile).use { output ->
+                input.copyTo(output)
+            }
         }
     }
 
     private fun shareUrl(url: String) {
-        try {
-            val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
-                type = "text/plain"
-                putExtra(android.content.Intent.EXTRA_TEXT, url)
+        entryPoint.applicationScope().launch(entryPoint.ioDispatcher()) {
+            try {
+                val mime = guessMimeHintForCopy(url)
+                val ext = when (mime) {
+                    "image/gif" -> "gif"
+                    "image/png" -> "png"
+                    "image/webp" -> "webp"
+                    else -> "jpg"
+                }
+
+                val dir = java.io.File(context.cacheDir, "clipboard_images").apply { mkdirs() }
+                val destFile = java.io.File(dir, "share_${System.currentTimeMillis()}.$ext")
+                downloadToFile(url, destFile)
+
+                val authority = "${context.packageName}.fileprovider"
+                val uri = FileProvider.getUriForFile(context, authority, destFile)
+
+                withContext(entryPoint.mainDispatcher()) {
+                    val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
+                        type = mime
+                        putExtra(android.content.Intent.EXTRA_STREAM, uri)
+                        clipData = android.content.ClipData.newRawUri("", uri)
+                        addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    }
+
+                    val resInfoList = context.packageManager.queryIntentActivities(intent, android.content.pm.PackageManager.MATCH_DEFAULT_ONLY)
+                    for (resolveInfo in resInfoList) {
+                        context.grantUriPermission(resolveInfo.activityInfo.packageName, uri, android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    }
+
+                    val chooser = android.content.Intent.createChooser(intent, context.getString(R.string.action_share_image))
+                    chooser.addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                    context.startActivity(chooser)
+                }
+            } catch (e: Exception) {
+                withContext(entryPoint.mainDispatcher()) {
+                    showToast(ToastOverlay.ToastType.ERROR, R.string.message_toast_save_failed)
+                }
             }
-            context.startActivity(android.content.Intent.createChooser(intent, "Share"))
-        } catch (_: Exception) {}
+        }
     }
 }

--- a/app/src/main/java/com/mezon/mobile/home/chat/PhotoViewer.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/PhotoViewer.kt
@@ -43,6 +43,11 @@ import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.Locale
+import com.mezon.mobile.ui.cells.BackupImageView
+import com.mezon.mobile.core.AvatarDrawable
+import java.text.SimpleDateFormat
+import java.util.Date
+
 import kotlin.math.abs
 
 private const val LOADING_SHOW_DELAY_MS = 300L
@@ -64,24 +69,39 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
         }
     }
 
+    data class GalleryItem(
+        val url: String,
+        val senderName: String,
+        val senderAvatarUrl: String?,
+        val timestamp: Long,
+        val isVideo: Boolean = false,
+        val uploaderId: Long = 0L
+    )
+
     private val backgroundDrawable = ColorDrawable(Color.BLACK)
     private val viewPager: ViewPager2
     private val topBar: FrameLayout
     private val bottomBar: LinearLayout
     private val counterView: android.widget.TextView
+    private var thumbnailRecyclerView: RecyclerView? = null
     private var toolbarVisible = true
 
-    private var urls = emptyList<String>()
+    private var items = emptyList<GalleryItem>()
     private var currentIndex = 0
     private var preferDrawableLoaderForSingle = false
     private var oldestEdgeBaselinePosition = -1
-    private val currentUrl get() = urls.getOrElse(currentIndex) { "" }
+    private val currentUrl get() = items.getOrNull(currentIndex)?.url ?: ""
+    private val currentItem get() = items.getOrNull(currentIndex)
 
     var onReachedOldestEdge: (() -> Unit)? = null
     var onCurrentUrlChanged: ((String) -> Unit)? = null
 
     private var activeTouchCount = 0
     private var viewPagerSwipeAllowed = true
+
+    private var avatarView: BackupImageView? = null
+    private var nameLabel: android.widget.TextView? = null
+    private var dateLabel: android.widget.TextView? = null
 
     init {
         requestWindowFeature(Window.FEATURE_NO_TITLE)
@@ -100,81 +120,89 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
             FrameLayout.LayoutParams.MATCH_PARENT
         ))
 
-        topBar = FrameLayout(context)
-        counterView = android.widget.TextView(context).apply {
+        topBar = FrameLayout(context).apply {
+            setBackgroundColor(0x99000000.toInt())
+        }
+        
+        val backBtn = ImageView(context).apply {
+            setImageResource(R.drawable.ic_arrow_back)
+            setColorFilter(Color.WHITE)
+            val p = LayoutHelper.dp(16)
+            setPadding(p, p, p, p)
+            setOnClickListener { dismissWithAnimation() }
+        }
+        topBar.addView(backBtn, FrameLayout.LayoutParams(LayoutHelper.dp(56), LayoutHelper.dp(56), Gravity.START or Gravity.CENTER_VERTICAL))
+
+        avatarView = BackupImageView(context).apply {
+            setRoundRadius(LayoutHelper.dp(20))
+        }
+        val avatarParams = FrameLayout.LayoutParams(LayoutHelper.dp(40), LayoutHelper.dp(40), Gravity.START or Gravity.CENTER_VERTICAL)
+        avatarParams.marginStart = LayoutHelper.dp(56)
+        topBar.addView(avatarView, avatarParams)
+
+        val textLayout = LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+            gravity = Gravity.CENTER_VERTICAL
+        }
+        nameLabel = android.widget.TextView(context).apply {
             setTextColor(Color.WHITE)
             textSize = 16f
+            typeface = android.graphics.Typeface.DEFAULT_BOLD
+            isSingleLine = true
         }
-        val closeDiameter = LayoutHelper.dp(44)
-        val closeWrap = FrameLayout(context).apply {
-            background = GradientDrawable().apply {
-                shape = GradientDrawable.OVAL
-                setColor(0x80000000.toInt())
-            }
-            outlineProvider = object : ViewOutlineProvider() {
-                override fun getOutline(view: View, outline: Outline) {
-                    outline.setOval(0, 0, view.width, view.height)
-                }
-            }
-            clipToOutline = true
-            isClickable = true
-            isFocusable = true
-            contentDescription = context.getString(R.string.common_close)
-            val tvRipple = TypedValue()
-            if (context.theme.resolveAttribute(android.R.attr.selectableItemBackgroundBorderless, tvRipple, true)) {
-                foreground = ContextCompat.getDrawable(context, tvRipple.resourceId)
-            }
-            setOnClickListener { dismissWithAnimation() }
-            val closeBtn = ImageView(context).apply {
-                setImageResource(android.R.drawable.ic_menu_close_clear_cancel)
-                setColorFilter(Color.WHITE)
-                val p = LayoutHelper.dp(10)
-                setPadding(p, p, p, p)
-                isClickable = false
-                isFocusable = false
-                importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
-            }
-            addView(closeBtn, FrameLayout.LayoutParams(
-                FrameLayout.LayoutParams.WRAP_CONTENT,
-                FrameLayout.LayoutParams.WRAP_CONTENT,
-                Gravity.CENTER
-            ))
+        dateLabel = android.widget.TextView(context).apply {
+            setTextColor(0xCCFFFFFF.toInt())
+            textSize = 13f
+            isSingleLine = true
         }
-        val counterParams = FrameLayout.LayoutParams(
-            FrameLayout.LayoutParams.WRAP_CONTENT,
-            FrameLayout.LayoutParams.WRAP_CONTENT,
-            Gravity.CENTER
-        )
-        topBar.addView(counterView, counterParams)
-        val closeBtnParams = FrameLayout.LayoutParams(closeDiameter, closeDiameter, Gravity.END or Gravity.CENTER_VERTICAL)
-        closeBtnParams.marginEnd = LayoutHelper.dp(8)
-        topBar.addView(closeWrap, closeBtnParams)
+        textLayout.addView(nameLabel, LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT)
+        textLayout.addView(dateLabel, LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT)
+        
+        val textParams = FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.WRAP_CONTENT, Gravity.START or Gravity.CENTER_VERTICAL)
+        textParams.marginStart = LayoutHelper.dp(108)
+        textParams.marginEnd = LayoutHelper.dp(56)
+        topBar.addView(textLayout, textParams)
+
+        val moreBtn = ImageView(context).apply {
+            setImageResource(R.drawable.ic_more_vertical_24)
+            setColorFilter(Color.WHITE)
+            val p = LayoutHelper.dp(16)
+            setPadding(p, p, p, p)
+            setOnClickListener { showMoreOptions(it) }
+        }
+        topBar.addView(moreBtn, FrameLayout.LayoutParams(LayoutHelper.dp(56), LayoutHelper.dp(56), Gravity.END or Gravity.CENTER_VERTICAL))
 
         val topBarParams = FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.MATCH_PARENT,
             LayoutHelper.dp(56)
         )
         topBarParams.gravity = Gravity.TOP
-        topBarParams.topMargin = AndroidUtilities.statusBarHeight + LayoutHelper.dp(8)
+        topBarParams.topMargin = AndroidUtilities.statusBarHeight
         root.addView(topBar, topBarParams)
 
         val navBarInset = AndroidUtilities.navigationBarHeight
         bottomBar = LinearLayout(context).apply {
-            orientation = LinearLayout.HORIZONTAL
-            gravity = Gravity.CENTER
+            orientation = LinearLayout.VERTICAL
+            gravity = Gravity.CENTER_HORIZONTAL
             setBackgroundColor(0x99000000.toInt())
-            val pad = LayoutHelper.dp(12)
-            setPadding(pad, pad, pad, pad + navBarInset)
+            setPadding(0, LayoutHelper.dp(12), 0, LayoutHelper.dp(12) + navBarInset)
         }
-        bottomBar.addView(createToolbarButton(context, android.R.drawable.ic_menu_share, "Share") {
-            shareUrl(currentUrl)
-        })
-        bottomBar.addView(createToolbarButton(context, android.R.drawable.ic_menu_save, "Save") {
-            downloadUrl(currentUrl)
-        })
-        bottomBar.addView(createToolbarButton(context, android.R.drawable.ic_menu_agenda, "Copy") {
-            copyImageFromCurrentUrl()
-        })
+        
+        counterView = android.widget.TextView(context).apply {
+            setTextColor(Color.WHITE)
+            textSize = 13f
+        }
+        val counterParams = LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT)
+        counterParams.bottomMargin = LayoutHelper.dp(8)
+        bottomBar.addView(counterView, counterParams)
+
+        thumbnailRecyclerView = RecyclerView(context).apply {
+            layoutManager = androidx.recyclerview.widget.LinearLayoutManager(context, RecyclerView.HORIZONTAL, false)
+            clipToPadding = false
+            setPadding(LayoutHelper.dp(12), 0, LayoutHelper.dp(12), 0)
+        }
+        bottomBar.addView(thumbnailRecyclerView, LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LayoutHelper.dp(64)))
+
         val bottomBarParams = FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.MATCH_PARENT,
             FrameLayout.LayoutParams.WRAP_CONTENT
@@ -187,7 +215,9 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
         viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
             override fun onPageSelected(position: Int) {
                 currentIndex = position
+                updateHeader()
                 updateCounter()
+                updateThumbnailSelection()
                 onCurrentUrlChanged?.invoke(currentUrl)
                 maybeNotifyOldestEdge(position)
                 syncViewPagerSwipeWithCurrentPhoto()
@@ -206,7 +236,7 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
             }
             return
         }
-        setViewPagerSwipeAllowed(urls.size > 1 && scale < SWIPE_ENABLE_SCALE)
+        setViewPagerSwipeAllowed(items.size > 1 && scale < SWIPE_ENABLE_SCALE)
     }
 
     private fun syncViewPagerSwipeWithCurrentPhoto() {
@@ -214,14 +244,14 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
         if (photoView != null) {
             refreshPhotoSwipeState(photoView)
         } else {
-            setViewPagerSwipeAllowed(urls.size > 1)
+            setViewPagerSwipeAllowed(items.size > 1)
         }
     }
 
     private fun setViewPagerSwipeAllowed(allowed: Boolean) {
         if (viewPagerSwipeAllowed == allowed) return
         viewPagerSwipeAllowed = allowed
-        viewPager.isUserInputEnabled = urls.size > 1 && allowed
+        viewPager.isUserInputEnabled = items.size > 1 && allowed
     }
 
     private fun onPhotoTouchEvent(ev: MotionEvent, photoView: PhotoView) {
@@ -317,39 +347,44 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
     }
 
     private fun maybeNotifyOldestEdge(position: Int) {
-        if (urls.size < 2) return
+        if (items.size < 2) return
         if (oldestEdgeBaselinePosition < 0) {
             oldestEdgeBaselinePosition = position
             return
         }
         if (position <= oldestEdgeBaselinePosition) return
-        if (position < urls.size - 2) return
+        if (position < items.size - 2) return
         oldestEdgeBaselinePosition = position
         onReachedOldestEdge?.invoke()
     }
 
     fun show(
-        url: String,
-        gallery: List<String> = emptyList(),
+        item: GalleryItem,
+        gallery: List<GalleryItem> = emptyList(),
         index: Int = 0,
         thumbBitmap: Bitmap? = null,
         preferDrawableLoader: Boolean = false
     ) {
-        urls = if (gallery.isEmpty()) listOf(url) else gallery
-        currentIndex = if (index in urls.indices) index else 0
-        preferDrawableLoaderForSingle = preferDrawableLoader && urls.size == 1
+        items = if (gallery.isEmpty()) listOf(item) else gallery
+        currentIndex = if (index in items.indices) index else 0
+        preferDrawableLoaderForSingle = preferDrawableLoader && items.size == 1
 
-        val single = urls.size == 1
-        val thumbUrl = urls[0]
+        val single = items.size == 1
+        val thumbUrl = items[0].url
         val singleAnimated = urlNeedsAnimatedDrawable(thumbUrl) || preferDrawableLoaderForSingle
         val singleShowsThumb = single && !singleAnimated
         oldestEdgeBaselinePosition = -1
         viewPager.adapter = PhotoPagerAdapter(thumbBitmap.takeIf { singleShowsThumb })
         viewPager.setCurrentItem(currentIndex, false)
+        
+        thumbnailRecyclerView?.adapter = ThumbnailAdapter()
+        
         activeTouchCount = 0
-        setViewPagerSwipeAllowed(urls.size > 1)
+        setViewPagerSwipeAllowed(items.size > 1)
 
+        updateHeader()
         updateCounter()
+        updateThumbnailSelection()
         backgroundDrawable.alpha = 0
         activeInstance = java.lang.ref.WeakReference(this)
         super.show()
@@ -364,27 +399,29 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
     }
 
     private fun updateCounter() {
-        if (urls.size > 1) {
-            counterView.text = "${currentIndex + 1} / ${urls.size}"
+        if (items.size > 1) {
+            counterView.text = "${currentIndex + 1} / ${items.size}"
             counterView.visibility = View.VISIBLE
         } else {
             counterView.visibility = View.GONE
         }
     }
 
-    fun updateGallery(newUrls: List<String>, keepUrl: String) {
-        if (newUrls.isEmpty() || newUrls == urls) return
-        val appendOnly = newUrls.size > urls.size && newUrls.subList(0, urls.size) == urls
-        val keepIndex = newUrls.indexOf(keepUrl).let {
-            if (it >= 0) it else currentIndex.coerceIn(0, newUrls.size - 1)
+    fun updateGallery(newItems: List<GalleryItem>, keepUrl: String) {
+        if (newItems.isEmpty() || newItems == items) return
+        val appendOnly = newItems.size > items.size && newItems.subList(0, items.size) == items
+        val keepIndex = newItems.indexOfFirst { it.url == keepUrl }.let {
+            if (it >= 0) it else currentIndex.coerceIn(0, newItems.size - 1)
         }
-        val prevSize = urls.size
-        urls = newUrls
+        val prevSize = items.size
+        items = newItems
         currentIndex = keepIndex
         if (appendOnly) {
-            viewPager.adapter?.notifyItemRangeInserted(prevSize, newUrls.size - prevSize)
+            viewPager.adapter?.notifyItemRangeInserted(prevSize, newItems.size - prevSize)
+            thumbnailRecyclerView?.adapter?.notifyItemRangeInserted(prevSize, newItems.size - prevSize)
         } else {
             viewPager.adapter?.notifyDataSetChanged()
+            thumbnailRecyclerView?.adapter?.notifyDataSetChanged()
             viewPager.setCurrentItem(currentIndex, false)
         }
         updateCounter()
@@ -405,6 +442,106 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
         })
         anim.start()
         viewPager.animate().alpha(0f).setDuration(150).start()
+    }
+
+
+    private fun updateHeader() {
+        val item = currentItem ?: return
+        nameLabel?.text = item.senderName.takeIf { it.isNotBlank() } ?: "User"
+        
+        val ts = item.timestamp
+        if (ts > 0) {
+            dateLabel?.text = SimpleDateFormat("MMM d 'at' h:mm a", Locale.US).format(Date(ts * 1000L))
+            dateLabel?.visibility = View.VISIBLE
+        } else {
+            dateLabel?.visibility = View.GONE
+        }
+
+        avatarView?.let { view ->
+            if (!item.senderAvatarUrl.isNullOrEmpty()) {
+                val proxyUrl = com.mezon.mobile.util.avatarImgproxyUrl(item.senderAvatarUrl, LayoutHelper.dp(40))
+                view.setImage(proxyUrl, item.uploaderId, item.senderName)
+            } else {
+                view.setImage(null, item.uploaderId, item.senderName)
+            }
+        }
+    }
+
+    private fun updateThumbnailSelection() {
+        thumbnailRecyclerView?.adapter?.notifyDataSetChanged()
+        if (items.isNotEmpty()) {
+            thumbnailRecyclerView?.scrollToPosition(currentIndex)
+        }
+    }
+
+    private fun showMoreOptions(anchorView: View) {
+        val url = currentUrl
+        val popup = com.mezon.mobile.ui.cells.PopupMenu(context, com.mezon.mobile.core.ThemeColors())
+        popup.addItem("Save Image")
+        popup.addItem("Copy Image")
+        popup.addItem("Share")
+        
+        popup.setOnItemClickListener { index ->
+            when (index) {
+                0 -> downloadUrl(url)
+                1 -> copyImageFromCurrentUrl()
+                2 -> shareUrl(url)
+            }
+        }
+        popup.show(anchorView)
+    }
+
+    private inner class ThumbnailAdapter : RecyclerView.Adapter<ThumbnailAdapter.ThumbViewHolder>() {
+        inner class ThumbViewHolder(val container: FrameLayout, val view: BackupImageView, val borderView: View) : RecyclerView.ViewHolder(container)
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ThumbViewHolder {
+            val container = FrameLayout(context).apply {
+                layoutParams = ViewGroup.MarginLayoutParams(LayoutHelper.dp(44), LayoutHelper.dp(44)).apply {
+                    marginEnd = LayoutHelper.dp(2)
+                }
+            }
+            val iv = BackupImageView(context).apply {
+                setRoundRadius(0)
+                setAspectFit(false)
+                setAspectFill(true)
+            }
+            container.addView(iv, FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
+
+            val borderView = View(context).apply {
+                val drawable = android.graphics.drawable.GradientDrawable().apply {
+                    shape = android.graphics.drawable.GradientDrawable.RECTANGLE
+                    setStroke(LayoutHelper.dp(2), 0xFF007AFF.toInt())
+                }
+                background = drawable
+                visibility = View.GONE
+            }
+            container.addView(borderView, FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
+
+            val holder = ThumbViewHolder(container, iv, borderView)
+            container.setOnClickListener {
+                val pos = holder.adapterPosition
+                if (pos != RecyclerView.NO_POSITION) {
+                    viewPager.setCurrentItem(pos, true)
+                }
+            }
+            return holder
+        }
+
+        override fun onBindViewHolder(holder: ThumbViewHolder, position: Int) {
+            val item = items[position]
+            val proxyUrl = createImgproxyUrl(item.url, 150, 150, "fill", 150)
+            holder.view.setImage(proxyUrl, "150_150", null as Drawable?)
+            
+            if (position == currentIndex) {
+                holder.view.alpha = 1.0f
+                holder.borderView.visibility = View.VISIBLE
+            } else {
+                holder.view.alpha = 0.5f
+                holder.borderView.visibility = View.GONE
+            }
+        }
+
+        override fun getItemCount() = items.size
     }
 
     override fun onBackPressed() {
@@ -579,7 +716,7 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
         }
 
         override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-            val url = urls[position]
+            val url = items[position].url
             val photoView = holder.photoView
 
             holder.pendingLoad?.cancel()
@@ -612,7 +749,7 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
                 }
             }
             val drawableLoader = urlNeedsAnimatedDrawable(url) ||
-                (preferDrawableLoaderForSingle && urls.size == 1)
+                (preferDrawableLoaderForSingle && items.size == 1)
             if (drawableLoader) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                     holder.pendingLoad = loader.loadDrawable(url, 0, 0,
@@ -650,26 +787,12 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
             }
         }
 
-        override fun getItemCount() = urls.size
+        override fun getItemCount() = items.size
 
         override fun getItemId(position: Int): Long =
-            urls.getOrNull(position)?.hashCode()?.toLong() ?: RecyclerView.NO_ID
+            items.getOrNull(position)?.url?.hashCode()?.toLong() ?: RecyclerView.NO_ID
     }
 
-    private fun createToolbarButton(ctx: Context, iconRes: Int, desc: String, onClick: () -> Unit): ImageView {
-        return ImageView(ctx).apply {
-            setImageResource(iconRes)
-            setColorFilter(Color.WHITE)
-            contentDescription = desc
-            val p = LayoutHelper.dp(16)
-            setPadding(p, p, p, p)
-            layoutParams = LinearLayout.LayoutParams(LayoutHelper.dp(56), LayoutHelper.dp(56)).apply {
-                marginStart = LayoutHelper.dp(8)
-                marginEnd = LayoutHelper.dp(8)
-            }
-            setOnClickListener { onClick() }
-        }
-    }
 
     private fun copyImageFromCurrentUrl() {
         val url = currentUrl

--- a/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/ChannelMediaGalleryAdapter.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/ChannelMediaGalleryAdapter.kt
@@ -344,21 +344,31 @@ internal class ChannelMediaGalleryAdapter(
                     compareByDescending<ChannelGalleryMediaItem> { it.createTimeSeconds }
                         .thenByDescending { it.id }
                 )
-                .filter { !it.isVideo }
-                .map { it.url }
-                .filter { it.isNotEmpty() }
+                .filter { !it.isVideo && it.url.isNotEmpty() }
+                .map { mediaItem ->
+                    PhotoViewer.GalleryItem(
+                        url = mediaItem.url,
+                        senderName = "User", // Can be resolved if needed
+                        senderAvatarUrl = null,
+                        timestamp = mediaItem.createTimeSeconds.toLong(),
+                        isVideo = mediaItem.isVideo,
+                        uploaderId = mediaItem.uploaderId
+                    )
+                }
 
         when {
             tapped.isVideo ->
                 VideoPlayerDialog(ctx).play(url)
 
-            tapped.filetype.contains("gif", true) ->
-                PhotoViewer(ctx).show(url, thumbBitmap = null, preferDrawableLoader = true)
-
+            tapped.filetype.contains("gif", true) -> {
+                val item = orderedImages.firstOrNull { it.url == url } ?: PhotoViewer.GalleryItem(url, "User", null, 0)
+                PhotoViewer(ctx).show(item, thumbBitmap = null, preferDrawableLoader = true)
+            }
             else -> {
-                val idx = orderedImages.indexOf(url).takeIf { it >= 0 } ?: 0
+                val idx = orderedImages.indexOfFirst { it.url == url }.takeIf { it >= 0 } ?: 0
+                val item = orderedImages.getOrNull(idx) ?: PhotoViewer.GalleryItem(url, "User", null, 0)
                 PhotoViewer(ctx).show(
-                    url,
+                    item = item,
                     gallery = orderedImages,
                     index = idx,
                     thumbBitmap = null

--- a/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/ChannelMediaGalleryAdapter.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/ChannelMediaGalleryAdapter.kt
@@ -249,21 +249,26 @@ internal class ChannelMediaGalleryAdapter(
                         setStroke(LayoutHelper.dp(1f), Color.parseColor("#242427"))
                     }
             }
-        val av =
-            AvatarView(ctx).apply {
-                setSizeDp(26)
-                setRoundRadius(13f)
-            }
-        avRing.addView(av, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT))
-        val avLp =
-            FrameLayout.LayoutParams(avPad, avPad).apply {
-                gravity = Gravity.END or Gravity.TOP
-                topMargin = LayoutHelper.dp(8f)
-                marginEnd = LayoutHelper.dp(8f)
-            }
+
+        val av = AvatarView(ctx).apply {
+            setSizeDp(24)
+            setRoundRadius(12f)
+        }
+        avRing.addView(av, LayoutHelper.createFrame(24, 24, Gravity.CENTER))
+
+        val anonymousAv = ImageView(ctx).apply {
+            visibility = View.GONE
+            val drawable = com.mezon.mobile.ui.cells.MezonIcon.anonymousAvatar.getDrawable(ctx)
+            setImageDrawable(drawable)
+            scaleType = ImageView.ScaleType.FIT_CENTER
+        }
+        avRing.addView(anonymousAv, LayoutHelper.createFrame(24, 24, Gravity.CENTER))
+
+        val avLp = LayoutHelper.createFrame(26, 26, Gravity.TOP or Gravity.END)
+        avLp.setMargins(0, LayoutHelper.dp(8f), LayoutHelper.dp(8f), 0)
         root.addView(avRing, avLp)
 
-        return MediaSlot(root, thumb, videoDimmer, play, av)
+        return MediaSlot(root, thumb, videoDimmer, play, av, anonymousAv)
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
@@ -302,6 +307,7 @@ internal class ChannelMediaGalleryAdapter(
             slot.thumb.cancelLoad()
             slot.thumb.setImageDrawable(null)
             slot.av.visibility = View.GONE
+            slot.anonymousAv.visibility = View.GONE
             slot.videoDimmer.visibility = View.GONE
             slot.play.visibility = View.GONE
             return
@@ -309,19 +315,25 @@ internal class ChannelMediaGalleryAdapter(
         slot.root.visibility = View.VISIBLE
         slot.av.visibility = View.VISIBLE
 
-        val m = members()[item.uploaderId]
-        val avatarUrl =
-            when {
-                isDm ->
-                    m?.avatarUrl ?: ""
-                else ->
-                    (m?.clanAvatar?.ifBlank { null } ?: m?.avatarUrl) ?: ""
-            }
-        val avatarUsername = m?.username.orEmpty()
-
-        slot.av.setVisibility(View.VISIBLE)
-        slot.av.setInfo(item.uploaderId, avatarUsername.ifEmpty { "_" })
-        slot.av.setImageUrl(avatarUrl)
+        val anonymousUserId = com.mezon.mobile.BuildConfig.MEZON_ANONYMOUS_USER_ID.toLongOrNull() ?: 0L
+        if (item.uploaderId == anonymousUserId) {
+            slot.av.visibility = View.GONE
+            slot.anonymousAv.visibility = View.VISIBLE
+        } else {
+            slot.av.visibility = View.VISIBLE
+            slot.anonymousAv.visibility = View.GONE
+            val m = members()[item.uploaderId]
+            val avatarUrl =
+                when {
+                    isDm ->
+                        m?.avatarUrl ?: ""
+                    else ->
+                        (m?.clanAvatar?.ifBlank { null } ?: m?.avatarUrl) ?: ""
+                }
+            val avatarUsername = m?.username.orEmpty()
+            slot.av.setInfo(item.uploaderId, avatarUsername.ifEmpty { "_" })
+            slot.av.setImageUrl(avatarUrl)
+        }
 
         val showVideo = item.isVideo
         slot.videoDimmer.visibility = if (showVideo) View.VISIBLE else View.GONE
@@ -338,6 +350,7 @@ internal class ChannelMediaGalleryAdapter(
         val ctx = hostContext() ?: return
         val url = tapped.url.ifBlank { return }
 
+        val anonymousUserId = com.mezon.mobile.BuildConfig.MEZON_ANONYMOUS_USER_ID.toLongOrNull() ?: 0L
         val orderedImages =
             galleryController.getItems(channelId)
                 .sortedWith(
@@ -346,10 +359,24 @@ internal class ChannelMediaGalleryAdapter(
                 )
                 .filter { !it.isVideo && it.url.isNotEmpty() }
                 .map { mediaItem ->
+                    val m = members()[mediaItem.uploaderId]
+                    val resolvedName = if (mediaItem.uploaderId == anonymousUserId) {
+                        ctx.getString(com.mezon.mobile.R.string.advanced_anonymous)
+                    } else if (isDm) {
+                        m?.displayName?.takeIf { it.isNotBlank() } ?: m?.username?.takeIf { it.isNotBlank() } ?: "User"
+                    } else {
+                        m?.clanNick?.takeIf { it.isNotBlank() } ?: m?.displayName?.takeIf { it.isNotBlank() } ?: m?.username?.takeIf { it.isNotBlank() } ?: "User"
+                    }
+                    val resolvedAvatar = if (isDm) {
+                        m?.avatarUrl
+                    } else {
+                        m?.clanAvatar?.takeIf { it.isNotBlank() } ?: m?.avatarUrl
+                    }
+
                     PhotoViewer.GalleryItem(
                         url = mediaItem.url,
-                        senderName = "User", // Can be resolved if needed
-                        senderAvatarUrl = null,
+                        senderName = resolvedName,
+                        senderAvatarUrl = resolvedAvatar,
                         timestamp = mediaItem.createTimeSeconds.toLong(),
                         isVideo = mediaItem.isVideo,
                         uploaderId = mediaItem.uploaderId
@@ -386,6 +413,7 @@ internal class ChannelMediaGalleryAdapter(
         val videoDimmer: View,
         val play: ImageView,
         val av: AvatarView,
+        val anonymousAv: ImageView
     )
 }
 

--- a/app/src/main/java/com/mezon/mobile/ui/cells/PopupMenu.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/cells/PopupMenu.kt
@@ -26,6 +26,7 @@ class PopupMenu(private val context: Context, private val theme: ThemeColors) {
     private val items = ArrayList<MenuItem>()
     private var popupWindow: PopupWindow? = null
     private var onItemClick: ((Int) -> Unit)? = null
+    private var onDismissListener: (() -> Unit)? = null
 
     data class MenuItem(
         val text: String,
@@ -93,6 +94,9 @@ class PopupMenu(private val context: Context, private val theme: ThemeColors) {
             isOutsideTouchable = true
             isFocusable = false
             setBackgroundDrawable(ColorDrawable(0))
+            setOnDismissListener {
+                onDismissListener?.invoke()
+            }
             showAsDropDown(anchorView, 0, 0, Gravity.END or Gravity.TOP)
         }
     }
@@ -101,6 +105,10 @@ class PopupMenu(private val context: Context, private val theme: ThemeColors) {
         cornerRadius = MENU_CORNER_RADIUS
         setColor(theme.surface)
         setStroke(LayoutHelper.dp(1), theme.borderDim)
+    }
+
+    fun setOnDismissListener(listener: () -> Unit) {
+        onDismissListener = listener
     }
 
     fun dismiss() {

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1600,4 +1600,9 @@
     <string name="community_settings_error_banner_size">Kích thước ảnh phải nhỏ hơn 10 MB</string>
     <string name="community_settings_error_banner_type">Vui lòng chọn file ảnh hợp lệ</string>
     <string name="community_settings_permission_denied">Bạn không có quyền quản lý cài đặt cộng đồng</string>
+    <string name="action_save_media">Lưu ảnh</string>
+    <string name="action_copy_image">Sao chép ảnh</string>
+    <string name="action_share_image">Chia sẻ ảnh</string>
+    <string name="message_toast_save_success">Lưu thành công</string>
+    <string name="message_toast_save_failed">Lưu thất bại</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1715,4 +1715,6 @@
     <string name="transaction_detail_time">Time</string>
     <string name="transaction_detail_sender">Sender name</string>
     <string name="transaction_detail_receiver">Receiver name</string>
+    <string name="message_toast_save_success">Save successfully</string>
+    <string name="message_toast_save_failed">Save failed</string>
 </resources>


### PR DESCRIPTION
task: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-110
result:
<img width="1644" height="3840" alt="image" src="https://github.com/user-attachments/assets/720ac36d-c72c-4590-be96-5fcac1033ab6" />

Root Cause:
The anonymous sender information (avatar and name) was showing incorrectly in the photo viewer header.
The popup menu items (Save, Copy, Share) were hardcoded.
The photo viewer dropdown menu did not toggle close when tapped repeatedly.
Sharing downloaded images only shared plain text URLs instead of actual files on Android.
The default Android Toast clashed with the app's custom UI, and sharing failed intermittently on certain target apps due to strict OS-level URI permissions.

Solution:
Resolved correct names/avatars using MEZON_ANONYMOUS_USER_ID in ChatFragment and ChannelMediaGalleryAdapter.
Localized popup action strings using new i18n keys (message_toast_save_success/failed).
Set isFocusable = false and added an dismiss listener callback to toggle the dropdown state properly.
Switched sharing to download the file locally to cacheDir and share it via FileProvider with explicit grantUriPermission.
Replaced default Toast with the custom ToastOverlay styled with ThemeColors.instance.

Test Cases
Open an anonymous user's image and verify the header displays the correct anonymous avatar and name.
Open the dropdown menu in the photo viewer and verify the action options show translated text based on system language.
Tap the option dropdown icon repeatedly and verify it toggles open and closed successfully.
Save an image and verify the success overlay toast appears using the custom style instead of the system toast.
Tap Share, select a target app, and verify the actual image file is successfully shared rather than just the URL string.