### PR TITLE
260815-ANDROID-Improve search global

### DIFF
--- a/app/src/main/java/com/mezon/mobile/search/GlobalSearchFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/search/GlobalSearchFragment.kt
@@ -185,6 +185,11 @@ class GlobalSearchFragment : BaseFragment() {
             if (channelScopedMembers != null) return@observe
             searchController.rebuildMembers()
         }
+        observe(NotificationCenter.friendsLoaded) { _, _, _ ->
+            if (fragmentView == null || isPaused) return@observe
+            if (channelScopedMembers != null) return@observe
+            searchController.rebuildMembers()
+        }
         observe(NotificationCenter.clanMembersDidLoad) { _, _, _ ->
             if (fragmentView == null || isPaused) return@observe
             if (channelScopedMembers != null) {

--- a/app/src/main/java/com/mezon/mobile/search/SearchController.kt
+++ b/app/src/main/java/com/mezon/mobile/search/SearchController.kt
@@ -13,6 +13,7 @@ import com.mezon.mobile.home.clans.CHANNEL_TYPE_VOICE
 import com.mezon.mobile.home.clans.ClanChannelEntity
 import com.mezon.mobile.home.clans.ClansController
 import com.mezon.mobile.home.clans.toClanChannelEntity
+import com.mezon.mobile.home.friends.FriendController
 import com.mezon.mobile.home.messages.DirectMessage
 import com.mezon.mobile.network.ApiCacheTracker
 import com.mezon.mobile.network.CHANNEL_TYPE_DM
@@ -67,6 +68,7 @@ class SearchController @Inject constructor(
     private val api: MezonApi,
     private val sessionManager: SessionManager,
     private val dialogsController: DialogsController,
+    private val friendController: FriendController,
     private val clansController: ClansController,
     private val userClanController: UserClanController,
     private val notificationCenter: NotificationCenter,
@@ -100,6 +102,29 @@ class SearchController @Inject constructor(
         appScope.launch {
             dispatcher.channelDeletedEvents.collect { event ->
                 removeChannelData(event.channelId)
+            }
+        }
+        appScope.launch {
+            dispatcher.channelCreatedEvents.collect { event ->
+                if (event.channelId == 0L || event.clanId == 0L) return@collect
+                if (event.channelType == CHANNEL_TYPE_DM || event.channelType == CHANNEL_TYPE_GROUP) {
+                    return@collect
+                }
+                upsertChannelData(
+                    ClanChannelEntity(
+                        clanId = event.clanId,
+                        channelId = event.channelId,
+                        parentId = event.parentId,
+                        categoryId = event.categoryId,
+                        categoryName = "",
+                        channelLabel = event.channelLabel,
+                        type = event.channelType,
+                        isPrivate = event.channelPrivate != 0,
+                        topic = "",
+                        unreadCount = 0,
+                        isMuted = false
+                    )
+                )
             }
         }
     }
@@ -141,6 +166,27 @@ class SearchController @Inject constructor(
         }
     }
 
+    private fun upsertChannelData(incoming: ClanChannelEntity) {
+        synchronized(this) {
+            val existing = channelById[incoming.channelId]
+            val channel = existing?.copy(
+                clanId = incoming.clanId,
+                parentId = incoming.parentId,
+                categoryId = incoming.categoryId,
+                channelLabel = incoming.channelLabel.ifBlank { existing.channelLabel },
+                type = incoming.type.takeIf { it != 0 } ?: existing.type,
+                isPrivate = incoming.isPrivate
+            ) ?: incoming
+
+            allChannels.removeAll { it.channelId == channel.channelId }
+            allChannels.add(channel)
+            channelById[channel.channelId] = channel
+            cachedChannelsQuery = null
+            cachedChannelsResult.clear()
+        }
+        notificationCenter.postNotificationOnMainThread(NotificationCenter.searchChannelsDidLoad)
+    }
+
     @Synchronized
     fun getMembers(): List<SearchMember> = ArrayList(allMembers)
 
@@ -158,6 +204,7 @@ class SearchController @Inject constructor(
 
     fun loadMembers(noCache: Boolean = false) {
         userClanController.loadUsers(noCache)
+        friendController.loadFriends(noCache)
         rebuildMembers()
     }
 
@@ -183,6 +230,25 @@ class SearchController @Inject constructor(
                 val seenUserIds = HashSet<Long>(dmUserIds)
                 seenUserIds.add(currentUserId)
 
+                val friendMembers = ArrayList<SearchMember>()
+                for (friend in friendController.friends.value) {
+                    val user = friend.user
+                    if (user.id == 0L || user.id in seenUserIds) continue
+                    seenUserIds.add(user.id)
+                    friendMembers.add(
+                        SearchMember(
+                            id = user.id,
+                            username = user.username,
+                            displayName = user.displayName.ifBlank { user.username },
+                            avatarUrl = user.avatarUrl,
+                            isOnline = user.online,
+                            isDm = false,
+                            channelId = 0L,
+                            channelType = 0
+                        )
+                    )
+                }
+
                 val nonDmMembers = ArrayList<SearchMember>()
                 for (user in clanUsers) {
                     if (user.id in seenUserIds) continue
@@ -193,6 +259,7 @@ class SearchController @Inject constructor(
                 synchronized(this@SearchController) {
                     allMembers.clear()
                     allMembers.addAll(dmMembers)
+                    allMembers.addAll(friendMembers)
                     allMembers.addAll(nonDmMembers)
                     membersLoaded = true
                     cachedMembersQuery = null


### PR DESCRIPTION
Root Cause
Member search only used DM and clan-user data, while channel search did not handle channelCreatedEvents, causing newly added friends, channels, and threads to remain missing until the cache was rebuilt.
Solution
Include friends when rebuilding member search, refresh on friendsLoaded, and upsert newly created channels or threads into the search cache when receiving channelCreatedEvents.
Test Cases
Accept a friend without a shared clan or DM and verify they appear in member search without restarting the app.
Accept a friend while Search is open and verify the member list updates immediately.
Verify a user present in multiple sources appears only once in member search.
Create a channel on the current device and verify it appears in channel search immediately.
Create a thread on the current device and verify it appears in channel search immediately.
Create a channel or thread from another device and verify it appears in search in real time.
Delete a channel or thread and verify it disappears from search immediately.
Restart the app and verify the updated members, channels, and threads remain searchable.