### PR TITLE
260731-ANDROID-Check exception handling fetch role

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/clans/settings/RoleSetupMembersFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/settings/RoleSetupMembersFragment.kt
@@ -111,14 +111,18 @@ class RoleSetupMembersFragment : BaseFragment() {
     private fun reloadRoleMemberSelection() {
         if (!isEditMode || !::adapter.isInitialized) return
         fragmentScope.launch {
-            val ids = roleController.loadAllRoleMemberUserIds(roleId)
-            withContext(Dispatchers.Main.immediate) {
-                initialMemberIds.clear()
-                initialMemberIds.addAll(ids)
-                selectedUserIds.clear()
-                selectedUserIds.addAll(ids)
-                adapter.refresh()
-                updateActionState()
+            try {
+                val ids = roleController.loadAllRoleMemberUserIds(roleId)
+                withContext(Dispatchers.Main.immediate) {
+                    initialMemberIds.clear()
+                    initialMemberIds.addAll(ids)
+                    selectedUserIds.clear()
+                    selectedUserIds.addAll(ids)
+                    adapter.refresh()
+                    updateActionState()
+                }
+            } catch (e: Exception) {
+                
             }
         }
     }


### PR DESCRIPTION
Root Cause
The network call roleController.loadAllRoleMemberUserIds(roleId) inside reloadRoleMemberSelection() was launched without any error handling. When the server returned a 503 Service Temporarily Unavailable status, the uncaught HttpRpcStatusException crashed the application.

Solution
Wrapped the network request and UI update block inside a try-catch block to safely catch exceptions.

Test Cases: Verify that the application does not crash when opening the Role Members screen while the API server returns a 503 error.
