### PR TITLE
260728-ANDROID-Handle multiple instance camera UX

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/call/CallController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/call/CallController.kt
@@ -635,6 +635,12 @@ class CallController @Inject constructor(
         notificationCenter.postNotificationOnMainThread(NotificationCenter.callMediaChanged)
     }
 
+    fun restartCamera() {
+        if (isLocalVideoEnabled) {
+            peerConnection?.restartCamera()
+        }
+    }
+
     fun toggleSpeaker() {
         isSpeakerOn = !isSpeakerOn
         if (isSpeakerOn) {

--- a/app/src/main/java/com/mezon/mobile/home/call/CallFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/call/CallFragment.kt
@@ -208,6 +208,13 @@ class CallFragment : BaseFragment() {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        if (::callController.isInitialized) {
+            callController.restartCamera()
+        }
+    }
+
     override fun onFragmentDestroy() {
         getParentActivity()?.volumeControlStream = AudioManager.USE_DEFAULT_STREAM_TYPE
         fragmentView?.removeCallbacks(finishAfterBusyRunnable)

--- a/app/src/main/java/com/mezon/mobile/home/call/PeerConnectionWrapper.kt
+++ b/app/src/main/java/com/mezon/mobile/home/call/PeerConnectionWrapper.kt
@@ -433,6 +433,18 @@ class PeerConnectionWrapper(
         localVideoTrack?.setEnabled(enabled)
     }
 
+    fun restartCamera() {
+        val capturer = videoCapturer
+        if (capturer != null && captureStarted) {
+            try {
+                capturer.stopCapture()
+                capturer.startCapture(1280, 720, 30)
+            } catch (e: Exception) {
+                android.util.Log.e(TAG, "restartCamera failed", e)
+            }
+        }
+    }
+
     fun switchCamera() {
         videoCapturer?.switchCamera(object : CameraVideoCapturer.CameraSwitchHandler {
             override fun onCameraSwitchDone(isFrontCamera: Boolean) {

--- a/app/src/main/java/com/mezon/mobile/home/call/PeerConnectionWrapper.kt
+++ b/app/src/main/java/com/mezon/mobile/home/call/PeerConnectionWrapper.kt
@@ -411,12 +411,23 @@ class PeerConnectionWrapper(
 
     fun setLocalVideoEnabled(enabled: Boolean) {
         val capturer = videoCapturer
-        if (capturer != null && enabled && !captureStarted) {
-            try {
-                capturer.startCapture(1280, 720, 30)
-                captureStarted = true
-            } catch (e: Exception) {
-                android.util.Log.e(TAG, "startCapture failed", e)
+        if (enabled) {
+            if (capturer != null && !captureStarted) {
+                try {
+                    capturer.startCapture(1280, 720, 30)
+                    captureStarted = true
+                } catch (e: Exception) {
+                    android.util.Log.e(TAG, "startCapture failed", e)
+                }
+            }
+        } else {
+            if (capturer != null && captureStarted) {
+                try {
+                    capturer.stopCapture()
+                    captureStarted = false
+                } catch (e: Exception) {
+                    android.util.Log.e(TAG, "stopCapture failed", e)
+                }
             }
         }
         localVideoTrack?.setEnabled(enabled)

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -5351,6 +5351,16 @@ open class ChatFragment : BaseFragment() {
 
     private fun launchCameraPhoto(): Boolean {
         val ctx = getContext() ?: return false
+        
+        if ((callController.isCallSessionActive() && callController.isLocalVideoEnabled) ||
+            (voiceController.isJoined && voiceController.isLocalVideoEnabled)) {
+            com.mezon.mobile.core.AlertDialog.Builder(ctx)
+                .setMessage(getString(R.string.camera_in_use_error))
+                .setPositiveButton(getString(android.R.string.ok), null)
+                .show()
+            return false
+        }
+
         val capture = CameraPhotoCapture.create(ctx)
         if (capture == null) {
             MezonToast.show(this, ToastOverlay.ToastType.ERROR, getString(R.string.camera_not_available))

--- a/app/src/main/java/com/mezon/mobile/home/chat/thread/CreateThreadFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/thread/CreateThreadFragment.kt
@@ -152,6 +152,8 @@ class CreateThreadFragment : BaseFragment() {
     private var useTopicFlow = false
 
     private lateinit var chatController: ChatController
+    private lateinit var callController: com.mezon.mobile.home.call.CallController
+    private lateinit var voiceController: com.mezon.mobile.home.voice.VoiceController
     private lateinit var topicController: TopicController
     private lateinit var channelController: ChannelController
     private lateinit var sessionManager: SessionManager
@@ -273,6 +275,8 @@ class CreateThreadFragment : BaseFragment() {
 
     override fun onInject(entryPoint: FragmentEntryPoint) {
         chatController = entryPoint.chatController()
+        callController = entryPoint.callController()
+        voiceController = entryPoint.voiceController()
         topicController = entryPoint.topicController()
         channelController = entryPoint.channelController()
         sessionManager = entryPoint.sessionManager()
@@ -1188,6 +1192,16 @@ class CreateThreadFragment : BaseFragment() {
 
     private fun launchCameraPhoto(): Boolean {
         val ctx = getContext() ?: return false
+        
+        if ((callController.isCallSessionActive() && callController.isLocalVideoEnabled) ||
+            (voiceController.isJoined && voiceController.isLocalVideoEnabled)) {
+            com.mezon.mobile.core.AlertDialog.Builder(ctx)
+                .setMessage(getString(R.string.camera_in_use_error))
+                .setPositiveButton(getString(android.R.string.ok), null)
+                .show()
+            return false
+        }
+
         val capture = CameraPhotoCapture.create(ctx)
         if (capture == null) {
             MezonToast.show(this, ToastOverlay.ToastType.ERROR, getString(R.string.camera_not_available))

--- a/app/src/main/java/com/mezon/mobile/home/voice/VoiceController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/voice/VoiceController.kt
@@ -48,6 +48,7 @@ class VoiceController @Inject constructor(
         private set
     var meetToken: String? = null
         private set
+    var isLocalVideoEnabled: Boolean = false
 
     private val aiAgentEnabled = HashMap<String, Boolean>()
 
@@ -72,6 +73,7 @@ class VoiceController @Inject constructor(
             currentVoiceInfo = null
             isJoined = false
             isConnecting = false
+            isLocalVideoEnabled = false
             meetToken = null
             aiAgentEnabled.clear()
         }

--- a/app/src/main/java/com/mezon/mobile/home/voice/VoiceRoomFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/voice/VoiceRoomFragment.kt
@@ -412,6 +412,23 @@ class VoiceRoomFragment : BaseFragment() {
     override fun onResume() {
         super.onResume()
         applyAgentHeaderUi()
+        
+        // Auto-recover camera if it was evicted by another app in the background
+        val scope = roomScope
+        val localParticipant = room?.localParticipant
+        if (scope != null && localParticipant != null && localParticipant.isCameraEnabled) {
+            scope.launch {
+                val track = localParticipant.getTrackPublication(io.livekit.android.room.track.Track.Source.CAMERA)?.track as? io.livekit.android.room.track.LocalVideoTrack
+                runCatching {
+                    track?.restartTrack()
+                }.onFailure {
+                    runCatching {
+                        localParticipant.setCameraEnabled(false)
+                        localParticipant.setCameraEnabled(true)
+                    }
+                }
+            }
+        }
     }
 
     override fun createView(context: Context): View {

--- a/app/src/main/java/com/mezon/mobile/home/voice/VoiceRoomFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/voice/VoiceRoomFragment.kt
@@ -578,6 +578,7 @@ class VoiceRoomFragment : BaseFragment() {
                 } else {
                     roomScope?.launch {
                         runCatching { room?.localParticipant?.setCameraEnabled(false) }
+                        voiceController.isLocalVideoEnabled = false
                         headerView.setSwitchCameraVisible(false)
                         doUpdateParticipantList()
                     }
@@ -839,11 +840,13 @@ class VoiceRoomFragment : BaseFragment() {
             runCatching { participant.setCameraEnabled(true) }
                 .onSuccess {
                     localCameraFacing = CameraPosition.FRONT
+                    voiceController.isLocalVideoEnabled = true
                     if (::headerView.isInitialized) headerView.setSwitchCameraVisible(true)
                     doUpdateParticipantList()
                 }
                 .onFailure { e ->
                     Log.e(TAG, "setCameraEnabled(true) failed", e)
+                    voiceController.isLocalVideoEnabled = false
                     if (::controlBar.isInitialized) controlBar.setCameraEnabled(false)
                 }
         }
@@ -898,6 +901,7 @@ class VoiceRoomFragment : BaseFragment() {
                     .onFailure { Log.w(TAG, "setMicrophoneEnabled(false) failed (likely no permission)", it) }
                 runCatching { room!!.localParticipant.setCameraEnabled(false) }
                     .onFailure { Log.w(TAG, "setCameraEnabled(false) failed (likely no permission)", it) }
+                voiceController.isLocalVideoEnabled = false
                 headerView.setSwitchCameraVisible(false)
 
                 Log.d(TAG, "Local participant: identity=${room!!.localParticipant.identity?.value} name=${room!!.localParticipant.name}")

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -87,6 +87,7 @@
     <string name="qr_login_require_mobile_session">Phiên đăng nhập đã hết hạn. Vui lòng đăng nhập lại để xác nhận đăng nhập QR.</string>
     <string name="qr_camera_denied_title">Không có quyền camera</string>
     <string name="camera_not_available">Không tìm thấy ứng dụng camera.</string>
+    <string name="camera_in_use_error">Camera hiện không hoạt động. Hãy đóng mọi ứng dụng camera khác mà bạn đang chạy.</string>
     <string name="camera_capture_failed">Không thể sử dụng ảnh này. Vui lòng thử lại.</string>
     <string name="camera_photo_preview">Xem trước ảnh vừa chụp</string>
     <string name="camera_retake">Chụp lại</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1182,6 +1182,7 @@
     <string name="permission_no_storage">Mezon needs access to your storage to send and save media. Please go to Settings and enable the permission.</string>
     <string name="permission_no_camera">Mezon needs access to your camera. Please go to Settings and enable the permission.</string>
     <string name="camera_not_available">No camera app is available.</string>
+    <string name="camera_in_use_error">Camera is currently in use. Please close any other camera apps you are running.</string>
     <string name="camera_capture_failed">Couldn\'t use this photo. Please try again.</string>
     <string name="camera_photo_preview">Captured photo preview</string>
     <string name="camera_retake">Retake</string>


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-128
result:
<img width="1644" height="3840" alt="image" src="https://github.com/user-attachments/assets/e4d59ebc-2414-4615-bcec-ef689f2740d4" />

Root Cause
Hardware Leak: When disabling the camera in a 1-1 call, WebRTC's stopCapture() was not called, causing the app to silently hold the camera hardware in the background and crash when the user opened the photo camera.
Missing Auto-Recovery: When the OS forcibly evicted the camera because another app was opened in the background, neither 1-1 calls nor Voice Channels had an automatic recovery mechanism upon returning to the foreground, resulting in a black screen.
Conflict Prevention: The app lacked a check to prevent users from opening the chat's photo camera while a 1-1 call or Voice Channel camera was already active.

Solution
Hardware Release: Updated PeerConnectionWrapper.setLocalVideoEnabled(false) to explicitly call stopCapture() and release the camera immediately.
Auto-Recovery: Implemented onResume() in CallFragment and VoiceRoomFragment to detect evicted cameras and automatically restart them (restartCamera() for WebRTC and restartTrack() for LiveKit).
Conflict Prevention: Updated ChatFragment and CreateThreadFragment to display a localized warning dialog and block camera access if local video is currently active in either CallController or VoiceController.

Test Cases
Test Case 1: Verify that turning off the camera in a 1-1 call properly releases the hardware so the user can successfully take a photo in the chat. Test Case 2: Verify that attempting to take a photo in a chat is blocked with a warning dialog if the camera is currently active in a 1-1 call or Voice Channel. Test Case 3: Verify that if the user puts an active 1-1 call in the background and opens the system camera, returning to the Mezon app automatically recovers the video feed. Test Case 4: Verify that if the user puts an active Voice Channel in the background and opens the system camera, returning to the Mezon app automatically recovers the video feed.