### PR TITLE
260729-ANDROID-Fix save image from context menu

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -6921,29 +6921,11 @@ open class ChatFragment : BaseFragment() {
                 }
 
                 appScope.launch(ioDispatcher) {
-                    try {
-                        val filename = url.substringAfterLast('/').substringBefore('?').ifEmpty { "download.jpg" }
-                        val downloadsDir = android.os.Environment.getExternalStoragePublicDirectory(android.os.Environment.DIRECTORY_DOWNLOADS)
-                        downloadsDir.mkdirs()
-                        val destFile = java.io.File(downloadsDir, filename)
-                        
-                        val conn = java.net.URL(url).openConnection() as java.net.HttpURLConnection
-                        conn.connect()
-                        if (conn.responseCode !in 200..299) {
-                            throw Exception("HTTP Error: ${conn.responseCode}")
-                        }
-                        conn.inputStream.use { input ->
-                            java.io.FileOutputStream(destFile).use { output ->
-                                input.copyTo(output)
-                            }
-                        }
-                        
-                        android.media.MediaScannerConnection.scanFile(ctx.applicationContext, arrayOf(destFile.absolutePath), null, null)
-                        withContext(Dispatchers.Main) {
+                    val success = com.mezon.mobile.util.FileUtils.downloadMediaToGallery(ctx, url)
+                    withContext(Dispatchers.Main) {
+                        if (success) {
                             MezonToast.show(this@ChatFragment, ToastOverlay.ToastType.SUCCESS, getString(R.string.message_toast_save_success))
-                        }
-                    } catch (e: Exception) {
-                        withContext(Dispatchers.Main) {
+                        } else {
                             MezonToast.show(this@ChatFragment, ToastOverlay.ToastType.ERROR, getString(R.string.message_toast_save_failed))
                         }
                     }

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -6912,8 +6912,42 @@ open class ChatFragment : BaseFragment() {
                 MezonToast.show(this, ToastOverlay.ToastType.INFO, getString(R.string.feature_coming_soon))
             }
             MessageActionBottomSheet.ActionType.SaveMedia -> {
-                getContext() ?: return
-                MezonToast.show(this, ToastOverlay.ToastType.INFO, getString(R.string.feature_coming_soon))
+                val ctx = getContext() ?: return
+                val url = msg.allImageAttachments.firstOrNull()?.url?.takeIf { it.isNotBlank() }
+                    ?: msg.attachmentUrl.takeIf { it.isNotBlank() }
+                if (url.isNullOrEmpty()) {
+                    MezonToast.show(this, ToastOverlay.ToastType.ERROR, getString(R.string.message_toast_save_failed))
+                    return
+                }
+
+                appScope.launch(ioDispatcher) {
+                    try {
+                        val filename = url.substringAfterLast('/').substringBefore('?').ifEmpty { "download.jpg" }
+                        val downloadsDir = android.os.Environment.getExternalStoragePublicDirectory(android.os.Environment.DIRECTORY_DOWNLOADS)
+                        downloadsDir.mkdirs()
+                        val destFile = java.io.File(downloadsDir, filename)
+                        
+                        val conn = java.net.URL(url).openConnection() as java.net.HttpURLConnection
+                        conn.connect()
+                        if (conn.responseCode !in 200..299) {
+                            throw Exception("HTTP Error: ${conn.responseCode}")
+                        }
+                        conn.inputStream.use { input ->
+                            java.io.FileOutputStream(destFile).use { output ->
+                                input.copyTo(output)
+                            }
+                        }
+                        
+                        android.media.MediaScannerConnection.scanFile(ctx.applicationContext, arrayOf(destFile.absolutePath), null, null)
+                        withContext(Dispatchers.Main) {
+                            MezonToast.show(this@ChatFragment, ToastOverlay.ToastType.SUCCESS, getString(R.string.message_toast_save_success))
+                        }
+                    } catch (e: Exception) {
+                        withContext(Dispatchers.Main) {
+                            MezonToast.show(this@ChatFragment, ToastOverlay.ToastType.ERROR, getString(R.string.message_toast_save_failed))
+                        }
+                    }
+                }
             }
             MessageActionBottomSheet.ActionType.CopyMediaLink -> {
                 val url = msg.attachmentUrl

--- a/app/src/main/java/com/mezon/mobile/home/chat/PhotoViewer.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/PhotoViewer.kt
@@ -910,18 +910,11 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
 
     private fun downloadUrl(url: String) {
         entryPoint.applicationScope().launch(entryPoint.ioDispatcher()) {
-            try {
-                val filename = url.substringAfterLast('/').substringBefore('?').ifEmpty { "download.jpg" }
-                val downloadsDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
-                downloadsDir.mkdirs()
-                val destFile = java.io.File(downloadsDir, filename)
-                downloadToFile(url, destFile)
-                android.media.MediaScannerConnection.scanFile(context, arrayOf(destFile.absolutePath), null, null)
-                withContext(entryPoint.mainDispatcher()) {
+            val success = com.mezon.mobile.util.FileUtils.downloadMediaToGallery(context, url)
+            withContext(entryPoint.mainDispatcher()) {
+                if (success) {
                     showToast(ToastOverlay.ToastType.SUCCESS, R.string.message_toast_save_success)
-                }
-            } catch (e: Exception) {
-                withContext(entryPoint.mainDispatcher()) {
+                } else {
                     showToast(ToastOverlay.ToastType.ERROR, R.string.message_toast_save_failed)
                 }
             }

--- a/app/src/main/java/com/mezon/mobile/util/FileUtils.kt
+++ b/app/src/main/java/com/mezon/mobile/util/FileUtils.kt
@@ -11,6 +11,31 @@ class ContentUriTooLargeException(val maxAllowedBytes: Int) : RuntimeException()
 
 object FileUtils {
 
+    suspend fun downloadMediaToGallery(context: android.content.Context, url: String): Boolean = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+        try {
+            val filename = url.substringAfterLast('/').substringBefore('?').ifEmpty { "download.jpg" }
+            val downloadsDir = android.os.Environment.getExternalStoragePublicDirectory(android.os.Environment.DIRECTORY_DOWNLOADS)
+            downloadsDir.mkdirs()
+            val destFile = java.io.File(downloadsDir, filename)
+            
+            val conn = java.net.URL(url).openConnection() as java.net.HttpURLConnection
+            conn.connect()
+            if (conn.responseCode !in 200..299) {
+                return@withContext false
+            }
+            conn.inputStream.use { input ->
+                java.io.FileOutputStream(destFile).use { output ->
+                    input.copyTo(output)
+                }
+            }
+            
+            android.media.MediaScannerConnection.scanFile(context.applicationContext, arrayOf(destFile.absolutePath), null, null)
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
     private const val STREAM_READ_CHUNK_BYTES = 8192
 
 


### PR DESCRIPTION
task: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-135
Root Cause: The "Save image" action in the message context menu was not implemented and only showed a placeholder "coming soon" toast.

Solution: Implemented the download logic in ChatFragment by reusing the code from PhotoViewer to download the media to the public Downloads directory and trigger the media scanner.

Test Cases:
Verify that tapping "Save image" on a media message successfully downloads the file and shows a success toast.
Verify that the downloaded image is immediately visible in the device's gallery app.
Verify that the app displays an error toast if the download fails (e.g., due to network issues).