### PR TITLE
260727-ANDROID-Fix capture image not sent

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/chat/CameraPhotoCapture.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/CameraPhotoCapture.kt
@@ -29,7 +29,8 @@ data class CameraPhotoCapture(
             height = bounds.outHeight.coerceAtLeast(0),
             size = file.length(),
             duration = 0,
-            isVideo = false
+            isVideo = false,
+            ownedCachePath = file.absolutePath
         )
     }
 

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -5411,16 +5411,22 @@ open class ChatFragment : BaseFragment() {
             capture.discard()
             return
         }
+        var wasSent = false
         val editor = ChatImageEditorDialog(ctx, item) { edited ->
+            wasSent = true
             cameraSourceAlert?.dismissWithoutAnimation()
             sendMessage(listOf(edited))
-            capture.discard()
+            if (edited !== item) {
+                capture.discard()
+            }
         }
         activeImageEditor?.dismiss()
         activeImageEditor = editor
         editor.setOnDismissListener {
             if (activeImageEditor === editor) activeImageEditor = null
-            capture.discard()
+            if (!wasSent) {
+                capture.discard()
+            }
         }
         editor.show()
     }


### PR DESCRIPTION
test cases: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-120
A race condition occurred when sending an unedited camera capture. The temporary image file was deleted synchronously on the UI thread (capture.discard()) immediately after initiating the asynchronous background upload. Consequently, the background uploader encountered a FileNotFoundException when attempting to read the image bytes.

Solution
UI flow: Postponed the call to capture.discard() inside ChatFragment and CreateThreadFragment so that the raw camera file is preserved when the user submits it.
Cache cleanup: Set ownedCachePath inside CameraPhotoCapture.toAttachment() so the background uploader can automatically clean up the temporary file after successfully reading it.

Test Cases
Test Case 1: Take a photo from the camera, send it immediately without editing, and verify that the message is sent successfully.
Test Case 2: Take a photo from the camera, apply edits (e.g., text, draw, crop), send it, and verify that the edited message is sent successfully.
Test Case 3: Take a photo from the camera, dismiss the preview dialog, and verify that the raw cache file is cleaned up.