### PR TITLE
260803-ANDROID-Update animated image

### DIFF
--- a/app/src/main/java/com/mezon/mobile/core/AvatarDrawable.kt
+++ b/app/src/main/java/com/mezon/mobile/core/AvatarDrawable.kt
@@ -7,12 +7,17 @@ import android.graphics.Color
 import android.graphics.ColorFilter
 import android.graphics.LinearGradient
 import android.graphics.Paint
+import android.graphics.Path
 import android.graphics.PixelFormat
 import android.graphics.RectF
 import android.graphics.Shader
 import android.graphics.Typeface
+import android.graphics.drawable.Animatable
 import android.graphics.drawable.Drawable
+import android.os.SystemClock
 import android.text.TextPaint
+import android.view.View
+import java.lang.ref.WeakReference
 
 class AvatarDrawable : Drawable() {
 
@@ -94,10 +99,27 @@ class AvatarDrawable : Drawable() {
     private var cachedGradientHeight = 0f
     private var lastBoundsWidth = -1
     private var lastBoundsHeight = -1
+    private var animatedDrawable: Drawable? = null
+    private var hostViewRef: WeakReference<View>? = null
+    private val clipPath = Path()
+
+    private val childAnimCallback = object : Drawable.Callback {
+        override fun invalidateDrawable(who: Drawable) {
+            invalidateSelf()
+            hostViewRef?.get()?.invalidate()
+        }
+        override fun scheduleDrawable(who: Drawable, what: Runnable, `when`: Long) {
+            val view = hostViewRef?.get() ?: return
+            view.postDelayed(what, `when` - SystemClock.uptimeMillis())
+        }
+        override fun unscheduleDrawable(who: Drawable, what: Runnable) {
+            hostViewRef?.get()?.removeCallbacks(what)
+        }
+    }
 
     fun setInfo(id: Long, username: String?) {
         val normalized = normalizeUsername(username)
-        if (id == currentUserId && photoBitmap != null) {
+        if (id == currentUserId && (photoBitmap != null || animatedDrawable != null)) {
             bgColor = getColorForName(normalized)
             bgColor2 = bgColor
             initial = getAvatarSymbols(normalized)
@@ -109,6 +131,7 @@ class AvatarDrawable : Drawable() {
         bgColor2 = bgColor
         hasGradient = false
         initial = getAvatarSymbols(normalized)
+        clearAnimatedDrawable()
         photoBitmap = null
         loadingPlaceholder = false
         cachedShader = null
@@ -179,13 +202,44 @@ class AvatarDrawable : Drawable() {
     }
 
     fun setPhoto(bitmap: Bitmap?) {
+        clearAnimatedDrawable()
         photoBitmap = bitmap
         cachedShader = null
         cachedShaderBitmap = null
         invalidateSelf()
     }
 
-    fun hasPhoto(): Boolean = photoBitmap != null
+    fun hasPhoto(): Boolean = photoBitmap != null || animatedDrawable != null
+
+    fun attachToView(view: View) {
+        hostViewRef = WeakReference(view)
+    }
+
+    fun setAnimatedPhoto(drawable: Drawable?) {
+        clearAnimatedDrawable()
+        animatedDrawable = drawable
+        photoBitmap = null
+        cachedShader = null
+        cachedShaderBitmap = null
+        loadingPlaceholder = false
+        drawable?.callback = childAnimCallback
+        invalidateSelf()
+    }
+
+    fun startAnimation() {
+        (animatedDrawable as? Animatable)?.start()
+    }
+
+    fun stopAnimation() {
+        (animatedDrawable as? Animatable)?.stop()
+    }
+
+    private fun clearAnimatedDrawable() {
+        val old = animatedDrawable ?: return
+        (old as? Animatable)?.stop()
+        old.callback = null
+        animatedDrawable = null
+    }
 
     override fun draw(canvas: Canvas) {
         val bounds = bounds
@@ -200,6 +254,18 @@ class AvatarDrawable : Drawable() {
         if (boundsChanged) {
             lastBoundsWidth = bounds.width()
             lastBoundsHeight = bounds.height()
+        }
+
+        val anim = animatedDrawable
+        if (anim != null) {
+            canvas.save()
+            clipPath.reset()
+            clipPath.addRoundRect(roundRectF, r, r, Path.Direction.CW)
+            canvas.clipPath(clipPath)
+            anim.setBounds(bounds.left, bounds.top, bounds.right, bounds.bottom)
+            anim.draw(canvas)
+            canvas.restore()
+            return
         }
 
         val photo = photoBitmap

--- a/app/src/main/java/com/mezon/mobile/core/AvatarDrawable.kt
+++ b/app/src/main/java/com/mezon/mobile/core/AvatarDrawable.kt
@@ -109,11 +109,20 @@ class AvatarDrawable : Drawable() {
             hostViewRef?.get()?.invalidate()
         }
         override fun scheduleDrawable(who: Drawable, what: Runnable, `when`: Long) {
-            val view = hostViewRef?.get() ?: return
-            view.postDelayed(what, `when` - SystemClock.uptimeMillis())
+            val view = hostViewRef?.get()
+            if (view != null) {
+                view.postDelayed(what, `when` - SystemClock.uptimeMillis())
+            } else {
+                scheduleSelf(what, `when`)
+            }
         }
         override fun unscheduleDrawable(who: Drawable, what: Runnable) {
-            hostViewRef?.get()?.removeCallbacks(what)
+            val view = hostViewRef?.get()
+            if (view != null) {
+                view.removeCallbacks(what)
+            } else {
+                unscheduleSelf(what)
+            }
         }
     }
 

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
@@ -403,6 +403,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         linkInviteBlock.onAttachedToWindow()
         embedMessage.onAttachedToWindow()
         avatarDrawable.startAnimation()
+        replyAvatarDrawable.startAnimation()
 
         reactionEmojiDrawables.forEach {
             if (it is android.graphics.drawable.AnimatedImageDrawable) {
@@ -434,6 +435,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         }
         topicButtonLayout.cancelAvatarLoad()
         avatarDrawable.stopAnimation()
+        replyAvatarDrawable.stopAnimation()
         avatarCancellable?.cancel()
         avatarCancellable = null
         senderRoleIconCancellable?.cancel()
@@ -1171,7 +1173,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         val sz = ROLE_ICON_SIZE
         val loader = MezonImageLoader.getInstance(context)
 
-        senderRoleIconCancellable = loader.loadDrawable(url, sz, sz, cacheAnimated = true, onSuccess = { drw ->
+        senderRoleIconCancellable = loader.loadDrawable(url, sz, sz, cacheAnimated = false, onSuccess = { drw ->
             if (senderRoleIconUrl == url) {
                 senderRoleIconDrawable = drw
                 drw.callback = this
@@ -2172,7 +2174,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
     private var replyBlockTop = 0f
     private var replyBlockRight = 0f
     private var replyBlockBottom = 0f
-    private val replyAvatarDrawable = AvatarDrawable()
+    private val replyAvatarDrawable = AvatarDrawable().also { it.attachToView(this) }
     private var replyAvatarCancellable: MezonImageLoader.Cancellable? = null
 
     private fun buildReplyLayouts(textWidth: Int) {

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
@@ -32,6 +32,7 @@ import com.mezon.mobile.util.FileUtils
 import com.mezon.mobile.util.PresignFinishContent
 import com.mezon.mobile.util.avatarImgproxyUrl
 import com.mezon.mobile.util.createImgproxyUrl
+import com.mezon.mobile.util.isAnimatedImageUrl
 import com.mezon.mobile.util.getEmojiDirectUrl
 import com.mezon.mobile.util.getEmojiUrl
 import com.mezon.mobile.util.MentionColors
@@ -180,7 +181,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
     var isInPinMode: Boolean = false
     var isTopicHeaderContent: Boolean = false
 
-    private val avatarDrawable = AvatarDrawable()
+    private val avatarDrawable = AvatarDrawable().also { it.attachToView(this) }
     private var currentAvatarUrl: String? = null
     private var measuredCellHeight = LayoutHelper.dp(60)
 
@@ -380,7 +381,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         isDither = true
     }
     private var senderRoleIconUrl: String? = null
-    private var senderRoleIconBitmap: Bitmap? = null
+    private var senderRoleIconDrawable: android.graphics.drawable.Drawable? = null
     private var senderRoleIconCancellable: MezonImageLoader.Cancellable? = null
     private var cachedSenderNameW = 0f
     private var reserveSenderRoleIcon = false
@@ -401,6 +402,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         ogpImage.onAttachedToWindow()
         linkInviteBlock.onAttachedToWindow()
         embedMessage.onAttachedToWindow()
+        avatarDrawable.startAnimation()
 
         reactionEmojiDrawables.forEach {
             if (it is android.graphics.drawable.AnimatedImageDrawable) {
@@ -431,6 +433,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             it?.callback = null
         }
         topicButtonLayout.cancelAvatarLoad()
+        avatarDrawable.stopAnimation()
         avatarCancellable?.cancel()
         avatarCancellable = null
         senderRoleIconCancellable?.cancel()
@@ -1150,7 +1153,8 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         senderRoleIconCancellable?.cancel()
         senderRoleIconCancellable = null
         senderRoleIconUrl = null
-        senderRoleIconBitmap = null
+        senderRoleIconDrawable?.callback = null
+        senderRoleIconDrawable = null
     }
 
     private fun loadSenderRoleIcon(url: String) {
@@ -1158,38 +1162,46 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             clearSenderRoleIcon()
             return
         }
-        if (url == senderRoleIconUrl && senderRoleIconBitmap != null) return
+        if (url == senderRoleIconUrl && senderRoleIconDrawable != null) return
         senderRoleIconCancellable?.cancel()
         senderRoleIconCancellable = null
         senderRoleIconUrl = url
-        senderRoleIconBitmap = null
+        senderRoleIconDrawable?.callback = null
+        senderRoleIconDrawable = null
         val sz = ROLE_ICON_SIZE
         val loader = MezonImageLoader.getInstance(context)
-        val cached = loader.getBitmapFromMemory(url, sz, sz)
-        if (cached != null) {
-            senderRoleIconBitmap = cached
-            invalidate()
-            return
-        }
-        senderRoleIconCancellable = loader.load(url, sz, sz, onSuccess = { bmp ->
+
+        senderRoleIconCancellable = loader.loadDrawable(url, sz, sz, cacheAnimated = true, onSuccess = { drw ->
             if (senderRoleIconUrl == url) {
-                senderRoleIconBitmap = bmp
+                senderRoleIconDrawable = drw
+                drw.callback = this
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P && drw is android.graphics.drawable.AnimatedImageDrawable) {
+                    drw.start()
+                }
                 invalidate()
             }
         }, onError = {
             if (senderRoleIconUrl == url) {
-                senderRoleIconBitmap = null
+                senderRoleIconDrawable?.callback = null
+                senderRoleIconDrawable = null
                 invalidate()
             }
         })
     }
 
+    override fun verifyDrawable(who: android.graphics.drawable.Drawable): Boolean {
+        return who == senderRoleIconDrawable || super.verifyDrawable(who)
+    }
+
     private fun drawSenderRoleIconAfterName(canvas: Canvas, contentLeft: Int, yOff: Float, sender: StaticLayout) {
-        if (!reserveSenderRoleIcon || senderRoleIconBitmap == null) return
+        if (!reserveSenderRoleIcon || senderRoleIconDrawable == null) return
         val ix = contentLeft + cachedSenderNameW + ROLE_ICON_GAP
         val iy = yOff + (sender.height - ROLE_ICON_SIZE) / 2f
         tmpRect.set(ix.toFloat(), iy, (ix + ROLE_ICON_SIZE).toFloat(), (iy + ROLE_ICON_SIZE).toFloat())
-        canvas.drawBitmap(senderRoleIconBitmap!!, null, tmpRect, roleIconBitmapPaint)
+        
+        val drw = senderRoleIconDrawable!!
+        drw.setBounds(tmpRect.left.toInt(), tmpRect.top.toInt(), tmpRect.right.toInt(), tmpRect.bottom.toInt())
+        drw.draw(canvas)
     }
 
     private fun currentWidth(): Int {
@@ -2216,13 +2228,18 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         if (url.isNotEmpty()) {
             val proxyUrl = avatarImgproxyUrl(url, AVATAR_SIZE)
             val loader = MezonImageLoader.getInstance(context)
-            val cached = loader.getBitmapFromMemory(proxyUrl, AVATAR_SIZE, AVATAR_SIZE)
-            if (cached != null) {
-                avatarDrawable.setLoadingPlaceholder(false)
-                avatarDrawable.setPhoto(cached)
-                avatarDrawable.setDrawableByInfo(true)
-                avatarFallbackVisible = true
-                return
+            val absoluteUrlFallback = com.mezon.mobile.util.plainSourceUrlFromImgproxy(proxyUrl) ?: proxyUrl
+            val isAnimated = com.mezon.mobile.util.isAnimatedImageUrl(absoluteUrlFallback)
+            
+            if (!isAnimated) {
+                val cached = loader.getBitmapFromMemory(proxyUrl, AVATAR_SIZE, AVATAR_SIZE)
+                if (cached != null) {
+                    avatarDrawable.setLoadingPlaceholder(false)
+                    avatarDrawable.setPhoto(cached)
+                    avatarDrawable.setDrawableByInfo(true)
+                    avatarFallbackVisible = true
+                    return
+                }
             }
 
             avatarDrawable.setLoadingPlaceholder(true)
@@ -2230,18 +2247,50 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             avatarFallbackVisible = false
             avatarLoadStartTime = System.currentTimeMillis()
 
-            avatarCancellable = loader.load(proxyUrl, AVATAR_SIZE, AVATAR_SIZE, onSuccess = { bmp ->
+            val successCallback: (Any) -> Unit = { drawable ->
                 avatarDrawable.setLoadingPlaceholder(false)
-                avatarDrawable.setPhoto(bmp)
+                if (drawable is android.graphics.drawable.Animatable) {
+                    avatarDrawable.setAnimatedPhoto(drawable as android.graphics.drawable.Drawable)
+                    avatarDrawable.startAnimation()
+                } else if (drawable is android.graphics.drawable.BitmapDrawable) {
+                    avatarDrawable.setPhoto(drawable.bitmap)
+                } else if (drawable is android.graphics.Bitmap) {
+                    avatarDrawable.setPhoto(drawable)
+                }
                 avatarDrawable.setDrawableByInfo(true)
                 avatarFallbackVisible = true
                 invalidate()
-            }, onError = {
-                avatarDrawable.setLoadingPlaceholder(false)
-                avatarDrawable.setDrawableByInfo(true)
-                avatarFallbackVisible = true
-                invalidate()
-            })
+            }
+
+            val errorCallback: (Throwable) -> Unit = {
+                if (absoluteUrlFallback != proxyUrl) {
+                    avatarCancellable = loader.loadDrawable(
+                        absoluteUrlFallback, AVATAR_SIZE, AVATAR_SIZE, successCallback,
+                        onError = {
+                            avatarDrawable.setLoadingPlaceholder(false)
+                            avatarDrawable.setDrawableByInfo(true)
+                            avatarFallbackVisible = true
+                            invalidate()
+                        }
+                    )
+                } else {
+                    avatarDrawable.setLoadingPlaceholder(false)
+                    avatarDrawable.setDrawableByInfo(true)
+                    avatarFallbackVisible = true
+                    invalidate()
+                }
+            }
+
+            if (isAnimated) {
+                avatarCancellable = loader.loadDrawable(absoluteUrlFallback, AVATAR_SIZE, AVATAR_SIZE, successCallback, {
+                    avatarDrawable.setLoadingPlaceholder(false)
+                    avatarDrawable.setDrawableByInfo(true)
+                    avatarFallbackVisible = true
+                    invalidate()
+                })
+            } else {
+                avatarCancellable = loader.load(proxyUrl, AVATAR_SIZE, AVATAR_SIZE, { bmp -> successCallback(bmp) }, errorCallback)
+            }
         } else {
             avatarDrawable.setPhoto(null)
             avatarDrawable.setDrawableByInfo(true)
@@ -2290,25 +2339,60 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             return
         }
         val proxyUrl = avatarImgproxyUrl(url, REPLY_AVATAR_SIZE)
+        val absoluteUrlFallback = com.mezon.mobile.util.plainSourceUrlFromImgproxy(proxyUrl) ?: proxyUrl
+        val isAnimated = com.mezon.mobile.util.isAnimatedImageUrl(absoluteUrlFallback)
         val loader = MezonImageLoader.getInstance(context)
-        val cached = loader.getBitmapFromMemory(proxyUrl, REPLY_AVATAR_SIZE, REPLY_AVATAR_SIZE)
-        if (cached != null) {
-            replyAvatarDrawable.setLoadingPlaceholder(false)
-            replyAvatarDrawable.setPhoto(cached)
-            replyAvatarDrawable.setDrawableByInfo(true)
-            return
+        
+        if (!isAnimated) {
+            val cached = loader.getBitmapFromMemory(proxyUrl, REPLY_AVATAR_SIZE, REPLY_AVATAR_SIZE)
+            if (cached != null) {
+                replyAvatarDrawable.setLoadingPlaceholder(false)
+                replyAvatarDrawable.setPhoto(cached)
+                replyAvatarDrawable.setDrawableByInfo(true)
+                return
+            }
         }
+        
         replyAvatarDrawable.setLoadingPlaceholder(true)
         replyAvatarDrawable.setDrawableByInfo(true)
-        replyAvatarCancellable = loader.load(proxyUrl, REPLY_AVATAR_SIZE, REPLY_AVATAR_SIZE, onSuccess = { bmp ->
+
+        val successCallback: (Any) -> Unit = { drawable ->
             replyAvatarDrawable.setLoadingPlaceholder(false)
-            replyAvatarDrawable.setPhoto(bmp)
+            if (drawable is android.graphics.drawable.Animatable) {
+                replyAvatarDrawable.setAnimatedPhoto(drawable as android.graphics.drawable.Drawable)
+                replyAvatarDrawable.startAnimation()
+            } else if (drawable is android.graphics.drawable.BitmapDrawable) {
+                replyAvatarDrawable.setPhoto(drawable.bitmap)
+            } else if (drawable is android.graphics.Bitmap) {
+                replyAvatarDrawable.setPhoto(drawable)
+            }
             replyAvatarDrawable.setDrawableByInfo(true)
             invalidate()
-        }, onError = {
-            replyAvatarDrawable.setLoadingPlaceholder(false)
-            replyAvatarDrawable.setDrawableByInfo(true)
-        })
+        }
+
+        val errorCallback: (Throwable) -> Unit = {
+            if (absoluteUrlFallback != proxyUrl) {
+                replyAvatarCancellable = loader.loadDrawable(
+                    absoluteUrlFallback, REPLY_AVATAR_SIZE, REPLY_AVATAR_SIZE, successCallback,
+                    onError = {
+                        replyAvatarDrawable.setLoadingPlaceholder(false)
+                        replyAvatarDrawable.setDrawableByInfo(true)
+                    }
+                )
+            } else {
+                replyAvatarDrawable.setLoadingPlaceholder(false)
+                replyAvatarDrawable.setDrawableByInfo(true)
+            }
+        }
+
+        if (isAnimated) {
+            replyAvatarCancellable = loader.loadDrawable(absoluteUrlFallback, REPLY_AVATAR_SIZE, REPLY_AVATAR_SIZE, successCallback, {
+                replyAvatarDrawable.setLoadingPlaceholder(false)
+                replyAvatarDrawable.setDrawableByInfo(true)
+            })
+        } else {
+            replyAvatarCancellable = loader.load(proxyUrl, REPLY_AVATAR_SIZE, REPLY_AVATAR_SIZE, { bmp -> successCallback(bmp) }, errorCallback)
+        }
     }
 
     private fun loadReplyAnonymousAvatar() {

--- a/app/src/main/java/com/mezon/mobile/home/chat/MezonImageLoader.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/MezonImageLoader.kt
@@ -238,7 +238,11 @@ class MezonImageLoader private constructor(context: Context) {
 
         val baseLogical = stableUrlForDiskAndMemory(url)
         val logicalUrl = if (noCache) "$baseLogical#nocache=${ephemeralIdGen.incrementAndGet()}" else baseLogical
-        val memKey = cacheKey(logicalUrl, reqWidth, reqHeight)
+        val memKey = if (animated && !cacheAnimated) {
+            cacheKey(logicalUrl, reqWidth, reqHeight) + "_${ephemeralIdGen.incrementAndGet()}"
+        } else {
+            cacheKey(logicalUrl, reqWidth, reqHeight)
+        }
 
         if (!animated && !noCache) {
             getFromMemory(memKey)?.let { cached ->

--- a/app/src/main/java/com/mezon/mobile/home/chat/ReactionDetailBottomSheet.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ReactionDetailBottomSheet.kt
@@ -250,8 +250,8 @@ class ReactionDetailBottomSheet(
     }
 
     private inner class SenderViewHolder(val row: LinearLayout) : RecyclerView.ViewHolder(row) {
-        private val avatarView = ImageView(row.context).apply {
-            scaleType = ImageView.ScaleType.CENTER_CROP
+        private val avatarView = com.mezon.mobile.ui.cells.BackupImageView(row.context).apply {
+            setAspectFill(true)
             outlineProvider = object : android.view.ViewOutlineProvider() {
                 override fun getOutline(view: View, outline: android.graphics.Outline) {
                     outline.setOval(0, 0, view.width, view.height)
@@ -294,25 +294,8 @@ class ReactionDetailBottomSheet(
                 member.clanAvatar.ifBlank { member.avatarUrl }
             } else ""
 
-            val loader = MezonImageLoader.getInstance(row.context)
-            val size = LayoutHelper.dp(36)
-            if (avatarUrl.isNotBlank()) {
-                val cached = loader.getBitmapFromMemory(avatarUrl, size, size)
-                if (cached != null) {
-                    avatarView.setImageBitmap(cached)
-                } else {
-                    val ad = AvatarDrawable()
-                    ad.setInfo(sender.senderId, member?.username)
-                    avatarView.setImageDrawable(ad)
-                    loader.load(avatarUrl, size, size, onSuccess = { bmp ->
-                        avatarView.setImageBitmap(bmp)
-                    })
-                }
-            } else {
-                val ad = AvatarDrawable()
-                ad.setInfo(sender.senderId, member?.username)
-                avatarView.setImageDrawable(ad)
-            }
+            val proxyUrl = if (avatarUrl.isNotBlank()) com.mezon.mobile.util.avatarImgproxyUrl(avatarUrl, LayoutHelper.dp(36)) else null
+            avatarView.setImage(proxyUrl, sender.senderId, member?.username ?: "")
         }
     }
 }

--- a/app/src/main/java/com/mezon/mobile/home/chat/TopicRootHeaderView.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/TopicRootHeaderView.kt
@@ -127,7 +127,7 @@ private class TopicRootMetaView(
     private var timeLayout: StaticLayout? = null
     private var avatarDisposable: MezonImageLoader.Cancellable? = null
     private var roleIconDisposable: MezonImageLoader.Cancellable? = null
-    private var roleIconBitmap: android.graphics.Bitmap? = null
+    private var roleIconDrawable: android.graphics.drawable.Drawable? = null
     private var roleIconUrl: String? = null
     private var reserveRoleIcon = false
     private var currentAvatarUrl: String? = null
@@ -206,34 +206,39 @@ private class TopicRootMetaView(
             roleIconDisposable?.cancel()
             roleIconDisposable = null
             roleIconUrl = null
-            roleIconBitmap = null
-            return
-        }
-        if (iconUrl == roleIconUrl && roleIconBitmap != null) return
-        roleIconDisposable?.cancel()
-        roleIconUrl = iconUrl
-        roleIconBitmap = null
-        val loader = MezonImageLoader.getInstance(context)
-        val cached = loader.getBitmapFromMemory(iconUrl, ROLE_ICON_SIZE, ROLE_ICON_SIZE)
-        if (cached != null) {
-            roleIconBitmap = cached
-            rebuildTextLayouts()
+            roleIconDrawable?.callback = null
+            roleIconDrawable = null
             invalidate()
             return
         }
-        roleIconDisposable = loader.load(iconUrl, ROLE_ICON_SIZE, ROLE_ICON_SIZE, onSuccess = { bmp ->
+        if (iconUrl == roleIconUrl && roleIconDrawable != null) return
+        roleIconDisposable?.cancel()
+        roleIconUrl = iconUrl
+        roleIconDrawable?.callback = null
+        roleIconDrawable = null
+
+        val loader = MezonImageLoader.getInstance(context)
+        roleIconDisposable = loader.loadDrawable(iconUrl, ROLE_ICON_SIZE, ROLE_ICON_SIZE, cacheAnimated = true, onSuccess = { drw ->
             if (roleIconUrl == iconUrl) {
-                roleIconBitmap = bmp
+                roleIconDrawable = drw
+                drw.callback = this
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P && drw is android.graphics.drawable.AnimatedImageDrawable) {
+                    drw.start()
+                }
                 rebuildTextLayouts()
                 invalidate()
             }
         }, onError = {
             if (roleIconUrl == iconUrl) {
-                roleIconBitmap = null
-                rebuildTextLayouts()
+                roleIconDrawable?.callback = null
+                roleIconDrawable = null
                 invalidate()
             }
         })
+    }
+
+    override fun verifyDrawable(who: android.graphics.drawable.Drawable): Boolean {
+        return who == roleIconDrawable || super.verifyDrawable(who)
     }
 
     private fun rebuildTextLayouts() {
@@ -287,16 +292,16 @@ private class TopicRootMetaView(
             canvas.translate(textLeft.toFloat(), y)
             it.draw(canvas)
             canvas.restore()
-            if (reserveRoleIcon && roleIconBitmap != null) {
-                val iconX = textLeft + it.getLineWidth(0).toInt() + ROLE_ICON_GAP
-                val iconY = y + (it.height - ROLE_ICON_SIZE) / 2f
+            if (reserveRoleIcon && roleIconDrawable != null) {
+                val ix = textLeft + it.getLineWidth(0).toInt() + ROLE_ICON_GAP
+                val iy = y + (it.height - ROLE_ICON_SIZE) / 2f
                 roleIconRect.set(
-                    iconX.toFloat(),
-                    iconY,
-                    (iconX + ROLE_ICON_SIZE).toFloat(),
-                    iconY + ROLE_ICON_SIZE
+                    ix.toFloat(), iy,
+                    (ix + ROLE_ICON_SIZE).toFloat(), (iy + ROLE_ICON_SIZE).toFloat()
                 )
-                canvas.drawBitmap(roleIconBitmap!!, null, roleIconRect, roleIconPaint)
+                val drw = roleIconDrawable!!
+                drw.setBounds(roleIconRect.left.toInt(), roleIconRect.top.toInt(), roleIconRect.right.toInt(), roleIconRect.bottom.toInt())
+                drw.draw(canvas)
             }
             y += it.height + TIME_GAP
         }

--- a/app/src/main/java/com/mezon/mobile/home/chat/UserProfileBottomSheet.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/UserProfileBottomSheet.kt
@@ -357,23 +357,52 @@ class UserProfileBottomSheet(
         }
         profileAvatarDrawable.setLoadingPlaceholder(true)
         img.setImageDrawable(profileAvatarDrawable)
-        avatarLoadDisposable = loader.load(
-            proxyUrl,
-            size,
-            size,
-            onSuccess = { bmp ->
-                avatarLoadDisposable = null
-                profileAvatarDrawable.setLoadingPlaceholder(false)
-                profileAvatarDrawable.setPhoto(bmp)
-                profileAvatarView?.setImageDrawable(profileAvatarDrawable)
-                backdropColorView?.setBackgroundColor(ColorUtilities.getDominantColor(bmp))
-            },
-            onError = {
+        avatarLoadDisposable?.cancel()
+        val absoluteUrlFallback = com.mezon.mobile.util.plainSourceUrlFromImgproxy(proxyUrl) ?: proxyUrl
+        val isAnimated = com.mezon.mobile.util.isAnimatedImageUrl(absoluteUrlFallback)
+
+        val successCallback: (Any) -> Unit = { result ->
+            avatarLoadDisposable = null
+            profileAvatarDrawable.setLoadingPlaceholder(false)
+            if (result is android.graphics.drawable.Animatable) {
+                profileAvatarDrawable.setAnimatedPhoto(result as android.graphics.drawable.Drawable)
+                profileAvatarDrawable.startAnimation()
+            } else if (result is android.graphics.drawable.BitmapDrawable) {
+                profileAvatarDrawable.setPhoto(result.bitmap)
+                backdropColorView?.setBackgroundColor(ColorUtilities.getDominantColor(result.bitmap))
+            } else if (result is android.graphics.Bitmap) {
+                profileAvatarDrawable.setPhoto(result)
+                backdropColorView?.setBackgroundColor(ColorUtilities.getDominantColor(result))
+            }
+            profileAvatarView?.setImageDrawable(profileAvatarDrawable)
+        }
+
+        val errorCallback: (Throwable) -> Unit = {
+            if (absoluteUrlFallback != proxyUrl) {
+                avatarLoadDisposable = loader.loadDrawable(
+                    absoluteUrlFallback, size, size, successCallback,
+                    onError = {
+                        avatarLoadDisposable = null
+                        profileAvatarDrawable.setLoadingPlaceholder(false)
+                        profileAvatarView?.setImageDrawable(profileAvatarDrawable)
+                    }
+                )
+            } else {
                 avatarLoadDisposable = null
                 profileAvatarDrawable.setLoadingPlaceholder(false)
                 profileAvatarView?.setImageDrawable(profileAvatarDrawable)
             }
-        )
+        }
+
+        if (isAnimated) {
+            avatarLoadDisposable = loader.loadDrawable(absoluteUrlFallback, size, size, successCallback, {
+                avatarLoadDisposable = null
+                profileAvatarDrawable.setLoadingPlaceholder(false)
+                profileAvatarView?.setImageDrawable(profileAvatarDrawable)
+            })
+        } else {
+            avatarLoadDisposable = loader.load(proxyUrl, size, size, { bmp -> successCallback(bmp) }, errorCallback)
+        }
     }
 
     // ─── User Info Card ───────────────────────────────────────────────

--- a/app/src/main/java/com/mezon/mobile/home/chat/WelcomeMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/WelcomeMessageCell.kt
@@ -96,7 +96,7 @@ class WelcomeMessageCell(context: Context, private val theme: ThemeColors) : Vie
         val placeholderKey = avatarPlaceholderKey.ifEmpty { channelName }
         val avatarId = if (avatarUserId != 0L) avatarUserId else channelName.hashCode().toLong()
         loadChannelAvatar(
-            context,
+            this,
             avatarDrawable,
             ChannelAvatarRequest(
                 channelType = channelType,

--- a/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/DmHeaderAvatarView.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/DmHeaderAvatarView.kt
@@ -37,7 +37,7 @@ class DmHeaderAvatarView(context: Context) : View(context) {
 
     private fun bindAvatar() {
         loadChannelAvatar(
-            context,
+            this,
             avatarDrawable,
             ChannelAvatarRequest(
                 channelType = channelType,

--- a/app/src/main/java/com/mezon/mobile/home/clans/UnreadDmCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/UnreadDmCell.kt
@@ -71,7 +71,7 @@ class UnreadDmCell(
 
     private fun loadAvatar(dm: DirectMessage) {
         loadChannelAvatar(
-            context,
+            this,
             avatar,
             ChannelAvatarRequest(
                 channelType = dm.type,

--- a/app/src/main/java/com/mezon/mobile/home/clans/settings/CommunitySettingsFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/settings/CommunitySettingsFragment.kt
@@ -517,9 +517,12 @@ class CommunitySettingsFragment : BaseFragment() {
             }
         }
 
-        fun applyLocalBannerPreview(bitmap: android.graphics.Bitmap, previewUrl: String) {
+        fun applyLocalBannerPreview(drawable: android.graphics.drawable.Drawable, previewUrl: String) {
             lastBannerUrl = previewUrl
-            bannerImageView.setImageBitmap(bitmap)
+            bannerImageView.setImageDrawable(drawable)
+            if (drawable is android.graphics.drawable.AnimatedImageDrawable) {
+                drawable.start()
+            }
             bannerCameraIcon.visibility = View.GONE
             bannerRemoveBtn.visibility = View.VISIBLE
         }
@@ -534,11 +537,13 @@ class CommunitySettingsFragment : BaseFragment() {
             if (hasBanner) {
                 val ctx = bannerImageView.context
                 val h = LayoutHelper.dp(140f)
-                MezonImageLoader.getInstance(ctx).load(previewUrl, 0, h, onSuccess = { bitmap ->
+                val w = com.mezon.mobile.core.AndroidUtilities.displaySize.x
+                MezonImageLoader.getInstance(ctx).loadDrawable(previewUrl, w, h, onSuccess = { drawable ->
                     if (lastBannerUrl == previewUrl) {
-                        bannerImageView.setImageBitmap(bitmap)
+                        bannerImageView.setImageDrawable(drawable)
+                        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P && drawable is android.graphics.drawable.AnimatedImageDrawable) drawable.start()
                     }
-                })
+                }, cacheAnimated = true)
             } else {
                 bannerImageView.setImageDrawable(null)
             }
@@ -659,8 +664,8 @@ class CommunitySettingsFragment : BaseFragment() {
                         MezonToast.show(this@CommunitySettingsFragment, ToastOverlay.ToastType.ERROR, getString(R.string.community_settings_error_banner))
                     is BannerLoadResult.Ok -> {
                         controller.onBannerPicked(result.bytes, result.mimeType, result.ext, previewUri)
-                        result.bitmap?.let { bmp ->
-                            formHolder?.applyLocalBannerPreview(bmp, previewUri)
+                        result.drawable?.let { d ->
+                            formHolder?.applyLocalBannerPreview(d, previewUri)
                         }
                     }
                 }
@@ -682,18 +687,44 @@ class CommunitySettingsFragment : BaseFragment() {
             val ext = when (mimeType) {
                 "image/png" -> "png"
                 "image/webp" -> "webp"
+                "image/gif" -> "gif"
                 else -> "jpg"
             }
-            val boundsOpts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-            BitmapFactory.decodeByteArray(bytes, 0, bytes.size, boundsOpts)
-            val maxEdgePx = maxOf(boundsOpts.outWidth, boundsOpts.outHeight)
-            var sample = 1
-            while (maxEdgePx / sample > MAX_BANNER_DECODE_EDGE) {
-                sample *= 2
+            
+            var drawable: android.graphics.drawable.Drawable? = null
+            val isAnimated = mimeType == "image/gif" || mimeType == "image/webp"
+            if (isAnimated && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+                try {
+                    val source = android.graphics.ImageDecoder.createSource(java.nio.ByteBuffer.wrap(bytes))
+                    drawable = android.graphics.ImageDecoder.decodeDrawable(source) { decoder, info, _ ->
+                        val maxW = com.mezon.mobile.core.AndroidUtilities.displaySize.x
+                        val maxH = LayoutHelper.dp(140f)
+                        if (maxW > 0 && maxH > 0) {
+                            val scale = Math.max(maxW.toFloat() / info.size.width, maxH.toFloat() / info.size.height)
+                            if (scale < 1f) {
+                                decoder.setTargetSize((info.size.width * scale).toInt(), (info.size.height * scale).toInt())
+                            }
+                        }
+                    }
+                } catch (_: Exception) {
+                }
             }
-            val decodeOpts = BitmapFactory.Options().apply { inSampleSize = sample }
-            val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size, decodeOpts)
-            BannerLoadResult.Ok(bytes, mimeType, ext, bitmap)
+
+            if (drawable == null) {
+                val boundsOpts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+                BitmapFactory.decodeByteArray(bytes, 0, bytes.size, boundsOpts)
+                val maxEdgePx = maxOf(boundsOpts.outWidth, boundsOpts.outHeight)
+                var sample = 1
+                while (maxEdgePx / sample > MAX_BANNER_DECODE_EDGE) {
+                    sample *= 2
+                }
+                val decodeOpts = BitmapFactory.Options().apply { inSampleSize = sample }
+                val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size, decodeOpts)
+                if (bitmap != null) {
+                    drawable = android.graphics.drawable.BitmapDrawable(ctx.resources, bitmap)
+                }
+            }
+            BannerLoadResult.Ok(bytes, mimeType, ext, drawable)
         } catch (_: Exception) {
             BannerLoadResult.Failed
         }
@@ -707,7 +738,7 @@ class CommunitySettingsFragment : BaseFragment() {
             val bytes: ByteArray,
             val mimeType: String,
             val ext: String,
-            val bitmap: android.graphics.Bitmap?,
+            val drawable: android.graphics.drawable.Drawable?,
         ) : BannerLoadResult
     }
 }

--- a/app/src/main/java/com/mezon/mobile/home/clans/settings/CommunitySettingsFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/settings/CommunitySettingsFragment.kt
@@ -520,7 +520,7 @@ class CommunitySettingsFragment : BaseFragment() {
         fun applyLocalBannerPreview(drawable: android.graphics.drawable.Drawable, previewUrl: String) {
             lastBannerUrl = previewUrl
             bannerImageView.setImageDrawable(drawable)
-            if (drawable is android.graphics.drawable.AnimatedImageDrawable) {
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P && drawable is android.graphics.drawable.AnimatedImageDrawable) {
                 drawable.start()
             }
             bannerCameraIcon.visibility = View.GONE

--- a/app/src/main/java/com/mezon/mobile/home/clans/settings/EmojiSettingFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/settings/EmojiSettingFragment.kt
@@ -482,6 +482,30 @@ class EmojiSettingFragment : BaseFragment() {
         }
         dialog.show()
         fragmentScope.launch {
+            if (isGif && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                val drawable = withContext(ioDispatcher) {
+                    try {
+                        val source = ImageDecoder.createSource(file)
+                        ImageDecoder.decodeDrawable(source) { decoder, _, _ ->
+                            decoder.setTargetSize(previewSide, previewSide)
+                        }
+                    } catch (_: Exception) {
+                        null
+                    }
+                }
+                if (drawable != null) {
+                    withContext(mainDispatcher) {
+                        if (!isFinished && previewIv.isAttachedToWindow) {
+                            previewIv.setImageDrawable(drawable)
+                            if (drawable is android.graphics.drawable.AnimatedImageDrawable) {
+                                drawable.start()
+                            }
+                        }
+                    }
+                    return@launch
+                }
+            }
+
             val bmp = withContext(ioDispatcher) {
                 decodePreviewBitmap(file, previewSide, isGif)
             } ?: return@launch

--- a/app/src/main/java/com/mezon/mobile/home/clans/settings/RoleDetailFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/settings/RoleDetailFragment.kt
@@ -83,7 +83,7 @@ class RoleDetailFragment : BaseFragment() {
     private lateinit var colorChevron: ImageView
     private lateinit var colorLock: ImageView
     private lateinit var deleteBtn: TextView
-    private lateinit var iconAvatar: AvatarView
+    private lateinit var iconAvatar: com.mezon.mobile.ui.cells.CdnIconView
     private lateinit var iconPlaceholder: ImageView
     private lateinit var iconRemoveBtn: TextView
     private lateinit var iconLock: ImageView
@@ -373,9 +373,9 @@ class RoleDetailFragment : BaseFragment() {
             setPadding(LayoutHelper.dp(12f), LayoutHelper.dp(12f), LayoutHelper.dp(12f), LayoutHelper.dp(12f))
         }
         iconPickerHit.addView(iconPlaceholder, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT))
-        iconAvatar = AvatarView(context).apply {
+        iconAvatar = com.mezon.mobile.ui.cells.CdnIconView(context, themeColors).apply {
             setSizeDp(50)
-            setRoundRadius(25f)
+            setCircular(true)
             visibility = View.GONE
         }
         iconPickerHit.addView(iconAvatar, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT))
@@ -460,7 +460,6 @@ class RoleDetailFragment : BaseFragment() {
         applyDetailEditableState(role)
         updateSaveActionState(role)
         refreshColorRowUi()
-        iconAvatar.setInfo(role.roleId, role.title)
         refreshIconPreview()
         refreshRemoveIconVisibility()
     }
@@ -756,8 +755,6 @@ class RoleDetailFragment : BaseFragment() {
         iconPlaceholder.visibility = if (hasIcon) View.GONE else View.VISIBLE
         iconAvatar.visibility = if (hasIcon) View.VISIBLE else View.GONE
         if (hasIcon) {
-            val r = roleController.getRole(clanId, roleId)
-            iconAvatar.setInfo(r?.roleId ?: roleId, r?.title ?: draftName)
             iconAvatar.setImageUrl(draftIconUrl)
         } else {
             iconAvatar.setImageUrl(null)

--- a/app/src/main/java/com/mezon/mobile/home/clans/settings/StickerSettingsFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/settings/StickerSettingsFragment.kt
@@ -372,6 +372,30 @@ class StickerSettingsFragment : BaseFragment() {
         dialog.show()
 
         fragmentScope.launch {
+            if (isGif && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                val drawable = withContext(ioDispatcher) {
+                    try {
+                        val source = ImageDecoder.createSource(file)
+                        ImageDecoder.decodeDrawable(source) { decoder, _, _ ->
+                            decoder.setTargetSize(previewSide, previewSide)
+                        }
+                    } catch (_: Exception) {
+                        null
+                    }
+                }
+                if (drawable != null) {
+                    withContext(mainDispatcher) {
+                        if (!isFinished && previewIv.isAttachedToWindow) {
+                            previewIv.setImageDrawable(drawable)
+                            if (drawable is android.graphics.drawable.AnimatedImageDrawable) {
+                                drawable.start()
+                            }
+                        }
+                    }
+                    return@launch
+                }
+            }
+
             val bmp = withContext(ioDispatcher) {
                 try {
                     val bytes = file.readBytes()
@@ -735,12 +759,16 @@ class StickerSettingsFragment : BaseFragment() {
                     "${BuildConfig.MEZON_BASE_IMG_URL}/stickers/${sticker.id}.webp"
                 }
                 val loadSize = LayoutHelper.dp(110f)
-                MezonImageLoader.getInstance(ctx).load(
+                MezonImageLoader.getInstance(ctx).loadDrawable(
                     displayUrl,
                     loadSize,
                     loadSize,
-                    onSuccess = { bmp -> views.imageView.setImageBitmap(bmp) },
+                    onSuccess = { d -> 
+                        views.imageView.setImageDrawable(d)
+                        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P && d is android.graphics.drawable.AnimatedImageDrawable) d.start()
+                    },
                     onError = { _ -> views.imageView.setImageDrawable(null) },
+                    cacheAnimated = true
                 )
 
                 if (row.canManage) {

--- a/app/src/main/java/com/mezon/mobile/home/clans/settings/WebhookEditFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/settings/WebhookEditFragment.kt
@@ -504,11 +504,17 @@ class WebhookEditFragment : BaseFragment() {
         val ctx = avatarView.context
         val s = LayoutHelper.dp(100f)
         if (draftAvatar.isNotBlank()) {
-            avatarLoadDisposable = MezonImageLoader.getInstance(ctx).load(
+            avatarLoadDisposable = MezonImageLoader.getInstance(ctx).loadDrawable(
                 draftAvatar,
                 s,
                 s,
-                onSuccess = { bmp -> avatarView.setImageBitmap(bmp) },
+                cacheAnimated = true,
+                onSuccess = { drawable ->
+                    avatarView.setImageDrawable(drawable)
+                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P && drawable is android.graphics.drawable.AnimatedImageDrawable) {
+                        drawable.start()
+                    }
+                },
                 onError = { avatarView.setImageDrawable(null) },
             )
         } else {

--- a/app/src/main/java/com/mezon/mobile/home/clans/settings/WebhooksListFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/settings/WebhooksListFragment.kt
@@ -404,11 +404,17 @@ class WebhooksListFragment : BaseFragment() {
             }
         }
         if (avatarUrl.isNotBlank()) {
-            MezonImageLoader.getInstance(ctx).load(
+            MezonImageLoader.getInstance(ctx).loadDrawable(
                 avatarUrl,
                 w50,
                 w50,
-                onSuccess = { bmp -> img.setImageBitmap(bmp) },
+                cacheAnimated = true,
+                onSuccess = { drawable ->
+                    img.setImageDrawable(drawable)
+                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P && drawable is android.graphics.drawable.AnimatedImageDrawable) {
+                        drawable.start()
+                    }
+                },
                 onError = {
                     img.setImageDrawable(null)
                     img.background = android.graphics.drawable.GradientDrawable().apply {

--- a/app/src/main/java/com/mezon/mobile/home/messages/ChannelAvatarLoader.kt
+++ b/app/src/main/java/com/mezon/mobile/home/messages/ChannelAvatarLoader.kt
@@ -1,10 +1,13 @@
 package com.mezon.mobile.home.messages
 
 import android.content.Context
+import android.graphics.drawable.Animatable
+import android.graphics.drawable.BitmapDrawable
 import com.mezon.mobile.core.AvatarDrawable
 import com.mezon.mobile.home.chat.MezonImageLoader
 import com.mezon.mobile.network.CHANNEL_TYPE_GROUP
 import com.mezon.mobile.util.avatarImgproxyUrl
+import com.mezon.mobile.util.isAnimatedImageUrl
 
 data class ChannelAvatarRequest(
     val channelType: Int,
@@ -76,18 +79,52 @@ fun loadChannelAvatar(
 
     avatarDrawable.setLoadingPlaceholder(true)
     val expectedKey = proxyUrl
-    state.disposable = loader.load(
-        proxyUrl, request.sizePx, request.sizePx,
-        onSuccess = { bmp ->
-            if (state.loadKey != expectedKey) return@load
+
+    val absoluteUrlFallback = com.mezon.mobile.util.plainSourceUrlFromImgproxy(proxyUrl) ?: proxyUrl
+    val isAnimated = isAnimatedImageUrl(absoluteUrlFallback)
+
+    val successCallback: (Any) -> Unit = { result ->
+        if (state.loadKey == expectedKey) {
             avatarDrawable.setLoadingPlaceholder(false)
-            avatarDrawable.setPhoto(bmp)
-            onInvalidate()
-        },
-        onError = {
-            if (state.loadKey != expectedKey) return@load
-            avatarDrawable.setLoadingPlaceholder(false)
+            if (result is android.graphics.drawable.Animatable) {
+                avatarDrawable.setAnimatedPhoto(result as android.graphics.drawable.Drawable)
+                avatarDrawable.startAnimation()
+            } else if (result is android.graphics.drawable.BitmapDrawable) {
+                avatarDrawable.setPhoto(result.bitmap)
+            } else if (result is android.graphics.Bitmap) {
+                avatarDrawable.setPhoto(result)
+            }
             onInvalidate()
         }
-    )
+    }
+
+    val errorCallback: (Throwable) -> Unit = {
+        if (absoluteUrlFallback != proxyUrl) {
+            state.disposable = loader.loadDrawable(
+                absoluteUrlFallback, request.sizePx, request.sizePx, successCallback,
+                onError = {
+                    if (state.loadKey == expectedKey) {
+                        avatarDrawable.setLoadingPlaceholder(false)
+                        onInvalidate()
+                    }
+                }
+            )
+        } else {
+            if (state.loadKey == expectedKey) {
+                avatarDrawable.setLoadingPlaceholder(false)
+                onInvalidate()
+            }
+        }
+    }
+
+    if (isAnimated) {
+        state.disposable = loader.loadDrawable(absoluteUrlFallback, request.sizePx, request.sizePx, successCallback, {
+            if (state.loadKey == expectedKey) {
+                avatarDrawable.setLoadingPlaceholder(false)
+                onInvalidate()
+            }
+        })
+    } else {
+        state.disposable = loader.load(proxyUrl, request.sizePx, request.sizePx, { bmp -> successCallback(bmp) }, errorCallback)
+    }
 }

--- a/app/src/main/java/com/mezon/mobile/home/messages/ChannelAvatarLoader.kt
+++ b/app/src/main/java/com/mezon/mobile/home/messages/ChannelAvatarLoader.kt
@@ -9,6 +9,8 @@ import com.mezon.mobile.network.CHANNEL_TYPE_GROUP
 import com.mezon.mobile.util.avatarImgproxyUrl
 import com.mezon.mobile.util.isAnimatedImageUrl
 
+import android.view.View
+
 data class ChannelAvatarRequest(
     val channelType: Int,
     val avatarUrl: String,
@@ -28,20 +30,21 @@ class ChannelAvatarLoadState {
 }
 
 fun loadChannelAvatar(
-    context: Context,
+    hostView: View,
     avatarDrawable: AvatarDrawable,
     request: ChannelAvatarRequest,
     state: ChannelAvatarLoadState,
     attached: Boolean,
     onInvalidate: () -> Unit
 ) {
+    avatarDrawable.attachToView(hostView)
     avatarDrawable.setInfo(request.avatarId, request.placeholderKey)
 
     if (request.channelType == CHANNEL_TYPE_GROUP && isDefaultGroupAvatarUrl(request.avatarUrl)) {
         if (state.loadKey == GroupAvatar.DEFAULT_LOAD_KEY && avatarDrawable.hasPhoto()) return
         state.cancel()
         state.loadKey = GroupAvatar.DEFAULT_LOAD_KEY
-        avatarDrawable.setPhoto(GroupAvatar.bitmap(context))
+        avatarDrawable.setPhoto(GroupAvatar.bitmap(hostView.context))
         onInvalidate()
         return
     }
@@ -64,7 +67,7 @@ fun loadChannelAvatar(
     state.cancel()
     state.loadKey = proxyUrl
 
-    val loader = MezonImageLoader.getInstance(context)
+    val loader = MezonImageLoader.getInstance(hostView.context)
     val cached = loader.getBitmapFromMemory(proxyUrl, request.sizePx, request.sizePx)
     if (cached != null) {
         avatarDrawable.setPhoto(cached)

--- a/app/src/main/java/com/mezon/mobile/home/messages/DialogCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/messages/DialogCell.kt
@@ -211,7 +211,7 @@ class DialogCell(context: Context, private val theme: ThemeColors) : BaseCell(co
 
     private fun loadAvatar(dm: DirectMessage) {
         loadChannelAvatar(
-            context,
+            this,
             avatarDrawable,
             ChannelAvatarRequest(
                 channelType = dm.type,

--- a/app/src/main/java/com/mezon/mobile/home/messages/DialogCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/messages/DialogCell.kt
@@ -19,7 +19,7 @@ class DialogCell(context: Context, private val theme: ThemeColors) : BaseCell(co
         private set
     var hasBuzz = false
 
-    private val avatarDrawable = AvatarDrawable()
+    private val avatarDrawable = AvatarDrawable().also { it.attachToView(this) }
     private val avatarLoadState = ChannelAvatarLoadState()
     private var attachedToWindow = false
     private var needsLayout = false
@@ -42,11 +42,13 @@ class DialogCell(context: Context, private val theme: ThemeColors) : BaseCell(co
             invalidate()
         }
         directMessage?.let { loadAvatar(it) }
+        avatarDrawable.startAnimation()
     }
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         attachedToWindow = false
+        avatarDrawable.stopAnimation()
         avatarLoadState.cancel()
     }
 

--- a/app/src/main/java/com/mezon/mobile/home/sharing/SharingTargetCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/sharing/SharingTargetCell.kt
@@ -71,7 +71,7 @@ class SharingTargetCell(context: Context, private val theme: ThemeColors) : View
             t.channelLabel
         }
         loadChannelAvatar(
-            context,
+            this,
             avatarDrawable,
             ChannelAvatarRequest(
                 channelType = t.channelType,

--- a/app/src/main/java/com/mezon/mobile/home/voice/ReactionOverlayView.kt
+++ b/app/src/main/java/com/mezon/mobile/home/voice/ReactionOverlayView.kt
@@ -13,6 +13,7 @@ import android.text.TextUtils
 import android.view.View
 import android.view.animation.LinearInterpolator
 import android.view.animation.PathInterpolator
+import android.graphics.drawable.Drawable
 import com.mezon.mobile.core.LayoutHelper
 import com.mezon.mobile.home.chat.MezonImageLoader
 import com.mezon.mobile.util.getEmojiUrl
@@ -70,7 +71,7 @@ class ReactionOverlayView(context: Context) : View(context) {
         var currentY: Float,
         var alpha: Float,
         var scale: Float,
-        var bitmap: Bitmap? = null,
+        var drawable: Drawable? = null,
         var displayName: String? = null
     )
 
@@ -143,7 +144,7 @@ class ReactionOverlayView(context: Context) : View(context) {
             if (trimmedName != null) {
                 fe.displayName = TextUtils.ellipsize(trimmedName, namePaint, NAME_MAX_WIDTH, TextUtils.TruncateAt.END).toString()
             }
-            loadEmojiBitmapIfNeeded(fe)
+            loadEmojiDrawableIfNeeded(fe)
             activeEmojis.add(fe)
         }
         ensureTickerRunning()
@@ -176,6 +177,8 @@ class ReactionOverlayView(context: Context) : View(context) {
             val fe = iter.next()
             val elapsed = now - fe.spawnTime
             if (elapsed >= ANIMATION_DURATION_MS) {
+                (fe.drawable as? android.graphics.drawable.Animatable)?.stop()
+                fe.drawable?.callback = null
                 iter.remove()
                 continue
             }
@@ -233,18 +236,18 @@ class ReactionOverlayView(context: Context) : View(context) {
             val fe = activeEmojis[i]
             if (fe.alpha <= 0f) continue
             val alphaInt = (fe.alpha * 255f).toInt().coerceIn(0, 255)
-            val bitmap = fe.bitmap
+            val drawable = fe.drawable
             val scaledHalf = EMOJI_BITMAP_SIZE * fe.scale * 0.5f
             var emojiDrawn = false
-            if (bitmap != null) {
-                bitmapPaint.alpha = alphaInt
-                tmpDstRect.set(
-                    fe.x - scaledHalf,
-                    fe.currentY - scaledHalf,
-                    fe.x + scaledHalf,
-                    fe.currentY + scaledHalf
+            if (drawable != null) {
+                drawable.alpha = alphaInt
+                drawable.setBounds(
+                    (fe.x - scaledHalf).toInt(),
+                    (fe.currentY - scaledHalf).toInt(),
+                    (fe.x + scaledHalf).toInt(),
+                    (fe.currentY + scaledHalf).toInt()
                 )
-                canvas.drawBitmap(bitmap, null, tmpDstRect, bitmapPaint)
+                drawable.draw(canvas)
                 emojiDrawn = true
             } else if (!fe.isServerEmojiId) {
                 emojiPaint.alpha = alphaInt
@@ -263,6 +266,10 @@ class ReactionOverlayView(context: Context) : View(context) {
 
     fun cancelAll() {
         stopTicker()
+        for (fe in activeEmojis) {
+            (fe.drawable as? android.graphics.drawable.Animatable)?.stop()
+            fe.drawable?.callback = null
+        }
         activeEmojis.clear()
         pendingEmojis.clear()
         invalidate()
@@ -273,23 +280,49 @@ class ReactionOverlayView(context: Context) : View(context) {
         cancelAll()
     }
 
-    private fun loadEmojiBitmapIfNeeded(fe: FloatingEmoji) {
+    private val animationCallback = object : Drawable.Callback {
+        override fun invalidateDrawable(who: Drawable) {
+            invalidate()
+        }
+        override fun scheduleDrawable(who: Drawable, what: Runnable, `when`: Long) {
+            postDelayed(what, `when` - SystemClock.uptimeMillis())
+        }
+        override fun unscheduleDrawable(who: Drawable, what: Runnable) {
+            removeCallbacks(what)
+        }
+    }
+
+    private fun loadEmojiDrawableIfNeeded(fe: FloatingEmoji) {
         if (!fe.isServerEmojiId) return
         val url = getEmojiUrl(fe.emoji) ?: return
         val loader = MezonImageLoader.getInstance(context)
-        val cached = loader.getBitmapFromMemory(url, EMOJI_BITMAP_SIZE, EMOJI_BITMAP_SIZE)
-        if (cached != null) {
-            fe.bitmap = cached
-            return
+
+        fun load(loadUrl: String, isRetry: Boolean) {
+            loader.loadDrawable(
+                loadUrl,
+                EMOJI_BITMAP_SIZE,
+                EMOJI_BITMAP_SIZE,
+                onSuccess = { drawable ->
+                    if (!activeEmojis.contains(fe)) return@loadDrawable
+                    if (drawable is android.graphics.drawable.Animatable) {
+                        drawable.callback = animationCallback
+                        drawable.start()
+                    }
+                    fe.drawable = drawable
+                    invalidate()
+                },
+                onError = {
+                    if (!isRetry) {
+                        val direct = com.mezon.mobile.util.getEmojiDirectUrl(fe.emoji)
+                        if (direct != null && direct != loadUrl) {
+                            load(direct, true)
+                        }
+                    }
+                },
+                cacheAnimated = false
+            )
         }
-        loader.load(
-            url,
-            EMOJI_BITMAP_SIZE,
-            EMOJI_BITMAP_SIZE,
-            onSuccess = { bmp ->
-                fe.bitmap = bmp
-                invalidate()
-            }
-        )
+
+        load(url, false)
     }
 }

--- a/app/src/main/java/com/mezon/mobile/ui/cells/AvatarView.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/cells/AvatarView.kt
@@ -7,10 +7,11 @@ import com.mezon.mobile.core.AvatarDrawable
 import com.mezon.mobile.core.LayoutHelper
 import com.mezon.mobile.home.chat.MezonImageLoader
 import com.mezon.mobile.util.avatarImgproxyUrl
+import com.mezon.mobile.util.isAnimatedImageUrl
 
 class AvatarView(context: Context) : View(context) {
 
-    private val avatarDrawable = AvatarDrawable()
+    private val avatarDrawable = AvatarDrawable().also { it.attachToView(this) }
     private var sizeDp = 40
     private var currentUrl: String? = null
     private var cancellable: MezonImageLoader.Cancellable? = null
@@ -48,23 +49,55 @@ class AvatarView(context: Context) : View(context) {
     }
 
     private fun loadImage(url: String) {
+        cancellable?.cancel()
         val sizePx = LayoutHelper.dp(sizeDp)
         val proxyUrl = avatarImgproxyUrl(url, sizePx)
         avatarDrawable.setLoadingPlaceholder(true)
-        cancellable = MezonImageLoader.getInstance(context).load(
-            proxyUrl, sizePx, sizePx,
-            onSuccess = { bmp ->
-                cancellable = null
-                avatarDrawable.setLoadingPlaceholder(false)
-                avatarDrawable.setPhoto(bmp)
-                invalidate()
-            },
-            onError = {
+        val loader = MezonImageLoader.getInstance(context)
+        
+        val absoluteUrlFallback = com.mezon.mobile.util.plainSourceUrlFromImgproxy(proxyUrl) ?: proxyUrl
+        val isAnimated = isAnimatedImageUrl(absoluteUrlFallback)
+
+        val successCallback: (Any) -> Unit = { result ->
+            cancellable = null
+            avatarDrawable.setLoadingPlaceholder(false)
+            if (result is android.graphics.drawable.Animatable) {
+                avatarDrawable.setAnimatedPhoto(result as android.graphics.drawable.Drawable)
+                avatarDrawable.startAnimation()
+            } else if (result is android.graphics.drawable.BitmapDrawable) {
+                avatarDrawable.setPhoto(result.bitmap)
+            } else if (result is android.graphics.Bitmap) {
+                avatarDrawable.setPhoto(result)
+            }
+            invalidate()
+        }
+
+        val errorCallback: (Throwable) -> Unit = {
+            if (absoluteUrlFallback != proxyUrl) {
+                cancellable = loader.loadDrawable(
+                    absoluteUrlFallback, sizePx, sizePx, successCallback,
+                    onError = {
+                        cancellable = null
+                        avatarDrawable.setLoadingPlaceholder(false)
+                        invalidate()
+                    }
+                )
+            } else {
                 cancellable = null
                 avatarDrawable.setLoadingPlaceholder(false)
                 invalidate()
             }
-        )
+        }
+
+        if (isAnimated) {
+            cancellable = loader.loadDrawable(absoluteUrlFallback, sizePx, sizePx, successCallback, {
+                cancellable = null
+                avatarDrawable.setLoadingPlaceholder(false)
+                invalidate()
+            })
+        } else {
+            cancellable = loader.load(proxyUrl, sizePx, sizePx, { bmp -> successCallback(bmp) }, errorCallback)
+        }
     }
 
     fun setPhoto(bitmap: android.graphics.Bitmap?) {
@@ -81,11 +114,13 @@ class AvatarView(context: Context) : View(context) {
         if (url != null && cancellable == null && !avatarDrawable.hasPhoto()) {
             loadImage(url)
         }
+        avatarDrawable.startAnimation()
     }
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         attachedToWindow = false
+        avatarDrawable.stopAnimation()
         cancellable?.cancel()
         cancellable = null
     }

--- a/app/src/main/java/com/mezon/mobile/ui/cells/BackupImageView.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/cells/BackupImageView.kt
@@ -111,6 +111,7 @@ class BackupImageView(context: Context) : View(context) {
         cancellable?.cancel()
         cancellable = null
         imageUrl = null
+        loadedDrawable?.callback = null
         loadedDrawable = context.resources.getDrawable(resId, null)
         invalidate()
     }
@@ -119,6 +120,7 @@ class BackupImageView(context: Context) : View(context) {
         cancellable?.cancel()
         cancellable = null
         imageUrl = null
+        loadedDrawable?.callback = null
         loadedDrawable = drawable
         invalidate()
     }
@@ -131,17 +133,53 @@ class BackupImageView(context: Context) : View(context) {
         cancellable?.cancel()
         val w = if (decodeWidth > 0) decodeWidth else measuredWidth.coerceAtLeast(LayoutHelper.dp(48))
         val h = if (decodeHeight > 0) decodeHeight else measuredHeight.coerceAtLeast(LayoutHelper.dp(48))
-        cancellable = MezonImageLoader.getInstance(context).load(
-            url, w, h,
-            onSuccess = { bmp ->
-                loadedDrawable = BitmapDrawable(context.resources, bmp)
-                invalidate()
-            },
-            onError = {
+        val proxyUrl = url
+        val absoluteUrlFallback = com.mezon.mobile.util.plainSourceUrlFromImgproxy(proxyUrl) ?: proxyUrl
+        val isAnimated = com.mezon.mobile.util.isAnimatedImageUrl(absoluteUrlFallback)
+        val loader = MezonImageLoader.getInstance(context)
+
+        val successCallback: (Any) -> Unit = { result ->
+            loadedDrawable?.callback = null
+            if (result is android.graphics.drawable.Animatable) {
+                loadedDrawable = result as android.graphics.drawable.Drawable
+                loadedDrawable?.callback = drawableCallback
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P && loadedDrawable is android.graphics.drawable.AnimatedImageDrawable) {
+                    (loadedDrawable as android.graphics.drawable.AnimatedImageDrawable).start()
+                }
+            } else if (result is android.graphics.drawable.BitmapDrawable) {
+                loadedDrawable = result
+            } else if (result is android.graphics.Bitmap) {
+                loadedDrawable = BitmapDrawable(context.resources, result)
+            }
+            invalidate()
+        }
+
+        val errorCallback: (Throwable) -> Unit = {
+            if (absoluteUrlFallback != proxyUrl) {
+                cancellable = loader.loadDrawable(
+                    absoluteUrlFallback, w, h, successCallback,
+                    onError = {
+                        loadedDrawable?.callback = null
+                        loadedDrawable = null
+                        invalidate()
+                    }
+                )
+            } else {
+                loadedDrawable?.callback = null
                 loadedDrawable = null
                 invalidate()
             }
-        )
+        }
+
+        if (isAnimated) {
+            cancellable = loader.loadDrawable(absoluteUrlFallback, w, h, successCallback, {
+                loadedDrawable?.callback = null
+                loadedDrawable = null
+                invalidate()
+            })
+        } else {
+            cancellable = loader.load(proxyUrl, w, h, { bmp -> successCallback(bmp) }, errorCallback)
+        }
     }
 
     override fun onAttachedToWindow() {
@@ -244,5 +282,21 @@ class BackupImageView(context: Context) : View(context) {
         super.onInitializeAccessibilityNodeInfo(info)
         info.className = "android.widget.ImageView"
         contentDescription?.let { info.contentDescription = it }
+    }
+
+    private val drawableCallback = object : android.graphics.drawable.Drawable.Callback {
+        override fun invalidateDrawable(who: android.graphics.drawable.Drawable) {
+            invalidate()
+        }
+        override fun scheduleDrawable(who: android.graphics.drawable.Drawable, what: Runnable, `when`: Long) {
+            postDelayed(what, `when` - android.os.SystemClock.uptimeMillis())
+        }
+        override fun unscheduleDrawable(who: android.graphics.drawable.Drawable, what: Runnable) {
+            removeCallbacks(what)
+        }
+    }
+
+    override fun verifyDrawable(who: android.graphics.drawable.Drawable): Boolean {
+        return who == loadedDrawable || super.verifyDrawable(who)
     }
 }

--- a/app/src/main/java/com/mezon/mobile/ui/cells/CdnIconView.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/cells/CdnIconView.kt
@@ -2,11 +2,9 @@ package com.mezon.mobile.ui.cells
 
 import android.content.Context
 import android.graphics.Bitmap
-import android.graphics.BitmapShader
 import android.graphics.Canvas
-import android.graphics.Matrix
 import android.graphics.Paint
-import android.graphics.Shader
+import android.os.SystemClock
 import android.view.View
 import com.mezon.mobile.core.LayoutHelper
 import com.mezon.mobile.core.ThemeColors
@@ -14,21 +12,25 @@ import com.mezon.mobile.home.chat.MezonImageLoader
 
 class CdnIconView(context: Context, private val theme: ThemeColors) : View(context) {
 
-    private val paint = Paint(Paint.ANTI_ALIAS_FLAG)
+    private var drawable: android.graphics.drawable.Drawable? = null
     private val placeholderPaint = Paint(Paint.ANTI_ALIAS_FLAG)
-    private var bitmap: Bitmap? = null
     private var sizeDp = 24
     private var isCircular = false
     private var currentUrl: String? = null
     private var cancellable: MezonImageLoader.Cancellable? = null
     private var attachedToWindow = false
 
-    private var cachedShader: BitmapShader? = null
-    private var cachedShaderBitmap: Bitmap? = null
-    private var cachedShaderWidth = 0
-    private val shaderMatrix = Matrix()
-    private val srcRect = android.graphics.Rect()
-    private val dstRect = android.graphics.Rect()
+    private val drawableCallback = object : android.graphics.drawable.Drawable.Callback {
+        override fun invalidateDrawable(who: android.graphics.drawable.Drawable) {
+            invalidate()
+        }
+        override fun scheduleDrawable(who: android.graphics.drawable.Drawable, what: Runnable, `when`: Long) {
+            postDelayed(what, `when` - SystemClock.uptimeMillis())
+        }
+        override fun unscheduleDrawable(who: android.graphics.drawable.Drawable, what: Runnable) {
+            removeCallbacks(what)
+        }
+    }
 
     fun setSizeDp(dp: Int) {
         sizeDp = dp
@@ -45,9 +47,8 @@ class CdnIconView(context: Context, private val theme: ThemeColors) : View(conte
         currentUrl = url
         cancellable?.cancel()
         cancellable = null
-        bitmap = null
-        cachedShader = null
-        cachedShaderBitmap = null
+        drawable?.callback = null
+        drawable = null
         if (url.isNullOrEmpty()) {
             invalidate()
             return
@@ -58,27 +59,33 @@ class CdnIconView(context: Context, private val theme: ThemeColors) : View(conte
 
     private fun loadImage(url: String) {
         val px = LayoutHelper.dp(sizeDp)
-        cancellable = MezonImageLoader.getInstance(context).load(
+        cancellable = MezonImageLoader.getInstance(context).loadDrawable(
             url, px, px,
-            onSuccess = { bmp ->
-                bitmap = bmp
-                cachedShader = null
-                cachedShaderBitmap = null
+            cacheAnimated = true,
+            onSuccess = { drw ->
+                drawable?.callback = null
+                drawable = drw
+                drw.callback = drawableCallback
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P && drw is android.graphics.drawable.AnimatedImageDrawable) {
+                    drw.start()
+                }
                 invalidate()
             },
             onError = {
-                bitmap = null
-                cachedShader = null
-                cachedShaderBitmap = null
+                drawable?.callback = null
+                drawable = null
                 invalidate()
             }
         )
     }
 
     fun setBitmap(bmp: Bitmap?) {
-        bitmap = bmp
-        cachedShader = null
-        cachedShaderBitmap = null
+        drawable?.callback = null
+        if (bmp != null) {
+            drawable = android.graphics.drawable.BitmapDrawable(resources, bmp)
+        } else {
+            drawable = null
+        }
         invalidate()
     }
 
@@ -86,7 +93,7 @@ class CdnIconView(context: Context, private val theme: ThemeColors) : View(conte
         super.onAttachedToWindow()
         attachedToWindow = true
         val url = currentUrl
-        if (url != null && bitmap == null && cancellable == null) {
+        if (url != null && drawable == null && cancellable == null) {
             loadImage(url)
         }
     }
@@ -106,24 +113,19 @@ class CdnIconView(context: Context, private val theme: ThemeColors) : View(conte
     override fun hasOverlappingRendering(): Boolean = false
 
     override fun onDraw(canvas: Canvas) {
-        val bmp = bitmap
-        if (bmp != null && !bmp.isRecycled) {
+        val drw = drawable
+        if (drw != null) {
             if (isCircular) {
-                if (cachedShader == null || cachedShaderBitmap !== bmp || cachedShaderWidth != width) {
-                    cachedShader = BitmapShader(bmp, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP)
-                    cachedShaderBitmap = bmp
-                    cachedShaderWidth = width
-                    val scale = width.toFloat() / bmp.width
-                    shaderMatrix.setScale(scale, scale)
-                    cachedShader!!.setLocalMatrix(shaderMatrix)
-                }
-                paint.shader = cachedShader
-                canvas.drawCircle(width / 2f, height / 2f, width / 2f, paint)
-                paint.shader = null
+                canvas.save()
+                val path = android.graphics.Path()
+                path.addCircle(width / 2f, height / 2f, width / 2f, android.graphics.Path.Direction.CW)
+                canvas.clipPath(path)
+                drw.setBounds(0, 0, width, height)
+                drw.draw(canvas)
+                canvas.restore()
             } else {
-                srcRect.set(0, 0, bmp.width, bmp.height)
-                dstRect.set(0, 0, width, height)
-                canvas.drawBitmap(bmp, srcRect, dstRect, paint)
+                drw.setBounds(0, 0, width, height)
+                drw.draw(canvas)
             }
         } else {
             placeholderPaint.color = theme.surfaceVariant
@@ -135,8 +137,7 @@ class CdnIconView(context: Context, private val theme: ThemeColors) : View(conte
         }
     }
 
-    fun clearShaderCache() {
-        cachedShader = null
-        cachedShaderBitmap = null
+    override fun verifyDrawable(who: android.graphics.drawable.Drawable): Boolean {
+        return who == drawable || super.verifyDrawable(who)
     }
 }

--- a/app/src/main/java/com/mezon/mobile/ui/cells/InputSuggestionCell.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/cells/InputSuggestionCell.kt
@@ -350,7 +350,7 @@ class InputSuggestionCell(
         val size = LayoutHelper.dp(effectiveDp.toFloat())
         currentImageUrl = url
         val loader = MezonImageLoader.getInstance(context)
-        imageDisposable = loader.loadDrawable(url, size, size, onSuccess = { drawable ->
+        imageDisposable = loader.loadDrawable(url, size, size, cacheAnimated = true, onSuccess = { drawable ->
             if (currentImageUrl == url) {
                 leadingDrawable = drawable
                 drawable.callback = this@InputSuggestionCell
@@ -403,5 +403,8 @@ class InputSuggestionCell(
             isFilterBitmap = true
             isDither = true
         }
+    }
+    override fun verifyDrawable(who: android.graphics.drawable.Drawable): Boolean {
+        return who == leadingDrawable || super.verifyDrawable(who)
     }
 }

--- a/app/src/main/java/com/mezon/mobile/ui/cells/ProfileSearchCell.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/cells/ProfileSearchCell.kt
@@ -102,7 +102,7 @@ class ProfileSearchCell(context: Context, private val theme: ThemeColors) : Base
 
     private fun loadAvatar(m: SearchMember, avatarId: Long, placeholderKey: String) {
         loadChannelAvatar(
-            context,
+            this,
             avatarDrawable,
             ChannelAvatarRequest(
                 channelType = if (m.isDm) m.channelType else 0,

--- a/app/src/main/java/com/mezon/mobile/util/ImageProxy.kt
+++ b/app/src/main/java/com/mezon/mobile/util/ImageProxy.kt
@@ -35,7 +35,6 @@ fun createImgproxyUrl(
     if (!sourceUrl.startsWith("https://cdn.mezon") && !sourceUrl.startsWith("https://cdn.komu") && !sourceUrl.startsWith("https://profile.mezon")) {
         return sourceUrl
     }
-    if (shouldSkipProxy(sourceUrl)) return sourceUrl
     val cap = maxEdgePx.coerceAtLeast(1).coerceAtMost(4096)
     val w = widthPx.coerceAtMost(cap)
     val h = heightPx.coerceAtMost(cap)

--- a/app/src/main/java/com/mezon/mobile/util/ImageProxy.kt
+++ b/app/src/main/java/com/mezon/mobile/util/ImageProxy.kt
@@ -8,6 +8,21 @@ private const val IMGPROXY_BASE_URL = BuildConfig.MEZON_IMGPROXY_BASE_URL
 private const val IMGPROXY_KEY = BuildConfig.MEZON_IMGPROXY_KEY
 private const val MAX_BYTES = 2_097_152
 private const val MAX_PROXY_DIM = 1200
+private val SKIP_PROXY_EXTENSIONS = setOf("gif", "webp")
+
+private fun sourceExtension(url: String): String {
+    if (url.isEmpty()) return ""
+    val path = try {
+        java.net.URI(url).path ?: ""
+    } catch (_: Exception) {
+        url
+    }
+    val dot = path.lastIndexOf('.')
+    return if (dot >= 0 && dot < path.length - 1) path.substring(dot + 1).lowercase() else ""
+}
+
+private fun shouldSkipProxy(sourceUrl: String): Boolean =
+    SKIP_PROXY_EXTENSIONS.contains(sourceExtension(sourceUrl))
 
 fun createImgproxyUrl(
     sourceUrl: String,
@@ -20,6 +35,7 @@ fun createImgproxyUrl(
     if (!sourceUrl.startsWith("https://cdn.mezon") && !sourceUrl.startsWith("https://cdn.komu") && !sourceUrl.startsWith("https://profile.mezon")) {
         return sourceUrl
     }
+    if (shouldSkipProxy(sourceUrl)) return sourceUrl
     val cap = maxEdgePx.coerceAtLeast(1).coerceAtMost(4096)
     val w = widthPx.coerceAtMost(cap)
     val h = heightPx.coerceAtMost(cap)
@@ -61,6 +77,13 @@ fun absoluteResourceUrl(raw: String): String {
 
 fun avatarImgproxyUrl(sourceUrl: String, sizePx: Int): String {
     if (sourceUrl.isEmpty()) return sourceUrl
+    if (shouldSkipProxy(sourceUrl)) return sourceUrl
     val bucket = AVATAR_BUCKETS_PX.firstOrNull { it >= sizePx } ?: AVATAR_BUCKETS_PX.last()
     return createImgproxyUrl(sourceUrl, bucket, bucket, "fill")
+}
+
+fun isAnimatedImageUrl(url: String): Boolean {
+    if (url.isEmpty()) return false
+    val ext = sourceExtension(url)
+    return ext == "gif" || ext == "webp"
 }


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-31
Root Cause
Proxy Failure on Disguised GIFs: Animated avatars uploaded with static file extensions (e.g., .jpg) are routed through the image proxy, which fails with an HTTP 422 Unprocessable Entity error. Since the app lacked fallback logic, these avatars defaulted to text placeholders.
Animation Callback Interference: The image loader shared the same AnimatedImageDrawable instance across multiple views when retrieving from cache, causing animation callbacks to overwrite each other and freeze the GIF.

Solution
Automatic Proxy Fallback: Added a robust error fallback that automatically bypasses the proxy and fetches the original source URL directly from the CDN if a proxy load fails.
Unique Cache Keys for Animated Images: Updated the image loader to generate unique memory cache keys for animated requests when cacheAnimated = false, guaranteeing independent drawable instances for each view.
App-wide GIF Support: Upgraded BackupImageView, ChatMessageCell, and settings fragments to properly handle Animatable drawables and control their start/stop lifecycles.

Test Cases
TC1: Verify that user avatars with animated GIFs disguised as static extensions (.jpg) animate correctly in User Profile, Short Profile, Chat Messages, and Reaction Sheets.
TC2: Verify that multiple views displaying the same animated avatar simultaneously animate independently without freezing.
TC3: Verify that static avatars continue to render correctly and are retrieved efficiently from the memory cache.
TC4: Verify that local banner, sticker, and emoji image previews play their animations correctly upon selection.