### PR TITLE
260813-ANDROID-Update check permission delete thread

### DIFF
--- a/app/src/main/java/com/mezon/mobile/data/db/MezonDatabase.kt
+++ b/app/src/main/java/com/mezon/mobile/data/db/MezonDatabase.kt
@@ -23,7 +23,7 @@ import androidx.room.RoomDatabase
         ClanRoleListMetaEntity::class,
         ClanRoleCacheEntity::class,
     ],
-    version = 34,
+    version = 35,
     exportSchema = false
 )
 abstract class MezonDatabase : RoomDatabase() {

--- a/app/src/main/java/com/mezon/mobile/home/chat/thread/ThreadInfo.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/thread/ThreadInfo.kt
@@ -61,6 +61,7 @@ fun ThreadInfo.toClanChannelEntity(
         lastSeenMessageTs = existing?.lastSeenMessageTs ?: 0L,
         lastSentMessageTs = existing?.lastSentMessageTs ?: 0L,
         active = if (active != 0) active else existing?.active ?: 0,
-        categoryOrder = existing?.categoryOrder ?: parentChannel?.categoryOrder ?: 0
+        categoryOrder = existing?.categoryOrder ?: parentChannel?.categoryOrder ?: 0,
+        creatorId = creatorId.takeIf { it != 0L } ?: existing?.creatorId ?: 0L,
     )
 }

--- a/app/src/main/java/com/mezon/mobile/home/clans/ClanChannelEntity.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ClanChannelEntity.kt
@@ -38,6 +38,7 @@ data class ClanChannelEntity(
     val active: Int = 0,
     val categoryOrder: Int = 0,
     val ageRestricted: Int = 0,
+    val creatorId: Long = 0L,
 ) {
     val isAgeRestricted: Boolean get() = ageRestricted == 1
     val isThread: Boolean get() = type == 7 && parentId != 0L
@@ -71,4 +72,5 @@ fun ChannelDescription.toClanChannelEntity(): ClanChannelEntity = ClanChannelEnt
     lastSentMessageTs = extractLastSentMessageTs(fallbackToCreateTime = false),
     active = active,
     ageRestricted = ageRestricted,
+    creatorId = creatorId,
 )

--- a/app/src/main/java/com/mezon/mobile/home/clans/PermissionPolicy.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/PermissionPolicy.kt
@@ -129,10 +129,17 @@ class PermissionPolicy @Inject constructor(
         if (clanId == 0L || channel.channelId == 0L) return false
         if (isWelcomeChannel(clanId, channel.channelId)) return false
         return if (channel.isThread) {
-            ensurePermissionChecker(listOf(CLAN_OWNER, MANAGE_THREAD, ADMINISTRATOR), channel.channelId, clanId)
-            checkPermission(CLAN_OWNER, channel.channelId, clanId) ||
-                checkPermission(ADMINISTRATOR, null, clanId) ||
-                checkPermission(MANAGE_THREAD, channel.channelId, clanId)
+            ensurePermissionChecker(
+                listOf(CLAN_OWNER, MANAGE_THREAD, ADMINISTRATOR, MANAGE_CHANNEL),
+                channel.channelId,
+                clanId,
+            )
+            val isOwner = checkPermission(CLAN_OWNER, channel.channelId, clanId)
+            val isAdministrator = checkPermission(ADMINISTRATOR, null, clanId)
+            val isCreator = channel.creatorId != 0L && channel.creatorId == userController.userId
+            val canManageThread = checkPermission(MANAGE_THREAD, channel.channelId, clanId) ||
+                checkPermission(MANAGE_CHANNEL, null, clanId)
+            isOwner || isAdministrator || (isCreator && canManageThread)
         } else {
             ensurePermissionChecker(listOf(ADMINISTRATOR, MANAGE_CHANNEL), null, clanId)
             canManageChannelForClan(clanId)


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-259
Root Cause: Android checked only the thread management permission and did not verify whether the user was the thread creator; additionally, creatorId was not persisted in the channel entity.
Solution: Persist creatorId and show “Delete Thread” only to clan owners, administrators, or thread creators who have manage-thread or manage-channel permission.
Test Cases:
Verify a clan owner can see the “Delete Thread” option.
Verify an administrator can see the “Delete Thread” option.
Verify a thread creator with thread management permission can see the “Delete Thread” option.
Verify a thread creator without thread management permission cannot see the “Delete Thread” option.
Verify a non-creator with thread management permission cannot see the “Delete Thread” option.
Verify a regular user without permission cannot see the “Delete Thread” option.