### PR TITLE
260804-ANDROID-Fix bug DM icon

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/profile/EditProfileFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/profile/EditProfileFragment.kt
@@ -130,6 +130,7 @@ class EditProfileFragment : BaseFragment() {
 
     private var currentDmLogoUrl: String = ""
     private lateinit var dmLogoView: AvatarView
+    private lateinit var removeDmLogoIcon: ImageView
     private lateinit var saveButtonView: View
     private var isUploadingAvatar = false
     private var isUploadingDmLogo = false
@@ -376,22 +377,24 @@ class EditProfileFragment : BaseFragment() {
             setSizeDp(50)
             setOnClickListener { openDmLogoPicker() }
         }
-        bindDmLogoPreview()
         val dmWrapper = FrameLayout(context)
         dmWrapper.addView(dmLogoView, LayoutHelper.createFrame(50, 50))
         
         val removeIconBg = GradientDrawable().apply {
             setColor(themeColors.error)
             cornerRadius = LayoutHelper.dpf(999f)
+            setStroke(LayoutHelper.dp(1.5f), 0xFFFFFFFF.toInt())
         }
-        val removeIcon = ImageView(context).apply {
+        removeDmLogoIcon = ImageView(context).apply {
             background = removeIconBg
             setImageResource(R.drawable.ic_close_icon) 
             imageTintList = android.content.res.ColorStateList.valueOf(0xFFFFFFFF.toInt())
-            setPadding(LayoutHelper.dp(2), LayoutHelper.dp(2), LayoutHelper.dp(2), LayoutHelper.dp(2))
+            setPadding(LayoutHelper.dp(4), LayoutHelper.dp(4), LayoutHelper.dp(4), LayoutHelper.dp(4))
             setOnClickListener { removeDmLogo() }
         }
-        dmWrapper.addView(removeIcon, LayoutHelper.createFrame(16, 16, Gravity.TOP or Gravity.END))
+        dmWrapper.addView(removeDmLogoIcon, LayoutHelper.createFrame(22, 22, Gravity.TOP or Gravity.END))
+        
+        bindDmLogoPreview()
         dmGroupCard.addView(dmWrapper, LayoutHelper.createLinear(LayoutHelper.WRAP_CONTENT, LayoutHelper.WRAP_CONTENT))
 
         content.addView(dmGroupCard, LayoutHelper.createLinear(
@@ -912,6 +915,9 @@ class EditProfileFragment : BaseFragment() {
         if (!::dmLogoView.isInitialized) return
         val url = currentDmLogoUrl.ifEmpty { com.mezon.mobile.BuildConfig.MEZON_LOGO_URL }
         dmLogoView.setImageUrl(url)
+        if (::removeDmLogoIcon.isInitialized) {
+            removeDmLogoIcon.visibility = if (url == com.mezon.mobile.BuildConfig.MEZON_LOGO_URL) View.GONE else View.VISIBLE
+        }
     }
 
     private fun removeDmLogo() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1146,7 +1146,7 @@
     <string name="edit_profile_change_avatar">Change Avatar</string>
     <string name="edit_profile_remove_avatar">Remove Avatar</string>
     <string name="edit_profile_avatar_too_large">Avatar file size must not exceed 10MB</string>
-    <string name="edit_profile_dm_logo_too_large">Logo file size must not exceed 1MB</string>
+    <string name="edit_profile_dm_logo_too_large">Icon file size must not exceed 1MB</string>
     <string name="edit_profile_select_clan">Select a Clan</string>
     <string name="edit_profile_clan_nickname">Clan Nickname</string>
     <string name="edit_profile_clan_nickname_duplicate">The nickname already exists in the clan. Please enter another nickname.</string>


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-126
Root Cause
The "Remove DM Logo" button (X) had a small touch target (16dp with 2dp padding) making it difficult to tap, and lacked a border to distinguish it from the background.
The button was always displayed, even when the default Mezon logo was active.

Solution
Increased the button size to 22dp with 4dp padding, and added a 1.5dp white border to its background.
Toggled the visibility of the remove button, hiding it when the default Mezon logo is active and showing it only when a custom logo is configured.

Test Cases
Verify that the remove button (X) is hidden when the default Mezon logo is active.
Verify that the remove button (X) appears after picking a custom logo.
Verify that the remove button (X) displays with a white border and a larger tap target.
Verify that clicking the remove button (X) successfully resets the logo to default and hides the button.