### PR TITLE
260811-ANDROID-Handle markdown preview DM

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/messages/DialogCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/messages/DialogCell.kt
@@ -199,7 +199,7 @@ class DialogCell(context: Context, private val theme: ThemeColors) : BaseCell(co
         val badgeSpace = if (badgeLayout != null) BADGE_MIN_W + BADGE_GAP else 0
         val previewWidth = contentWidth - badgeSpace - buzzSpace
         val previewText = when {
-            dm.lastMessageContent.isNotEmpty() -> dm.lastMessageContent
+            dm.lastMessageContent.isNotEmpty() -> formatDirectMessagePreview(dm.lastMessageContent)
             dm.lastSentMessageId > 0L || dm.lastSentMessageTs > 0L -> ""
             else -> context.getString(R.string.dm_no_messages)
         }

--- a/app/src/main/java/com/mezon/mobile/home/messages/DirectMessage.kt
+++ b/app/src/main/java/com/mezon/mobile/home/messages/DirectMessage.kt
@@ -94,11 +94,18 @@ private const val PREVIEW_MAX_UTF8_BYTES = 32
 private const val PREVIEW_ELLIPSIS_THRESHOLD_BYTES = PREVIEW_MAX_UTF8_BYTES - 3
 private const val PREVIEW_ELLIPSIS = "..."
 
-fun formatDirectMessagePreview(preview: String): String {
-    if (preview.isEmpty() || preview.endsWith(PREVIEW_ELLIPSIS)) return preview
+private val HEADING_REGEX = Regex("^#{1,6}\\s+", RegexOption.MULTILINE)
 
-    val byteCount = preview.toByteArray(Charsets.UTF_8).size
-    return if (byteCount >= PREVIEW_ELLIPSIS_THRESHOLD_BYTES) preview + PREVIEW_ELLIPSIS else preview
+private fun stripHeadingMarkdown(text: String): String {
+    return HEADING_REGEX.replace(text, "")
+}
+
+fun formatDirectMessagePreview(preview: String): String {
+    val stripped = stripHeadingMarkdown(preview)
+    if (stripped.isEmpty() || stripped.endsWith(PREVIEW_ELLIPSIS)) return stripped
+
+    val byteCount = stripped.toByteArray(Charsets.UTF_8).size
+    return if (byteCount >= PREVIEW_ELLIPSIS_THRESHOLD_BYTES) stripped + PREVIEW_ELLIPSIS else stripped
 }
 
 fun ChannelDescription.toDirectMessage(currentUserId: Long, previewContext: android.content.Context? = null): DirectMessage {


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-51
Root cause: New previews and legacy Room cache could contain raw Markdown heading prefixes.
Solution: Normalize new previews in formatDirectMessagePreview() and normalize cached previews again before rendering in DialogCell.
Test cases:
Verify # alo12434 displays as alo12434.
Verify a cached # alo12434 preview displays as alo12434.
Verify newly received heading messages display without the heading prefix.
Verify #hashtag and normal previews remain unchanged.