### PR TITLE
260813-ANDROID-Update sreenshot UI transaction detail

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/wallet/TransferSuccessFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/wallet/TransferSuccessFragment.kt
@@ -91,7 +91,7 @@ class TransferSuccessFragment : BaseFragment() {
             orientation = LinearLayout.VERTICAL
             setPadding(LayoutHelper.dp(24), LayoutHelper.dp(32), LayoutHelper.dp(24), LayoutHelper.dp(24))
         }
-        cardView = body
+        cardView = outer
 
         val scroll = ScrollView(context).apply {
             overScrollMode = ScrollView.OVER_SCROLL_NEVER


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-267
Root Cause: Android captured only the content body, which had no background and excluded the action buttons.
Solution: Capture the outer container so the exported image includes the themed background and all action buttons.
Test Cases:
Verify the shared image has the correct background color.
Verify the saved image has the correct background color.
Verify the shared image includes Share, Save image, New transfer, and Done buttons.
Verify the saved image includes Share, Save image, New transfer, and Done buttons.
Verify the Transaction Detail UI remains unchanged after sharing or saving.