### PR TITLE
260805-ANDROID-Handle jump to msg tab messages- #258

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/notifications/NotificationsFragment.kt
@@ -386,7 +386,9 @@ class NotificationsFragment : BaseFragment() {
                 fragmentScope.launch {
                     val dmChannelId = dialogsController.getOrCreateDm(entity.senderId)
                     if (dmChannelId != 0L) {
-                        openChatFromNotification(entity, dmChannelId)
+                        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Main) {
+                            openChatFromNotification(entity, dmChannelId)
+                        }
                     }
                 }
                 return

--- a/app/src/main/java/com/mezon/mobile/home/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/notifications/NotificationsFragment.kt
@@ -33,6 +33,7 @@ import com.mezon.mobile.network.CHANNEL_TYPE_DM
 import com.mezon.mobile.network.CHANNEL_TYPE_GROUP
 import com.mezon.mobile.network.CHANNEL_TYPE_THREAD
 import com.mezon.mobile.ui.cells.MezonIcon
+import kotlinx.coroutines.launch
 
 private data class TabDef(val category: Int, val labelRes: Int, val icon: MezonIcon)
 
@@ -380,6 +381,22 @@ class NotificationsFragment : BaseFragment() {
             return
         }
         val channelId = entity.channelId
+        if (channelId == 0L) {
+            if (entity.clanId == 0L && entity.senderId != 0L) {
+                fragmentScope.launch {
+                    val dmChannelId = dialogsController.getOrCreateDm(entity.senderId)
+                    if (dmChannelId != 0L) {
+                        openChatFromNotification(entity, dmChannelId)
+                    }
+                }
+                return
+            }
+            return
+        }
+        openChatFromNotification(entity, channelId)
+    }
+
+    private fun openChatFromNotification(entity: NotificationEntity, channelId: Long) {
         if (channelId == 0L) return
         val rawClanId = entity.clanId
         val dm = dialogsController.getDialog(channelId)


### PR DESCRIPTION
task: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-96
Root Cause
When tapping direct message (DM) notifications from the Messages tab, the backend returns a channel_id of 0 in the payload, preventing the app from identifying the target chat room and jumping to the specific message.

Solution
Implemented a fallback mechanism that fetches or creates the DM channel using the notification's senderId if the channelId is 0, ensuring successful navigation and message jumping.

Test Cases
Tap on a DM notification in the Messages tab and verify it successfully opens the direct chat room and scrolls to the target message.
Tap on a notification that already contains a valid channel ID (e.g., Mentions tab) and verify the jump navigation still works correctly.