### PR TITLE
260811-ANDROID-Handle fallback local data reply- #268

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -579,6 +579,7 @@ open class ChatFragment : BaseFragment() {
             val changedClanId = args.getOrNull(0) as? Long ?: return@observe
             if (changedClanId != clanId || !::adapter.isInitialized) return@observe
             adapter.currentUserRoleIds = resolveSelfRoleIds()
+            updateVisibleRows(NotificationCenter.UPDATE_MASK_NAME)
         }
         observe(NotificationCenter.selectedClanChanged) { _, _, _ ->
             if (isPaused) return@observe
@@ -2099,6 +2100,15 @@ open class ChatFragment : BaseFragment() {
             }
             override fun didPressReply(cell: ChatMessageCell, replyMessageId: Long) {
                 scrollToReplyMessage(replyMessageId)
+            }
+            override fun resolveReplyIdentity(senderId: Long): Pair<String, String>? {
+                val member = memberResolver.resolveMember(senderId, clanId, channelId, channelType)
+                    ?: return null
+                val name = member.clanNick.ifBlank {
+                    member.displayName.ifBlank { member.username }
+                }
+                val avatar = member.clanAvatar.ifBlank { member.avatarUrl }
+                return if (name.isBlank() && avatar.isBlank()) null else name to avatar
             }
             override fun didTapReaction(cell: ChatMessageCell, msg: MessageEntity, group: ReactionGroup) {
                 handleReactionTap(msg, group)

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
@@ -704,6 +704,14 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             if (nameChanged || senderDisplayRoleChanged(msg.senderId)) {
                 rebuildLayout = true
             }
+            if (hasReply) {
+                val oldReplyName = replySenderName
+                val oldReplyAvatar = replySenderAvatarUrl
+                parseReply(msg)
+                if (oldReplyName != replySenderName || oldReplyAvatar != replySenderAvatarUrl) {
+                    rebuildLayout = true
+                }
+            }
             val isAnon = msg.senderId == ANONYMOUS_USER_ID
             val avatarUsername = if (isAnon) "Anonymous" else msg.senderName.ifBlank { msg.senderUsername }
             avatarDrawable.setInfo(msg.senderId, avatarUsername)
@@ -2134,7 +2142,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
                 ?.replace("\\\"", "\"")
                 ?: ""
             replySenderName = refClanNick.ifBlank {
-                refDisplayName.ifBlank { replySenderUsername.ifBlank { "Anonymous" } }
+                refDisplayName.ifBlank { replySenderUsername }
             }
             val rawRefContent = refContentMatch?.groupValues?.getOrNull(1)
                 ?.replace("\\n", " ")
@@ -2144,15 +2152,25 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
 
             val senderIdMatch = REFERENCE_SENDER_ID_REGEX.find(content)
             replySenderId = senderIdMatch?.groupValues?.getOrNull(1)?.toLongOrNull() ?: 0L
+            val avatarMatch = REFERENCE_AVATAR_REGEX.find(content)
+            replySenderAvatarUrl = avatarMatch?.groupValues?.getOrNull(1)?.replace("\\/", "/")
+
             val isAnonymousReply = replySenderId == ANONYMOUS_USER_ID
             if (isAnonymousReply) {
                 replySenderName = "Anonymous"
                 replySenderUsername = "Anonymous"
+            } else if (replySenderId != 0L &&
+                (replySenderName.isBlank() || replySenderAvatarUrl.isNullOrBlank())
+            ) {
+                val cachedIdentity = delegate?.resolveReplyIdentity(replySenderId)
+                if (replySenderName.isBlank()) {
+                    replySenderName = cachedIdentity?.first.orEmpty().ifBlank { replySenderId.toString() }
+                }
+                if (replySenderAvatarUrl.isNullOrBlank()) {
+                    replySenderAvatarUrl = cachedIdentity?.second
+                }
             }
             replyHasAttachment = content.contains("\"has_attachment\":true")
-
-            val avatarMatch = REFERENCE_AVATAR_REGEX.find(content)
-            replySenderAvatarUrl = avatarMatch?.groupValues?.getOrNull(1)?.replace("\\/", "/")
 
             replyAvatarDrawable.setInfo(replySenderId, replySenderUsername.ifBlank { replySenderName })
             if (isAnonymousReply) loadReplyAnonymousAvatar() else loadReplyAvatar(replySenderAvatarUrl ?: "")
@@ -2450,6 +2468,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         fun didLongPress(cell: ChatMessageCell, msg: MessageEntity) {}
         fun didClickAvatar(cell: ChatMessageCell, msg: MessageEntity) {}
         fun didPressReply(cell: ChatMessageCell, replyMessageId: Long) {}
+        fun resolveReplyIdentity(senderId: Long): Pair<String, String>? = null
         fun didTapReaction(cell: ChatMessageCell, msg: MessageEntity, group: ReactionGroup) {}
         fun didLongPressReaction(cell: ChatMessageCell, msg: MessageEntity, group: ReactionGroup) {}
         fun didTapAddReaction(cell: ChatMessageCell, msg: MessageEntity) {}


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-237
Root cause: Android also trusted incomplete reply references, defaulted missing names to Anonymous, and did not re-resolve identity after the local member cache loaded.
Solution: Resolve only missing reply fields from the local MemberResolver cache and refresh visible replies when clan-member data becomes available.
Test cases:
Verify a reply with complete reference identity remains unchanged.
Verify missing name and avatar are resolved from the local member cache.
Verify cached names use clanNick → displayName → username.
Verify cached avatars use clanAvatar → user avatar.
Verify the anonymous user ID always displays Anonymous.
Verify a cache miss displays the sender ID instead of Anonymous.
Verify a visible reply refreshes after the clan-member cache finishes loading.