### PR TITLE
260728-ANDROID-Fix text avatar show incorrect call

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/call/CallAvatarView.kt
+++ b/app/src/main/java/com/mezon/mobile/home/call/CallAvatarView.kt
@@ -66,15 +66,18 @@ class CallAvatarView(
     fun setData(name: String, username: String, avatarUrl: String?) {
         peerName = name
         avatarDrawable.setInfo(0L, username.ifEmpty { name })
-        if (currentAvatarUrl != avatarUrl) {
-            currentAvatarUrl = avatarUrl
+        
+        val actualAvatarUrl = if (avatarUrl == "null") null else avatarUrl
+        
+        if (currentAvatarUrl != actualAvatarUrl) {
+            currentAvatarUrl = actualAvatarUrl
             cancellable?.cancel()
             cancellable = null
-            if (avatarUrl.isNullOrBlank()) {
+            if (actualAvatarUrl.isNullOrBlank()) {
                 avatarDrawable.setLoadingPlaceholder(false)
                 avatarDrawable.setPhoto(null)
             } else if (attachedToWindow) {
-                loadAvatar(avatarUrl)
+                loadAvatar(actualAvatarUrl)
             }
         }
         invalidate()

--- a/app/src/main/java/com/mezon/mobile/home/call/CallController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/call/CallController.kt
@@ -340,7 +340,7 @@ class CallController @Inject constructor(
             Log.d(TAG, "acceptCallFromFcm: parsing FCM offer data")
             val parsed = parseSignalingData(offerJson)
             val callerName = parsed.optString("callerName", "Unknown")
-            val callerAvatar = parsed.optString("callerAvatar", "")
+            val callerAvatar = parsed.optString("callerAvatar", "").takeIf { it != "null" } ?: ""
             val callerIdStr = parsed.optString("callerId", "0")
             val channelIdStr = parsed.optString("channelId", "0")
 
@@ -818,7 +818,7 @@ class CallController @Inject constructor(
         try {
             val parsed = parseSignalingData(jsonData)
             val callerName = parsed.optString("callerName", "Unknown")
-            val callerAvatar = parsed.optString("callerAvatar", "")
+            val callerAvatar = parsed.optString("callerAvatar", "").takeIf { it != "null" } ?: ""
 
             val sdpString = SdpCompressor.sdpPlainTextFromNegotiationJson(parsed)
             if (sdpString.isNullOrEmpty()) {


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-119
result:
<img width="1644" height="3840" alt="image" src="https://github.com/user-attachments/assets/a6db394c-e53a-4e61-bb9a-912730be969c" />

Root Cause
When parsing the signalling JSON payload, the platform's JSON parser deserializes an explicit JSON null avatar value into the literal string "null". This causes the call screen to request the invalid "null" URL from imgproxy, which returns its default placeholder fallback image (grey circle with person icon) instead of rendering the text avatar.

Solution
Filtered out literal "null" strings from the callerAvatar parsing logic in CallController.kt.
Added a fallback check in CallAvatarView.kt to ensure "null" URLs are normalized to null, correctly triggering the local text avatar rendering.

Test Cases
Test Case 1: Verify that initiating a call to a user without an avatar displays a text avatar based on their username on the ringing screen.
Test Case 2: Verify that receiving an incoming call from a user without an avatar correctly displays their initials as a text avatar instead of a grey placeholder icon.
Test Case 3: Verify that calling a user who has a custom avatar still displays their correct image avatar normally.