### PR TITLE
260731-ANDROID-Fix bug upload emoji

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/clans/settings/EmojiSettingFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/settings/EmojiSettingFragment.kt
@@ -508,11 +508,7 @@ class EmojiSettingFragment : BaseFragment() {
                     file.name.endsWith(".webp", true) -> "image/webp"
                     else -> "image/jpeg"
                 }
-                val ext = when {
-                    isGif -> "gif"
-                    mime == "image/webp" -> "webp"
-                    else -> "jpg"
-                }
+                val ext = "webp"
 
                 val opts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
                 BitmapFactory.decodeByteArray(bytes, 0, bytes.size, opts)
@@ -521,6 +517,7 @@ class EmojiSettingFragment : BaseFragment() {
 
                 val primaryFilename = "emojis/$primaryId.$ext"
                 val primaryUrl = uploadBytes(bytes, primaryFilename, mime, w, h)
+                val parsedPrimaryId = primaryUrl.substringAfterLast('/').substringBeforeLast('.').toLongOrNull() ?: primaryId
 
                 val emojiRecordId = if (isForSale) {
                     val thumbBmp = decodeSaleThumbBytes(bytes, w, h, isGif)
@@ -534,11 +531,11 @@ class EmojiSettingFragment : BaseFragment() {
                     val thumbId = newEmojiNumericId()
                     val thumbBytes = encodeTinyJpeg(scaled)
                     scaled.recycle()
-                    val thumbName = "emojis/$thumbId.jpg"
+                    val thumbName = "emojis/$thumbId.webp"
                     uploadBytes(thumbBytes, thumbName, "image/jpeg", 35, 35)
-                    thumbId
+                    parsedPrimaryId
                 } else {
-                    primaryId
+                    parsedPrimaryId
                 }
 
                 val shortname = ":$innerName:"


### PR DESCRIPTION
issue:https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-151
Root Cause
ID Mismatch: The Android client used a locally generated random ID to create the emoji record, whereas the MinIO upload server generates a new snowflake ID for the uploaded file, causing a mismatch.
Extension Discrepancy: The Android client uploaded files with varying extensions (e.g., .jpg, .gif), while other clients (Web, iOS) always hardcode and expect the .webp extension when constructing emoji URLs.

Solution
Parse the actual server-generated ID from the returned upload URL and pass it to the CreateClanEmoji API.
Force the upload filename extension to always be .webp to align with the rendering logic on other platforms.

Test Cases
TC 1: Upload a JPG/PNG emoji from the Android app and verify it displays correctly in the Web client's emoji list.
TC 2: Upload a GIF emoji from the Android app and verify it animates and renders successfully on the Web client.
TC 3: Upload an emoji with "For Sale" toggled on and verify both the thumbnail and main emoji are registered and displayed correctly.