### PR TITLE
fix(chat): stop the presign gate from hiding attachments it does not own

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
@@ -994,7 +994,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             val isLocalUri = att.url.startsWith("content://") || att.url.startsWith("file://")
             val isVideo = att.filetype.startsWith("video/", true)
             slotIsVideo[i] = isVideo
-            slotPresignPending[i] = msg.isPresignAttachmentPending(att.url, filter)
+            slotPresignPending[i] = msg.isPresignAttachmentPending(att.url, filter, snapshot.allPresignFinished)
             slotUploadPending[i] = !slotPresignPending[i] && msg.isAttachmentUploadPending(att.url, filter)
             slotUploadFailed[i] = msg.attachmentUploadFailed(att.url) ||
                 (att.url == msg.attachmentUrl && msg.isLocalAttachmentUrl(att.url) &&
@@ -1948,7 +1948,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         fileAttachmentUrls.clear()
         for (att in files) {
             fileAttachmentUrls.add(att.url)
-            filePresignPending.add(msg.isPresignAttachmentPending(att.url, filter))
+            filePresignPending.add(msg.isPresignAttachmentPending(att.url, filter, snapshot.allPresignFinished))
             fileUploadPending.add(
                 !filePresignPending.last() && msg.isAttachmentUploadPending(att.url, filter)
             )

--- a/app/src/main/java/com/mezon/mobile/home/chat/MessageEntity.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/MessageEntity.kt
@@ -148,14 +148,16 @@ data class MessageEntity(
 
     data class DisplayAttachmentSnapshot(
         val filter: PresignFinishContent.PresignFilterContext,
+        val allPresignFinished: Boolean,
         val media: List<AttachmentInfo>,
         val files: List<AttachmentInfo>,
     ) {
         val hasMedia: Boolean get() = media.isNotEmpty()
         val hasFiles: Boolean get() = files.isNotEmpty()
         val hasActivePresignPending: Boolean
-            get() = filter.hasActivePending(media, { it.url }) ||
-                filter.hasActivePending(files, { it.url })
+            get() = !allPresignFinished &&
+                (filter.hasActivePending(media, { it.url }) ||
+                    filter.hasActivePending(files, { it.url }))
     }
 
     fun displayAttachmentSnapshot(
@@ -164,8 +166,10 @@ data class MessageEntity(
         val filter = PresignFinishContent.PresignFilterContext.from(content, timestampSeconds, nowSeconds)
         val mediaSource = allImageAttachments
         val filesSource = allFileAttachments
+        val allFinished = filter.allFinished(mediaSource + filesSource) { it.url }
         return DisplayAttachmentSnapshot(
             filter = filter,
+            allPresignFinished = allFinished,
             media = filter.filterDisplayable(mediaSource) { it.url },
             files = filter.filterDisplayable(filesSource) { it.url },
         )
@@ -356,8 +360,10 @@ data class MessageEntity(
     fun isPresignAttachmentPending(
         url: String,
         filter: PresignFinishContent.PresignFilterContext,
+        allPresignFinished: Boolean = false,
     ): Boolean {
         if (isMe) return false
+        if (allPresignFinished) return false
         if (isLocalAttachmentUrl(url)) return false
         return filter.isUnfinished(url)
     }

--- a/app/src/main/java/com/mezon/mobile/util/AttachmentUploader.kt
+++ b/app/src/main/java/com/mezon/mobile/util/AttachmentUploader.kt
@@ -492,7 +492,10 @@ object AttachmentUploader {
         )
         val urls = start.urlsList
         val uploadId = start.uploadId
-        val serverFilename = start.filename.ifEmpty { uploadFilename }
+        // The object key must come from the server: falling back to the local name
+        // silently builds a CDN url that points at nothing.
+        val serverFilename = start.filename
+        require(serverFilename.isNotEmpty()) { "multipart upload start returned an empty filename" }
         val cdnUrl = "$cdnBaseUrl/$serverFilename"
         if (urls.size == 1 && uploadId.isEmpty()) {
             Log.d(TAG, "presign multipart→single file=$uploadFilename cdnUrl=$cdnUrl minioUrl=${urls[0]}")
@@ -537,7 +540,10 @@ object AttachmentUploader {
         )
         val urls = start.urlsList
         val uploadId = start.uploadId
-        val serverFilename = start.filename.ifEmpty { uploadFilename }
+        // The object key must come from the server: falling back to the local name
+        // silently builds a CDN url that points at nothing.
+        val serverFilename = start.filename
+        require(serverFilename.isNotEmpty()) { "multipart upload start returned an empty filename" }
         val cdnUrl = "$cdnBaseUrl/$serverFilename"
         if (urls.size == 1 && uploadId.isEmpty()) {
             Log.d(TAG, "presign multipart→single bytes file=$uploadFilename cdnUrl=$cdnUrl minioUrl=${urls[0]}")

--- a/app/src/main/java/com/mezon/mobile/util/PresignFinishContent.kt
+++ b/app/src/main/java/com/mezon/mobile/util/PresignFinishContent.kt
@@ -43,6 +43,7 @@ object PresignFinishContent {
         fun isUnfinished(url: String): Boolean {
             if (url.isBlank()) return false
             if (url.startsWith("content://") || url.startsWith("file://")) return false
+            if (!isMezonCdnUrl(url)) return false
             val keys = finishedKeys ?: return false
             val key = presignKey(url)
             return key.isNotEmpty() && !keys.contains(key)
@@ -56,6 +57,18 @@ object PresignFinishContent {
         fun <T> filterDisplayable(attachments: List<T>, urlSelector: (T) -> String): List<T> {
             if (!expirePending) return attachments
             return attachments.filter { !isExpired(urlSelector(it)) }
+        }
+
+        /**
+         * A sender that dies before its final flush leaves the last keys unsent, so
+         * matching by name alone would keep those attachments hidden until they are
+         * dropped. Once as many keys have arrived as there are presignable
+         * attachments, everything is considered uploaded - same rule as web/desktop.
+         */
+        fun <T> allFinished(attachments: List<T>, urlSelector: (T) -> String): Boolean {
+            val keys = finishedKeys ?: return false
+            val presignable = attachments.count { isMezonCdnUrl(urlSelector(it)) }
+            return presignable > 0 && keys.size >= presignable
         }
 
         fun <T> hasDisplayable(attachments: List<T>, urlSelector: (T) -> String): Boolean {
@@ -90,6 +103,20 @@ object PresignFinishContent {
         } catch (_: Exception) {
             null
         }
+    }
+
+    /**
+     * Only attachments living on a mezon CDN are uploaded through a presigned URL,
+     * so only those can be waiting for a `presign_finish` key. Anything else - a
+     * Tenor GIF, an image someone linked from the web - is already reachable and
+     * must never be hidden (nor dropped once the message passes its expiry).
+     */
+    fun isMezonCdnUrl(url: String): Boolean {
+        val trimmed = url.trim()
+        return trimmed.startsWith("https://cdn.mezon") ||
+            trimmed.startsWith("https://cdn.komu") ||
+            trimmed.startsWith("http://cdn.mezon") ||
+            trimmed.startsWith("http://cdn.komu")
     }
 
     fun presignKey(cdnUrl: String): String {


### PR DESCRIPTION
## What was wrong

`PresignFinishContent.PresignFilterContext.isUnfinished` gated **every** URL in a message that carries `presign_finish`, not just the ones that went through a presigned upload. It only skipped `content://` and `file://`.

So in any message with that field, a Tenor GIF or an externally hosted image was treated as "upload not confirmed": hidden behind the pending placeholder, and then **removed from the message entirely** once it passed the ten minute expiry. Those objects were never uploaded by us and are already reachable — there is nothing to wait for.

Two further holes in the same path:

- **A sender that dies before its final flush loses its last keys.** Membership was matched strictly per key, with no completion shortcut, so those attachments stayed hidden until they were dropped. Web and desktop both accept the batch as complete once as many keys have arrived as there are presignable attachments; Android did not.
- **Multipart start built a CDN url from the local filename when the server returned an empty one** (`start.filename.ifEmpty { uploadFilename }`). That silently produces a url with no bucket/clan path — a link that points at nothing, with no error anywhere.

## What changed

- `isMezonCdnUrl(...)` scopes the gate to mezon CDN hosts, so nothing else is ever hidden or expired.
- `PresignFilterContext.allFinished(...)` implements the count shortcut, wired through `DisplayAttachmentSnapshot.allPresignFinished` into both call sites in `ChatMessageCell`.
- Multipart start now requires a server-provided filename instead of falling back. The surrounding `prepareAndPresignAttachment` already retries and marks the file failed on exception, so this surfaces as a normal presign failure rather than a broken link.

## Verification

Reviewed every affected call site by hand. **Not compiled locally** — the build needs `google-services.json`, which is not in the repo; please let CI confirm.

## Not included

The video poster is uploaded eagerly, before the main file, but its key never enters `presign_finish` and the receive-side gate keys off the video url — so the poster sits on the CDN and is still covered by the flat placeholder until the whole video finishes. Fixing that means touching the custom drawing in `ChatMessageCell`; it is a UX improvement, not a correctness bug, so it is left for a separate change.
