### PR TITLE
260818-ANDROID-Update share video and improve app stability- #275

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -139,6 +139,13 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".home.sharing.VideoShareRefinementActivity"
+            android:configChanges="keyboardHidden|orientation|screenSize"
+            android:excludeFromRecents="true"
+            android:exported="false"
+            android:theme="@style/Theme.Mezon.VideoShareRefinement" />
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/app/src/main/java/com/mezon/mobile/MainActivity.kt
+++ b/app/src/main/java/com/mezon/mobile/MainActivity.kt
@@ -50,6 +50,7 @@ import com.mezon.mobile.home.messages.MessageActivitiesController
 import com.mezon.mobile.home.MainTabsActivity
 import com.mezon.mobile.home.chat.ChatFragment
 import com.mezon.mobile.home.chat.PhotoViewer
+import com.mezon.mobile.home.chat.VideoPlayerDialog
 import com.mezon.mobile.home.call.CallController
 import com.mezon.mobile.home.call.CallFragment
 import com.mezon.mobile.home.call.CallManager
@@ -63,6 +64,8 @@ import com.mezon.mobile.home.clans.ClanChannelEntity
 import com.mezon.mobile.home.friends.AddFriendFragment
 import com.mezon.mobile.home.friends.FriendController
 import com.mezon.mobile.home.sharing.SharingFragment
+import com.mezon.mobile.home.sharing.ExistingVideoShareStore
+import com.mezon.mobile.home.sharing.VideoShareRefinementContract
 import com.mezon.mobile.home.stream.StreamingRoomFragment
 import com.mezon.mobile.home.voice.VoiceOverlayManager
 import com.mezon.mobile.home.voice.VoiceRoomFragment
@@ -1410,6 +1413,27 @@ class MainActivity : BasePermissionsActivity(),
         if (action != Intent.ACTION_SEND && action != Intent.ACTION_SEND_MULTIPLE) return false
         if (!StartupCache.hasSession) return false
 
+        if (action == Intent.ACTION_SEND) {
+            val internalShareToken = intent.getStringExtra(
+                VideoShareRefinementContract.EXTRA_INTERNAL_SHARE_TOKEN
+            )
+            val existingAttachment = ExistingVideoShareStore.consume(internalShareToken)
+            if (internalShareToken != null) {
+                intent.removeExtra(VideoShareRefinementContract.EXTRA_INTERNAL_SHARE_TOKEN)
+            }
+            if (existingAttachment != null) {
+                intent.action = null
+                PhotoViewer.dismissActiveIfShowing()
+                VideoPlayerDialog.dismissActiveIfShowing()
+
+                val params = INavigationLayout.NavigationParams(
+                    SharingFragment.fromExistingAttachment(existingAttachment)
+                )
+                actionBarLayout.presentFragment(params)
+                return true
+            }
+        }
+
         val uris = ArrayList<Uri>()
         val sharedText = intent.getStringExtra(Intent.EXTRA_TEXT)
         val mimeType = intent.type
@@ -1442,6 +1466,7 @@ class MainActivity : BasePermissionsActivity(),
         intent.removeExtra(Intent.EXTRA_TEXT)
 
         PhotoViewer.dismissActiveIfShowing()
+        VideoPlayerDialog.dismissActiveIfShowing()
 
         val fragment = SharingFragment.fromDevice(
             uris = uris,

--- a/app/src/main/java/com/mezon/mobile/home/ChannelGalleryController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChannelGalleryController.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.mezon.mobile.BuildConfig
 import com.mezon.mezon.api.ChannelAttachment
 import com.mezon.mobile.core.NotificationCenter
+import com.mezon.mobile.data.db.MessageDao
 import com.mezon.mobile.di.ApplicationScope
 import com.mezon.mobile.di.IoDispatcher
 import com.mezon.mobile.home.chat.AttachmentInfo
@@ -32,7 +33,13 @@ data class ChannelGalleryMediaItem(
     val filetype: String,
     val createTimeSeconds: Int,
     val uploaderId: Long,
-    val messageId: Long
+    val messageId: Long,
+    val thumbnail: String = "",
+    val filename: String = "",
+    val width: Int = 0,
+    val height: Int = 0,
+    val size: Int = 0,
+    val duration: Int = 0
 ) {
     val isVideo: Boolean get() = filetype.lowercase(Locale.US).startsWith("video/")
 }
@@ -51,6 +58,7 @@ class ChannelGalleryController @Inject constructor(
     private val sessionManager: SessionManager,
     private val notificationCenter: NotificationCenter,
     private val apiCacheTracker: ApiCacheTracker,
+    private val messageDao: MessageDao,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     @ApplicationScope private val appScope: CoroutineScope
 ) {
@@ -238,7 +246,17 @@ class ChannelGalleryController @Inject constructor(
                     )
                 }
 
-                val batchSorted = raw.attachmentsList.mapNotNull { it.toFilteredMediaOrNull() }
+                val messageIds = raw.attachmentsList.mapNotNull { attachment ->
+                    attachment.messageId.takeIf { it != 0L }
+                }.distinct()
+                val cachedMessages = withContext(ioDispatcher) {
+                    if (messageIds.isEmpty()) emptyMap<Long, MessageEntity>()
+                    else messageDao.getByIds(channelId, messageIds).associateBy { it.id }
+                }
+                val batchSorted = raw.attachmentsList.mapNotNull { attachment ->
+                    attachment.toFilteredMediaOrNull()
+                        ?.enrichFromMessage(cachedMessages[attachment.messageId])
+                }
                     .distinctBy { it.id }
                     .sortedWith(
                         compareByDescending<ChannelGalleryMediaItem> { it.createTimeSeconds }.thenByDescending { it.id }
@@ -417,7 +435,13 @@ private fun AttachmentInfo.toGalleryMediaItem(message: MessageEntity, index: Int
         filetype = filetype,
         createTimeSeconds = message.timestampSeconds.coerceAtMost(Int.MAX_VALUE.toLong()).toInt(),
         uploaderId = message.senderId,
-        messageId = message.id
+        messageId = message.id,
+        thumbnail = thumb,
+        filename = filename,
+        width = width,
+        height = height,
+        size = size,
+        duration = duration
     )
 }
 
@@ -437,6 +461,25 @@ private fun ChannelAttachment.toFilteredMediaOrNull(): ChannelGalleryMediaItem? 
         filetype = filetype,
         createTimeSeconds = createTimeSeconds,
         uploaderId = uploader,
-        messageId = messageId
+        messageId = messageId,
+        filename = filename,
+        width = width,
+        height = height,
+        size = filesize.trim().toLongOrNull()
+            ?.coerceIn(0L, Int.MAX_VALUE.toLong())
+            ?.toInt()
+            ?: 0
+    )
+}
+
+private fun ChannelGalleryMediaItem.enrichFromMessage(message: MessageEntity?): ChannelGalleryMediaItem {
+    val attachment = message?.allImageAttachments?.firstOrNull { it.url == url } ?: return this
+    return copy(
+        thumbnail = thumbnail.ifBlank { attachment.thumb },
+        filename = filename.ifBlank { attachment.filename },
+        width = width.takeIf { it > 0 } ?: attachment.width,
+        height = height.takeIf { it > 0 } ?: attachment.height,
+        size = size.takeIf { it > 0 } ?: attachment.size,
+        duration = duration.takeIf { it > 0 } ?: attachment.duration
     )
 }

--- a/app/src/main/java/com/mezon/mobile/home/ChannelGalleryController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChannelGalleryController.kt
@@ -413,7 +413,11 @@ class ChannelGalleryController @Inject constructor(
                     val existingIds = state.items.mapTo(HashSet(state.items.size)) { it.id }
 
                     mediaItems.forEach candidateLoop@{ candidate ->
-                        if (candidate.id in existingIds) return@candidateLoop
+                        val alreadyLoaded = candidate.id in existingIds ||
+                            (candidate.messageId != 0L && state.items.any {
+                                !it.isPending && it.messageId == candidate.messageId && it.url == candidate.url
+                            })
+                        if (alreadyLoaded) return@candidateLoop
                         val pendingIndex = if (!candidate.isPending) {
                             state.items.indexOfFirst { it.isPending && it.url == candidate.url }
                         } else {

--- a/app/src/main/java/com/mezon/mobile/home/ChannelGalleryController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChannelGalleryController.kt
@@ -41,7 +41,8 @@ data class ChannelGalleryMediaItem(
     val width: Int = 0,
     val height: Int = 0,
     val size: Int = 0,
-    val duration: Int = 0
+    val duration: Int = 0,
+    val isPending: Boolean = false
 ) {
     val isVideo: Boolean get() = isVideoAttachmentType(filetype)
 }
@@ -409,13 +410,20 @@ class ChannelGalleryController @Inject constructor(
 
                 var stateChanged = false
                 synchronized(state) {
-                    val existingUrls = state.items.mapTo(HashSet(state.items.size)) { it.url }
                     val existingIds = state.items.mapTo(HashSet(state.items.size)) { it.id }
 
                     mediaItems.forEach candidateLoop@{ candidate ->
-                        if (candidate.url in existingUrls || candidate.id in existingIds) return@candidateLoop
-                        state.items.add(candidate)
-                        existingUrls.add(candidate.url)
+                        if (candidate.id in existingIds) return@candidateLoop
+                        val pendingIndex = if (!candidate.isPending) {
+                            state.items.indexOfFirst { it.isPending && it.url == candidate.url }
+                        } else {
+                            -1
+                        }
+                        if (pendingIndex >= 0) {
+                            state.items[pendingIndex] = candidate
+                        } else {
+                            state.items.add(candidate)
+                        }
                         existingIds.add(candidate.id)
                         stateChanged = true
                         changed = true
@@ -509,7 +517,8 @@ private fun AttachmentInfo.toGalleryMediaItem(message: MessageEntity, index: Int
         width = width,
         height = height,
         size = size,
-        duration = duration
+        duration = duration,
+        isPending = message.isSending
     )
 }
 

--- a/app/src/main/java/com/mezon/mobile/home/ChatController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChatController.kt
@@ -1943,16 +1943,18 @@ class ChatController @Inject constructor(
             !markdownMarkers.isNullOrEmpty() -> buildTextContentWithEmojis(text, null, null, markdownMarkers)
             else -> buildTextContent(text)
         }
+        val messageFiletype = if (isVideoAttachmentType(attachment.filetype)) "video" else attachment.filetype
         val protoAttachment = messageAttachment {
             url = attachment.url
             filename = attachment.filename
-            filetype = attachment.filetype
+            filetype = messageFiletype
             size = attachment.size
             width = attachment.width
             height = attachment.height
             if (attachment.thumb.isNotEmpty()) thumbnail = attachment.thumb
             if (attachment.duration != 0) duration = attachment.duration
         }
+        val anon = isAnonymousSend(clanId)
         appScope.launch(ioDispatcher) {
             val ok = try {
                 runCatching {
@@ -1967,10 +1969,40 @@ class ChatController @Inject constructor(
                         this.isPublic = isPublic
                         this.content = content
                         attachments.add(protoAttachment)
-                        if (isAnonymousSend(clanId)) anonymousMessage = true
+                        if (anon) anonymousMessage = true
                     }
-                    channelSend(session.apiUrl, session.token, request)
+                    val ack = channelSend(session.apiUrl, session.token, request)
                     markForwardTargetUsed(channelId, channelType)
+                    if (ack.messageId != 0L) {
+                        val user = userController.get()
+                        val (senderName, senderAvatar) = optimisticSenderPresentation(user, clanId, channelType, anon)
+                        val sent = MessageEntity(
+                            id = ack.messageId,
+                            channelId = channelId,
+                            senderId = if (anon) ANONYMOUS_USER_ID else user.userId,
+                            senderName = senderName,
+                            senderUsername = if (anon) "Anonymous" else user.username,
+                            senderAvatar = senderAvatar,
+                            content = content,
+                            timestampSeconds = System.currentTimeMillis() / 1000,
+                            code = MessageEntity.CODE_CHAT,
+                            isMe = true,
+                            messageType = resolveOptimisticTypeFromAttachment(protoAttachment),
+                            attachmentUrl = attachment.url,
+                            attachmentThumb = attachment.thumb,
+                            attachmentWidth = attachment.width,
+                            attachmentHeight = attachment.height,
+                            attachmentFilename = attachment.filename,
+                            attachmentFiletype = messageFiletype,
+                            attachmentSize = attachment.size,
+                            attachmentDuration = attachment.duration
+                        )
+                        notificationCenter.postNotificationOnMainThread(
+                            NotificationCenter.didReceiveNewMessages,
+                            channelId,
+                            sent
+                        )
+                    }
                 }
                 true
             } catch (e: CancellationException) {

--- a/app/src/main/java/com/mezon/mobile/home/ChatController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChatController.kt
@@ -1733,7 +1733,7 @@ class ChatController @Inject constructor(
         contentResolver: android.content.ContentResolver,
         markdownMarkers: List<MarkdownMarker>? = null,
         parentId: Long = 0L
-    ) {
+    ): Long {
         val mode = channelTypeToStreamMode(channelType)
         val isPublic = !isChannelPrivate
         val baseContent = when {
@@ -1827,6 +1827,68 @@ class ChatController @Inject constructor(
                     NotificationCenter.pendingMessageError, channelId, tempId
                 )
             }
+        }
+        return tempId
+    }
+
+    fun shareExistingMediaToChannel(
+        channelId: Long,
+        clanId: Long,
+        channelType: Int,
+        isChannelPrivate: Boolean,
+        text: String,
+        attachment: AttachmentInfo,
+        markdownMarkers: List<MarkdownMarker>? = null,
+        parentId: Long = 0L,
+        onComplete: (ok: Boolean) -> Unit
+    ) {
+        if (attachment.url.isBlank()) {
+            appScope.launch(Dispatchers.Main) { onComplete(false) }
+            return
+        }
+        val mode = channelTypeToStreamMode(channelType)
+        val isPublic = !isChannelPrivate
+        val content = when {
+            text.isBlank() -> PresignFinishContent.emptyOutgoingContent()
+            !markdownMarkers.isNullOrEmpty() -> buildTextContentWithEmojis(text, null, null, markdownMarkers)
+            else -> buildTextContent(text)
+        }
+        val protoAttachment = messageAttachment {
+            url = attachment.url
+            filename = attachment.filename
+            filetype = attachment.filetype
+            size = attachment.size
+            width = attachment.width
+            height = attachment.height
+            if (attachment.thumb.isNotEmpty()) thumbnail = attachment.thumb
+            if (attachment.duration != 0) duration = attachment.duration
+        }
+        appScope.launch(ioDispatcher) {
+            val ok = try {
+                runCatching {
+                    joinChannelOnSocket(channelId, clanId, channelType, isChannelPrivate, parentId)
+                }
+                sessionManager.withAutoRefresh { session ->
+                    ensureActiveArchivedThreadIfNeeded(session.apiUrl, session.token, channelId, clanId, channelType)
+                    val request = channelMessageSend {
+                        this.clanId = clanId
+                        this.channelId = channelId
+                        this.mode = mode
+                        this.isPublic = isPublic
+                        this.content = content
+                        attachments.add(protoAttachment)
+                        if (isAnonymousSend(clanId)) anonymousMessage = true
+                    }
+                    channelSend(session.apiUrl, session.token, request)
+                    markForwardTargetUsed(channelId, channelType)
+                }
+                true
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                false
+            }
+            withContext(Dispatchers.Main) { onComplete(ok) }
         }
     }
 

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -2071,7 +2071,28 @@ open class ChatFragment : BaseFragment() {
                 val thumbBmp = cell.getMediaBitmap(attachmentIndex)
 
                 if (isVideo) {
-                    VideoPlayerDialog(context).play(url)
+                    val uploaderId = msg.senderId
+                    val (senderName, senderAvatarUrl) = resolveGallerySender(
+                        uploaderId,
+                        msg.senderName,
+                        msg.senderAvatar
+                    )
+                    VideoPlayerDialog(context).play(
+                        VideoPlayerDialog.VideoItem(
+                            url = url,
+                            senderName = senderName,
+                            senderAvatarUrl = senderAvatarUrl,
+                            timestamp = msg.timestampSeconds,
+                            uploaderId = uploaderId,
+                            thumbnailUrl = att.thumb,
+                            filename = att.filename,
+                            mimeType = att.filetype,
+                            width = att.width,
+                            height = att.height,
+                            size = att.size,
+                            duration = att.duration
+                        )
+                    )
                 } else {
                     val seed = allMedia.filter { !it.filetype.startsWith("video/") && it.url.isNotEmpty() }.map { it.url }
                     openChannelPhotoViewer(context, url, thumbBmp, seed, msg)

--- a/app/src/main/java/com/mezon/mobile/home/chat/PhotoViewer.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/PhotoViewer.kt
@@ -38,9 +38,6 @@ import com.mezon.mobile.util.createImgproxyUrl
 import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.text.SimpleDateFormat
-import java.util.Calendar
-import java.util.Date
 import java.util.Locale
 
 import kotlin.math.abs
@@ -460,31 +457,14 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
         val item = currentItem ?: return
         nameLabel?.text = item.senderName.takeIf { it.isNotBlank() } ?: "User"
         
-        val ts = item.timestamp
-        if (ts > 0) {
-            val msgCal = Calendar.getInstance().apply { timeInMillis = ts * 1000L }
-            val nowCal = Calendar.getInstance().apply { timeInMillis = System.currentTimeMillis() }
-
-            val msgYear = msgCal.get(Calendar.YEAR)
-            val msgDayOfYear = msgCal.get(Calendar.DAY_OF_YEAR)
-            val nowYear = nowCal.get(Calendar.YEAR)
-            val nowDayOfYear = nowCal.get(Calendar.DAY_OF_YEAR)
-
-            val isToday = msgYear == nowYear && msgDayOfYear == nowDayOfYear
-            val isYesterday = (msgYear == nowYear && msgDayOfYear == nowDayOfYear - 1) ||
-                    (nowDayOfYear == 1 && msgYear == nowYear - 1 &&
-                            msgDayOfYear == msgCal.getActualMaximum(Calendar.DAY_OF_YEAR))
-
-            val timeStr = SimpleDateFormat("h:mm a", Locale.getDefault()).format(Date(ts * 1000L))
-
-            dateLabel?.text = when {
-                isToday -> "${context.getString(R.string.common_today_at)} $timeStr"
-                isYesterday -> "${context.getString(R.string.common_yesterday_at)} $timeStr"
-                else -> SimpleDateFormat("MMM d, h:mm a", Locale.getDefault()).format(Date(ts * 1000L))
+        val formattedDate = formatViewerHeaderDate(context, item.timestamp)
+        dateLabel?.apply {
+            if (formattedDate != null) {
+                text = formattedDate
+                visibility = View.VISIBLE
+            } else {
+                visibility = View.GONE
             }
-            dateLabel?.visibility = View.VISIBLE
-        } else {
-            dateLabel?.visibility = View.GONE
         }
 
         avatarView?.let { view ->
@@ -514,7 +494,11 @@ class PhotoViewer(context: Context) : Dialog(context, android.R.style.Theme_Blac
             return
         }
         val url = currentUrl
-        optionsMenu = com.mezon.mobile.ui.cells.PopupMenu(context, ThemeColors.instance).apply {
+        optionsMenu = com.mezon.mobile.ui.cells.PopupMenu(
+            context,
+            ThemeColors.instance,
+            fullWidthDividers = true
+        ).apply {
             addItem(context.getString(R.string.action_save_media))
             addItem(context.getString(R.string.action_copy_image))
             addItem(context.getString(R.string.action_share_image))

--- a/app/src/main/java/com/mezon/mobile/home/chat/VideoPlayerDialog.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/VideoPlayerDialog.kt
@@ -1,10 +1,8 @@
 package com.mezon.mobile.home.chat
 
 import android.animation.ObjectAnimator
-import android.app.Dialog
 import android.app.DownloadManager
 import android.content.BroadcastReceiver
-import android.content.ComponentName
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
@@ -15,7 +13,6 @@ import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.GradientDrawable
 import android.net.Uri
 import android.os.Environment
-import android.util.Log
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
@@ -26,6 +23,8 @@ import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.ProgressBar
 import android.widget.TextView
+import androidx.activity.ComponentDialog
+import androidx.activity.OnBackPressedCallback
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -40,15 +39,13 @@ import com.mezon.mobile.core.AndroidUtilities
 import com.mezon.mobile.core.LayoutHelper
 import com.mezon.mobile.core.ThemeColors
 import com.mezon.mobile.di.FragmentEntryPoint
+import com.mezon.mobile.home.sharing.ExistingVideoShareStore
 import com.mezon.mobile.home.sharing.VideoShareRefinementContract
 import com.mezon.mobile.ui.cells.BackupImageView
 import com.mezon.mobile.ui.cells.PopupMenu
 import com.mezon.mobile.ui.cells.ToastOverlay
 import com.mezon.mobile.util.avatarImgproxyUrl
 import dagger.hilt.android.EntryPointAccessors
-import java.text.SimpleDateFormat
-import java.util.Calendar
-import java.util.Date
 import java.util.Locale
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -60,7 +57,7 @@ private const val VIDEO_SEEK_INCREMENT_MS = 15_000L
 private const val VIDEO_CONTROLLER_TIMEOUT_MS = 3_000
 private const val VIDEO_SAVE_PROGRESS_POLL_INTERVAL_MS = 300L
 private const val NO_PENDING_DOWNLOAD_ID = -1L
-private val VIDEO_ANONYMOUS_USER_ID = BuildConfig.MEZON_ANONYMOUS_USER_ID.toLongOrNull() ?: 0L
+private val VIDEO_ANONYMOUS_USER_ID = BuildConfig.MEZON_ANONYMOUS_USER_ID.toLongOrNull() ?: -1L
 
 private fun Context.findLifecycleOwner(): LifecycleOwner? {
     var current: Context? = this
@@ -74,7 +71,7 @@ private fun Context.findLifecycleOwner(): LifecycleOwner? {
 }
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
-class VideoPlayerDialog(context: Context) : Dialog(context, android.R.style.Theme_Black_NoTitleBar_Fullscreen) {
+class VideoPlayerDialog(context: Context) : ComponentDialog(context, android.R.style.Theme_Black_NoTitleBar_Fullscreen) {
 
     companion object {
         private var activeInstance: java.lang.ref.WeakReference<VideoPlayerDialog>? = null
@@ -138,13 +135,17 @@ class VideoPlayerDialog(context: Context) : Dialog(context, android.R.style.Them
             if (!isShowing) return
             player?.let { playbackPositionMs = it.currentPosition }
             releasePlayer()
+            stopSaveProgress()
             stoppedForLifecycle = true
         }
 
         override fun onStart(owner: LifecycleOwner) {
-            if (!isShowing || !stoppedForLifecycle || !::currentItem.isInitialized) return
-            initializePlayer(playbackPositionMs, playWhenReady = false)
-            stoppedForLifecycle = false
+            if (!isShowing) return
+            if (stoppedForLifecycle && ::currentItem.isInitialized) {
+                initializePlayer(playbackPositionMs, playWhenReady = false)
+                stoppedForLifecycle = false
+            }
+            pendingDownloadId.takeIf { it != NO_PENDING_DOWNLOAD_ID }?.let(::startSaveProgress)
         }
 
         override fun onResume(owner: LifecycleOwner) {
@@ -167,7 +168,18 @@ class VideoPlayerDialog(context: Context) : Dialog(context, android.R.style.Them
         override fun onReceive(receiverContext: Context?, intent: Intent?) {
             if (intent?.action != DownloadManager.ACTION_DOWNLOAD_COMPLETE) return
             val downloadId = intent.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, NO_PENDING_DOWNLOAD_ID)
-            handleDownloadTerminalStatus(downloadId, getDownloadStatus(downloadId))
+            if (downloadId != pendingDownloadId) return
+            val pendingResult = goAsync()
+            entryPoint.applicationScope().launch(entryPoint.ioDispatcher()) {
+                try {
+                    val status = getDownloadStatus(downloadId)
+                    withContext(entryPoint.mainDispatcher()) {
+                        handleDownloadTerminalStatus(downloadId, status)
+                    }
+                } finally {
+                    pendingResult.finish()
+                }
+            }
         }
     }
 
@@ -177,6 +189,11 @@ class VideoPlayerDialog(context: Context) : Dialog(context, android.R.style.Them
 
     init {
         requestWindowFeature(Window.FEATURE_NO_TITLE)
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                dismissWithAnimation()
+            }
+        })
         window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
         window?.addFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
         window?.setBackgroundDrawable(backgroundDrawable)
@@ -469,25 +486,9 @@ class VideoPlayerDialog(context: Context) : Dialog(context, android.R.style.Them
         val item = currentItem
         nameLabel.text = item.senderName.takeIf { it.isNotBlank() } ?: "User"
 
-        val timestamp = item.timestamp
-        if (timestamp > 0) {
-            val messageCalendar = Calendar.getInstance().apply { timeInMillis = timestamp * 1000L }
-            val currentCalendar = Calendar.getInstance().apply { timeInMillis = System.currentTimeMillis() }
-            val isToday = messageCalendar.get(Calendar.YEAR) == currentCalendar.get(Calendar.YEAR) &&
-                messageCalendar.get(Calendar.DAY_OF_YEAR) == currentCalendar.get(Calendar.DAY_OF_YEAR)
-            val isYesterday =
-                (messageCalendar.get(Calendar.YEAR) == currentCalendar.get(Calendar.YEAR) &&
-                    messageCalendar.get(Calendar.DAY_OF_YEAR) == currentCalendar.get(Calendar.DAY_OF_YEAR) - 1) ||
-                    (currentCalendar.get(Calendar.DAY_OF_YEAR) == 1 &&
-                        messageCalendar.get(Calendar.YEAR) == currentCalendar.get(Calendar.YEAR) - 1 &&
-                        messageCalendar.get(Calendar.DAY_OF_YEAR) == messageCalendar.getActualMaximum(Calendar.DAY_OF_YEAR))
-            val time = SimpleDateFormat("h:mm a", Locale.getDefault()).format(Date(timestamp * 1000L))
-
-            dateLabel.text = when {
-                isToday -> "${context.getString(R.string.common_today_at)} $time"
-                isYesterday -> "${context.getString(R.string.common_yesterday_at)} $time"
-                else -> SimpleDateFormat("MMM d, h:mm a", Locale.getDefault()).format(Date(timestamp * 1000L))
-            }
+        val formattedDate = formatViewerHeaderDate(context, item.timestamp)
+        if (formattedDate != null) {
+            dateLabel.text = formattedDate
             dateLabel.visibility = View.VISIBLE
         } else {
             dateLabel.visibility = View.GONE
@@ -511,13 +512,15 @@ class VideoPlayerDialog(context: Context) : Dialog(context, android.R.style.Them
     private fun showMoreOptions(anchorView: View) {
         if (System.currentTimeMillis() - lastMenuDismissTime < 200) return
 
-        optionsMenu = PopupMenu(context, ThemeColors.instance).apply {
+        optionsMenu = PopupMenu(context, ThemeColors.instance, fullWidthDividers = true).apply {
             addItem(context.getString(R.string.action_save_video))
-            addItem(context.getString(R.string.action_share_video))
+            addItem(context.getString(R.string.action_share_video_to_mezon))
+            addItem(context.getString(R.string.action_share_video_to_other_apps))
             setOnItemClickListener { index ->
                 when (index) {
                     0 -> saveVideo()
-                    1 -> shareVideo()
+                    1 -> shareVideoToMezon()
+                    2 -> shareVideoToOtherApps()
                 }
             }
             setOnDismissListener {
@@ -666,9 +669,9 @@ class VideoPlayerDialog(context: Context) : Dialog(context, android.R.style.Them
         return getDownloadProgress(downloadId)?.status
     }
 
-    private fun shareVideo() {
+    private fun buildShareAttachment(): AttachmentInfo? {
         val item = currentItem
-        if (item.url.isEmpty()) return
+        if (item.url.isEmpty()) return null
         val currentVideoSize = player?.videoSize
         val resolvedWidth = item.width.takeIf { it > 0 } ?: currentVideoSize?.width?.takeIf { it > 0 } ?: 0
         val resolvedHeight = item.height.takeIf { it > 0 } ?: currentVideoSize?.height?.takeIf { it > 0 } ?: 0
@@ -682,7 +685,7 @@ class VideoPlayerDialog(context: Context) : Dialog(context, android.R.style.Them
             ?: VideoShareRefinementContract.mimeTypeFromUrl(item.url)
         val filename = item.filename.takeIf { it.isNotBlank() }
             ?: VideoShareRefinementContract.filenameFromUrl(item.url, mimeType)
-        val attachment = AttachmentInfo(
+        return AttachmentInfo(
             url = item.url,
             thumb = item.thumbnailUrl,
             width = resolvedWidth,
@@ -692,24 +695,18 @@ class VideoPlayerDialog(context: Context) : Dialog(context, android.R.style.Them
             size = item.size,
             duration = resolvedDuration
         )
+    }
+
+    private fun shareVideoToMezon() {
+        val attachment = buildShareAttachment() ?: return
         try {
-            val targetIntent = Intent(Intent.ACTION_SEND).apply {
-                type = mimeType
+            val token = ExistingVideoShareStore.put(attachment)
+            val shareIntent = Intent(context, MainActivity::class.java).apply {
+                action = Intent.ACTION_SEND
+                type = attachment.filetype
+                putExtra(VideoShareRefinementContract.EXTRA_INTERNAL_SHARE_TOKEN, token)
             }
-            val mezonComponent = ComponentName(context, MainActivity::class.java)
-            val mezonIntent = Intent(targetIntent).apply {
-                component = mezonComponent
-                putExtra(VideoShareRefinementContract.EXTRA_INTERNAL_TARGET, true)
-            }
-            val chooser = Intent.createChooser(targetIntent, context.getString(R.string.action_share_video)).apply {
-                putExtra(
-                    Intent.EXTRA_CHOOSER_REFINEMENT_INTENT_SENDER,
-                    VideoShareRefinementContract.createIntentSender(context, attachment)
-                )
-                putExtra(Intent.EXTRA_INITIAL_INTENTS, arrayOf(mezonIntent))
-                putExtra(Intent.EXTRA_EXCLUDE_COMPONENTS, arrayOf(mezonComponent))
-            }
-            context.startActivity(chooser)
+            context.startActivity(shareIntent)
         } catch (_: Exception) {
             if (isShowing) {
                 showToast(ToastOverlay.ToastType.ERROR, R.string.message_toast_share_failed)
@@ -717,8 +714,14 @@ class VideoPlayerDialog(context: Context) : Dialog(context, android.R.style.Them
         }
     }
 
-    @Suppress("OVERRIDE_DEPRECATION")
-    override fun onBackPressed() {
-        dismissWithAnimation()
+    private fun shareVideoToOtherApps() {
+        val attachment = buildShareAttachment() ?: return
+        try {
+            context.startActivity(VideoShareRefinementContract.createPreparationIntent(context, attachment))
+        } catch (_: Exception) {
+            if (isShowing) {
+                showToast(ToastOverlay.ToastType.ERROR, R.string.message_toast_share_failed)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/mezon/mobile/home/chat/VideoPlayerDialog.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/VideoPlayerDialog.kt
@@ -1,112 +1,441 @@
 package com.mezon.mobile.home.chat
 
+import android.animation.ObjectAnimator
 import android.app.Dialog
 import android.app.DownloadManager
-import android.content.ClipData
-import android.content.ClipboardManager
+import android.content.BroadcastReceiver
+import android.content.ComponentName
 import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.res.ColorStateList
 import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.GradientDrawable
 import android.net.Uri
 import android.os.Environment
+import android.util.Log
 import android.view.Gravity
+import android.view.View
 import android.view.ViewGroup
 import android.view.Window
 import android.view.WindowManager
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
-import android.widget.Toast
+import android.widget.ProgressBar
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.PlayerView
+import com.mezon.mobile.BuildConfig
+import com.mezon.mobile.MainActivity
+import com.mezon.mobile.R
+import com.mezon.mobile.core.AndroidUtilities
 import com.mezon.mobile.core.LayoutHelper
+import com.mezon.mobile.core.ThemeColors
+import com.mezon.mobile.di.FragmentEntryPoint
+import com.mezon.mobile.home.sharing.VideoShareRefinementContract
+import com.mezon.mobile.ui.cells.BackupImageView
+import com.mezon.mobile.ui.cells.PopupMenu
+import com.mezon.mobile.ui.cells.ToastOverlay
+import com.mezon.mobile.util.avatarImgproxyUrl
+import dagger.hilt.android.EntryPointAccessors
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+private const val VIDEO_SEEK_INCREMENT_MS = 15_000L
+private const val VIDEO_CONTROLLER_TIMEOUT_MS = 3_000
+private const val VIDEO_SAVE_PROGRESS_POLL_INTERVAL_MS = 300L
+private const val NO_PENDING_DOWNLOAD_ID = -1L
+private val VIDEO_ANONYMOUS_USER_ID = BuildConfig.MEZON_ANONYMOUS_USER_ID.toLongOrNull() ?: 0L
+
+private fun Context.findLifecycleOwner(): LifecycleOwner? {
+    var current: Context? = this
+    while (current is ContextWrapper) {
+        if (current is LifecycleOwner) return current
+        val base = current.baseContext
+        if (base === current) break
+        current = base
+    }
+    return current as? LifecycleOwner
+}
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 class VideoPlayerDialog(context: Context) : Dialog(context, android.R.style.Theme_Black_NoTitleBar_Fullscreen) {
 
+    companion object {
+        private var activeInstance: java.lang.ref.WeakReference<VideoPlayerDialog>? = null
+
+        fun dismissActiveIfShowing() {
+            activeInstance?.get()?.takeIf { it.isShowing }?.dismiss()
+            activeInstance = null
+        }
+    }
+
+    data class VideoItem(
+        val url: String,
+        val senderName: String,
+        val senderAvatarUrl: String?,
+        val timestamp: Long,
+        val uploaderId: Long,
+        val thumbnailUrl: String = "",
+        val filename: String = "",
+        val mimeType: String = "",
+        val width: Int = 0,
+        val height: Int = 0,
+        val size: Int = 0,
+        val duration: Int = 0
+    )
+
+    private val backgroundDrawable = ColorDrawable(Color.BLACK)
     private val playerView: PlayerView
+    private val topBar: FrameLayout
+    private val avatarView: BackupImageView
+    private val nameLabel: android.widget.TextView
+    private val dateLabel: android.widget.TextView
+    private val saveProgressOverlay: FrameLayout
+    private val saveProgressLabel: TextView
+    private val saveProgressBar: ProgressBar
+
     private var player: ExoPlayer? = null
-    private var currentUrl = ""
+    private lateinit var currentItem: VideoItem
+    private var optionsMenu: PopupMenu? = null
+    private var lastMenuDismissTime = 0L
+    private var saveProgressJob: Job? = null
+    private var pendingDownloadId = NO_PENDING_DOWNLOAD_ID
+    private var isDownloadReceiverRegistered = false
+    private val hostLifecycleOwner = context.findLifecycleOwner()
+    private var isLifecycleObserverRegistered = false
+    private var playbackPositionMs = 0L
+    private var resumePlaybackOnForeground = false
+    private var stoppedForLifecycle = false
+
+    private val lifecycleObserver = object : DefaultLifecycleObserver {
+        override fun onPause(owner: LifecycleOwner) {
+            if (!isShowing) return
+            player?.let { currentPlayer ->
+                playbackPositionMs = currentPlayer.currentPosition
+                resumePlaybackOnForeground = currentPlayer.playWhenReady &&
+                    currentPlayer.playbackState != Player.STATE_ENDED
+                currentPlayer.pause()
+            }
+        }
+
+        override fun onStop(owner: LifecycleOwner) {
+            if (!isShowing) return
+            player?.let { playbackPositionMs = it.currentPosition }
+            releasePlayer()
+            stoppedForLifecycle = true
+        }
+
+        override fun onStart(owner: LifecycleOwner) {
+            if (!isShowing || !stoppedForLifecycle || !::currentItem.isInitialized) return
+            initializePlayer(playbackPositionMs, playWhenReady = false)
+            stoppedForLifecycle = false
+        }
+
+        override fun onResume(owner: LifecycleOwner) {
+            if (!isShowing || !resumePlaybackOnForeground) return
+            player?.play()
+            resumePlaybackOnForeground = false
+        }
+
+        override fun onDestroy(owner: LifecycleOwner) {
+            if (isShowing) {
+                dismiss()
+            } else {
+                unregisterLifecycleObserver()
+                releasePlayer()
+            }
+        }
+    }
+
+    private val downloadCompleteReceiver = object : BroadcastReceiver() {
+        override fun onReceive(receiverContext: Context?, intent: Intent?) {
+            if (intent?.action != DownloadManager.ACTION_DOWNLOAD_COMPLETE) return
+            val downloadId = intent.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, NO_PENDING_DOWNLOAD_ID)
+            handleDownloadTerminalStatus(downloadId, getDownloadStatus(downloadId))
+        }
+    }
+
+    private val entryPoint: FragmentEntryPoint by lazy {
+        EntryPointAccessors.fromApplication(context.applicationContext, FragmentEntryPoint::class.java)
+    }
 
     init {
         requestWindowFeature(Window.FEATURE_NO_TITLE)
         window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
         window?.addFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
-        window?.setBackgroundDrawable(android.graphics.drawable.ColorDrawable(Color.BLACK))
+        window?.setBackgroundDrawable(backgroundDrawable)
 
         val root = FrameLayout(context)
 
         playerView = PlayerView(context).apply {
             setShowBuffering(PlayerView.SHOW_BUFFERING_ALWAYS)
             setBackgroundColor(Color.BLACK)
-            controllerAutoShow = false
+            useController = true
+            controllerAutoShow = true
+            controllerHideOnTouch = true
+            controllerShowTimeoutMs = VIDEO_CONTROLLER_TIMEOUT_MS
+            setShowPreviousButton(false)
+            setShowNextButton(false)
+            setShowRewindButton(true)
+            setShowFastForwardButton(true)
         }
-        root.addView(playerView, FrameLayout.LayoutParams(
-            FrameLayout.LayoutParams.MATCH_PARENT,
-            FrameLayout.LayoutParams.MATCH_PARENT
-        ))
-
-        val closeButton = ImageView(context).apply {
-            setImageResource(android.R.drawable.ic_menu_close_clear_cancel)
-            setColorFilter(Color.WHITE)
-            setPadding(LayoutHelper.dp(12), LayoutHelper.dp(12), LayoutHelper.dp(12), LayoutHelper.dp(12))
-            setOnClickListener { dismiss() }
-        }
-        val closeParams = FrameLayout.LayoutParams(LayoutHelper.dp(48), LayoutHelper.dp(48))
-        closeParams.gravity = Gravity.TOP or Gravity.START
-        closeParams.topMargin = LayoutHelper.dp(40)
-        closeParams.leftMargin = LayoutHelper.dp(8)
-        root.addView(closeButton, closeParams)
-
-        val toolbar = LinearLayout(context).apply {
-            orientation = LinearLayout.HORIZONTAL
-            gravity = Gravity.CENTER
-            setBackgroundColor(0x99000000.toInt())
-            val pad = LayoutHelper.dp(12)
-            setPadding(pad, pad, pad, pad)
-        }
-        val toolbarParams = FrameLayout.LayoutParams(
-            FrameLayout.LayoutParams.MATCH_PARENT,
-            LayoutHelper.dp(56)
+        root.addView(
+            playerView,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT
+            )
         )
-        toolbarParams.gravity = Gravity.BOTTOM
-        root.addView(toolbar, toolbarParams)
 
-        toolbar.addView(makeButton(android.R.drawable.ic_menu_share) { shareUrl() })
-        toolbar.addView(makeButton(android.R.drawable.ic_menu_save) { downloadUrl() })
-        toolbar.addView(makeButton(android.R.drawable.ic_menu_agenda) { copyLink() })
+        topBar = FrameLayout(context).apply {
+            setBackgroundColor(0x99000000.toInt())
+            isClickable = true
+        }
+
+        val backButton = ImageView(context).apply {
+            setImageResource(R.drawable.ic_arrow_back)
+            setColorFilter(Color.WHITE)
+            val padding = LayoutHelper.dp(16)
+            setPadding(padding, padding, padding, padding)
+            setOnClickListener { dismissWithAnimation() }
+        }
+        topBar.addView(
+            backButton,
+            FrameLayout.LayoutParams(
+                LayoutHelper.dp(56),
+                LayoutHelper.dp(56),
+                Gravity.START or Gravity.CENTER_VERTICAL
+            )
+        )
+
+        avatarView = BackupImageView(context).apply {
+            setRoundRadius(LayoutHelper.dp(20))
+        }
+        topBar.addView(
+            avatarView,
+            FrameLayout.LayoutParams(
+                LayoutHelper.dp(40),
+                LayoutHelper.dp(40),
+                Gravity.START or Gravity.CENTER_VERTICAL
+            ).apply {
+                marginStart = LayoutHelper.dp(56)
+            }
+        )
+
+        val textLayout = LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+            gravity = Gravity.CENTER_VERTICAL
+        }
+        nameLabel = android.widget.TextView(context).apply {
+            setTextColor(Color.WHITE)
+            textSize = 16f
+            typeface = android.graphics.Typeface.DEFAULT_BOLD
+            isSingleLine = true
+        }
+        dateLabel = android.widget.TextView(context).apply {
+            setTextColor(0xCCFFFFFF.toInt())
+            textSize = 13f
+            isSingleLine = true
+        }
+        textLayout.addView(nameLabel, LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT)
+        textLayout.addView(dateLabel, LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT)
+        topBar.addView(
+            textLayout,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                Gravity.START or Gravity.CENTER_VERTICAL
+            ).apply {
+                marginStart = LayoutHelper.dp(108)
+                marginEnd = LayoutHelper.dp(56)
+            }
+        )
+
+        val moreButton = ImageView(context).apply {
+            setImageResource(R.drawable.ic_more_vertical_24)
+            setColorFilter(Color.WHITE)
+            val padding = LayoutHelper.dp(16)
+            setPadding(padding, padding, padding, padding)
+            setOnClickListener { showMoreOptions(it) }
+        }
+        topBar.addView(
+            moreButton,
+            FrameLayout.LayoutParams(
+                LayoutHelper.dp(56),
+                LayoutHelper.dp(56),
+                Gravity.END or Gravity.CENTER_VERTICAL
+            )
+        )
+
+        root.addView(
+            topBar,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                LayoutHelper.dp(56),
+                Gravity.TOP
+            ).apply {
+                topMargin = AndroidUtilities.statusBarHeight
+            }
+        )
+
+        playerView.setControllerVisibilityListener(
+            PlayerView.ControllerVisibilityListener { visibility ->
+                setHeaderVisible(visibility == View.VISIBLE)
+            }
+        )
+
+        saveProgressOverlay = FrameLayout(context).apply {
+            visibility = View.GONE
+            setBackgroundColor(0x66000000)
+            isClickable = true
+            isFocusable = true
+        }
+        val saveProgressCard = LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+            gravity = Gravity.CENTER_HORIZONTAL
+            setPadding(
+                LayoutHelper.dp(28),
+                LayoutHelper.dp(24),
+                LayoutHelper.dp(28),
+                LayoutHelper.dp(24)
+            )
+            background = GradientDrawable().apply {
+                setColor(0xFF1D1D2B.toInt())
+                cornerRadius = LayoutHelper.dpf(14f)
+            }
+        }
+        val saveProgressSpinner = ProgressBar(context).apply {
+            isIndeterminate = true
+            indeterminateTintList = ColorStateList.valueOf(Color.WHITE)
+        }
+        saveProgressCard.addView(
+            saveProgressSpinner,
+            LinearLayout.LayoutParams(LayoutHelper.dp(40), LayoutHelper.dp(40)).apply {
+                gravity = Gravity.CENTER_HORIZONTAL
+            }
+        )
+        saveProgressLabel = TextView(context).apply {
+            setTextColor(Color.WHITE)
+            textSize = 16f
+            gravity = Gravity.CENTER
+            text = context.getString(R.string.video_save_downloading)
+        }
+        saveProgressCard.addView(
+            saveProgressLabel,
+            LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT
+            ).apply {
+                topMargin = LayoutHelper.dp(14)
+            }
+        )
+        saveProgressBar = ProgressBar(context, null, android.R.attr.progressBarStyleHorizontal).apply {
+            max = 100
+            progress = 0
+            isIndeterminate = true
+            progressTintList = ColorStateList.valueOf(ThemeColors.instance.primary)
+            progressBackgroundTintList = ColorStateList.valueOf(0xFF5A5A66.toInt())
+        }
+        saveProgressCard.addView(
+            saveProgressBar,
+            LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LayoutHelper.dp(4)
+            ).apply {
+                topMargin = LayoutHelper.dp(18)
+            }
+        )
+        saveProgressOverlay.addView(
+            saveProgressCard,
+            FrameLayout.LayoutParams(LayoutHelper.dp(290), FrameLayout.LayoutParams.WRAP_CONTENT, Gravity.CENTER)
+        )
+        root.addView(
+            saveProgressOverlay,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT
+            )
+        )
 
         setContentView(root)
-        setOnDismissListener { releasePlayer() }
-    }
-
-    private fun makeButton(iconRes: Int, onClick: () -> Unit): ImageView {
-        return ImageView(context).apply {
-            setImageResource(iconRes)
-            setColorFilter(Color.WHITE)
-            val p = LayoutHelper.dp(16)
-            setPadding(p, p, p, p)
-            layoutParams = LinearLayout.LayoutParams(LayoutHelper.dp(56), LayoutHelper.dp(56)).apply {
-                marginStart = LayoutHelper.dp(8)
-                marginEnd = LayoutHelper.dp(8)
-            }
-            setOnClickListener { onClick() }
+        setOnDismissListener {
+            optionsMenu?.dismiss()
+            cancelPendingDownload()
+            releasePlayer()
         }
     }
 
-    fun play(url: String) {
-        currentUrl = url
+    fun play(item: VideoItem) {
+        currentItem = item
+        updateHeader()
+        playbackPositionMs = 0L
+        resumePlaybackOnForeground = false
+        stoppedForLifecycle = false
+        initializePlayer(startPositionMs = 0L, playWhenReady = true)
+
+        playerView.alpha = 1f
+        topBar.alpha = 1f
+        topBar.visibility = View.VISIBLE
+        backgroundDrawable.alpha = 0
+        activeInstance = java.lang.ref.WeakReference(this)
+        super.show()
+        registerLifecycleObserver()
+        ObjectAnimator.ofInt(backgroundDrawable, "alpha", 0, 255).setDuration(200).start()
+        playerView.showController()
+    }
+
+    override fun dismiss() {
+        resumePlaybackOnForeground = false
+        stoppedForLifecycle = false
+        unregisterLifecycleObserver()
+        if (activeInstance?.get() === this) {
+            activeInstance = null
+        }
+        super.dismiss()
+    }
+
+    private fun initializePlayer(startPositionMs: Long, playWhenReady: Boolean) {
         releasePlayer()
-        player = ExoPlayer.Builder(context).build().also { exo ->
-            playerView.player = exo
-            exo.setMediaItem(MediaItem.fromUri(url))
-            exo.repeatMode = Player.REPEAT_MODE_OFF
-            exo.prepare()
-            exo.playWhenReady = true
-        }
-        show()
-        playerView.hideController()
+        player = ExoPlayer.Builder(context)
+            .setSeekBackIncrementMs(VIDEO_SEEK_INCREMENT_MS)
+            .setSeekForwardIncrementMs(VIDEO_SEEK_INCREMENT_MS)
+            .build()
+            .also { exoPlayer ->
+                playerView.player = exoPlayer
+                exoPlayer.setMediaItem(MediaItem.fromUri(currentItem.url))
+                exoPlayer.repeatMode = Player.REPEAT_MODE_OFF
+                if (startPositionMs > 0L) exoPlayer.seekTo(startPositionMs)
+                exoPlayer.prepare()
+                exoPlayer.playWhenReady = playWhenReady
+            }
+    }
+
+    private fun registerLifecycleObserver() {
+        if (isLifecycleObserverRegistered) return
+        hostLifecycleOwner?.lifecycle?.addObserver(lifecycleObserver) ?: return
+        isLifecycleObserverRegistered = true
+    }
+
+    private fun unregisterLifecycleObserver() {
+        if (!isLifecycleObserverRegistered) return
+        hostLifecycleOwner?.lifecycle?.removeObserver(lifecycleObserver)
+        isLifecycleObserverRegistered = false
     }
 
     private fun releasePlayer() {
@@ -115,38 +444,281 @@ class VideoPlayerDialog(context: Context) : Dialog(context, android.R.style.Them
         playerView.player = null
     }
 
-    private fun copyLink() {
-        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-        clipboard.setPrimaryClip(ClipData.newPlainText("url", currentUrl))
-        Toast.makeText(context, "Link copied", Toast.LENGTH_SHORT).show()
+    private fun setHeaderVisible(visible: Boolean) {
+        val targetAlpha = if (visible) 1f else 0f
+        if (visible) topBar.visibility = View.VISIBLE
+        topBar.animate().alpha(targetAlpha).setDuration(200).withEndAction {
+            if (!visible) topBar.visibility = View.INVISIBLE
+        }.start()
     }
 
-    private fun downloadUrl() {
-        try {
-            val filename = currentUrl.substringAfterLast('/').substringBefore('?').ifEmpty { "video" }
-            val request = DownloadManager.Request(Uri.parse(currentUrl))
-                .setTitle(filename)
-                .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
-                .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, filename)
-            val dm = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
-            dm.enqueue(request)
-            Toast.makeText(context, "Downloading...", Toast.LENGTH_SHORT).show()
-        } catch (_: Exception) {
-            Toast.makeText(context, "Download failed", Toast.LENGTH_SHORT).show()
+    private fun dismissWithAnimation() {
+        val animator = ObjectAnimator.ofInt(backgroundDrawable, "alpha", 255, 0)
+        animator.duration = 150
+        animator.addListener(object : android.animation.AnimatorListenerAdapter() {
+            override fun onAnimationEnd(animation: android.animation.Animator) {
+                dismiss()
+            }
+        })
+        animator.start()
+        playerView.animate().alpha(0f).setDuration(150).start()
+        topBar.animate().alpha(0f).setDuration(150).start()
+    }
+
+    private fun updateHeader() {
+        val item = currentItem
+        nameLabel.text = item.senderName.takeIf { it.isNotBlank() } ?: "User"
+
+        val timestamp = item.timestamp
+        if (timestamp > 0) {
+            val messageCalendar = Calendar.getInstance().apply { timeInMillis = timestamp * 1000L }
+            val currentCalendar = Calendar.getInstance().apply { timeInMillis = System.currentTimeMillis() }
+            val isToday = messageCalendar.get(Calendar.YEAR) == currentCalendar.get(Calendar.YEAR) &&
+                messageCalendar.get(Calendar.DAY_OF_YEAR) == currentCalendar.get(Calendar.DAY_OF_YEAR)
+            val isYesterday =
+                (messageCalendar.get(Calendar.YEAR) == currentCalendar.get(Calendar.YEAR) &&
+                    messageCalendar.get(Calendar.DAY_OF_YEAR) == currentCalendar.get(Calendar.DAY_OF_YEAR) - 1) ||
+                    (currentCalendar.get(Calendar.DAY_OF_YEAR) == 1 &&
+                        messageCalendar.get(Calendar.YEAR) == currentCalendar.get(Calendar.YEAR) - 1 &&
+                        messageCalendar.get(Calendar.DAY_OF_YEAR) == messageCalendar.getActualMaximum(Calendar.DAY_OF_YEAR))
+            val time = SimpleDateFormat("h:mm a", Locale.getDefault()).format(Date(timestamp * 1000L))
+
+            dateLabel.text = when {
+                isToday -> "${context.getString(R.string.common_today_at)} $time"
+                isYesterday -> "${context.getString(R.string.common_yesterday_at)} $time"
+                else -> SimpleDateFormat("MMM d, h:mm a", Locale.getDefault()).format(Date(timestamp * 1000L))
+            }
+            dateLabel.visibility = View.VISIBLE
+        } else {
+            dateLabel.visibility = View.GONE
+        }
+
+        when {
+            item.uploaderId == VIDEO_ANONYMOUS_USER_ID -> {
+                avatarView.setImageDrawable(com.mezon.mobile.ui.cells.MezonIcon.anonymousAvatar.getDrawable(context))
+            }
+            !item.senderAvatarUrl.isNullOrEmpty() -> {
+                avatarView.setImage(
+                    avatarImgproxyUrl(item.senderAvatarUrl, LayoutHelper.dp(40)),
+                    item.uploaderId,
+                    item.senderName
+                )
+            }
+            else -> avatarView.setImage(null, item.uploaderId, item.senderName)
         }
     }
 
-    private fun shareUrl() {
-        try {
-            val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
-                type = "text/plain"
-                putExtra(android.content.Intent.EXTRA_TEXT, currentUrl)
+    private fun showMoreOptions(anchorView: View) {
+        if (System.currentTimeMillis() - lastMenuDismissTime < 200) return
+
+        optionsMenu = PopupMenu(context, ThemeColors.instance).apply {
+            addItem(context.getString(R.string.action_save_video))
+            addItem(context.getString(R.string.action_share_video))
+            setOnItemClickListener { index ->
+                when (index) {
+                    0 -> saveVideo()
+                    1 -> shareVideo()
+                }
             }
-            context.startActivity(android.content.Intent.createChooser(intent, "Share"))
-        } catch (_: Exception) {}
+            setOnDismissListener {
+                optionsMenu = null
+                lastMenuDismissTime = System.currentTimeMillis()
+            }
+            show(anchorView)
+        }
     }
 
+    private fun showToast(type: ToastOverlay.ToastType, messageResId: Int) {
+        val parent = window?.decorView as? ViewGroup ?: return
+        ToastOverlay(context, ThemeColors.instance).show(parent, type, context.getString(messageResId))
+    }
+
+    private fun saveVideo() {
+        val url = currentItem.url
+        if (url.isEmpty() || pendingDownloadId != NO_PENDING_DOWNLOAD_ID) return
+
+        try {
+            val filename = url.substringAfterLast('/').substringBefore('?').ifEmpty { "video" }
+            val request = DownloadManager.Request(Uri.parse(url))
+                .setTitle(filename)
+                .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+                .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, filename)
+            val downloadManager = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+            registerDownloadReceiver()
+            pendingDownloadId = downloadManager.enqueue(request)
+            startSaveProgress(pendingDownloadId)
+        } catch (_: Exception) {
+            cancelPendingDownload()
+            showToast(ToastOverlay.ToastType.ERROR, R.string.message_toast_save_failed)
+        }
+    }
+
+    private fun registerDownloadReceiver() {
+        if (isDownloadReceiverRegistered) return
+        ContextCompat.registerReceiver(
+            context,
+            downloadCompleteReceiver,
+            IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
+            ContextCompat.RECEIVER_EXPORTED
+        )
+        isDownloadReceiverRegistered = true
+    }
+
+    private fun clearPendingDownloadObserver() {
+        pendingDownloadId = NO_PENDING_DOWNLOAD_ID
+        stopSaveProgress()
+        if (!isDownloadReceiverRegistered) return
+        runCatching { context.unregisterReceiver(downloadCompleteReceiver) }
+        isDownloadReceiverRegistered = false
+    }
+
+    private fun cancelPendingDownload() {
+        val downloadId = pendingDownloadId
+        if (downloadId != NO_PENDING_DOWNLOAD_ID) {
+            runCatching {
+                val downloadManager = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+                downloadManager.remove(downloadId)
+            }
+        }
+        clearPendingDownloadObserver()
+    }
+
+    private fun startSaveProgress(downloadId: Long) {
+        saveProgressJob?.cancel()
+        saveProgressLabel.text = context.getString(R.string.video_save_downloading)
+        saveProgressBar.isIndeterminate = true
+        saveProgressBar.progress = 0
+        saveProgressOverlay.visibility = View.VISIBLE
+
+        saveProgressJob = entryPoint.applicationScope().launch(entryPoint.mainDispatcher()) {
+            while (isActive && pendingDownloadId == downloadId && isShowing) {
+                val snapshot = withContext(entryPoint.ioDispatcher()) {
+                    getDownloadProgress(downloadId)
+                }
+                if (snapshot != null) {
+                    if (handleDownloadTerminalStatus(downloadId, snapshot.status)) break
+                    updateSaveProgress(snapshot)
+                }
+                delay(VIDEO_SAVE_PROGRESS_POLL_INTERVAL_MS)
+            }
+        }
+    }
+
+    private fun handleDownloadTerminalStatus(downloadId: Long, status: Int?): Boolean {
+        if (downloadId != pendingDownloadId) return false
+        val toast = when (status) {
+            DownloadManager.STATUS_SUCCESSFUL -> ToastOverlay.ToastType.SUCCESS to R.string.message_toast_save_success
+            DownloadManager.STATUS_FAILED -> ToastOverlay.ToastType.ERROR to R.string.message_toast_save_failed
+            else -> return false
+        }
+        clearPendingDownloadObserver()
+        if (isShowing) showToast(toast.first, toast.second)
+        return true
+    }
+
+    private fun updateSaveProgress(snapshot: DownloadProgressSnapshot) {
+        if (snapshot.totalBytes <= 0L) {
+            saveProgressLabel.text = context.getString(R.string.video_save_downloading)
+            saveProgressBar.isIndeterminate = true
+            return
+        }
+
+        val percent = ((snapshot.downloadedBytes.toDouble() / snapshot.totalBytes.toDouble()) * 100.0)
+            .toInt()
+            .coerceIn(0, 100)
+        saveProgressLabel.text = context.getString(R.string.video_save_downloading_progress, percent)
+        saveProgressBar.isIndeterminate = false
+        saveProgressBar.progress = percent
+    }
+
+    private fun stopSaveProgress() {
+        saveProgressJob?.cancel()
+        saveProgressJob = null
+        if (saveProgressOverlay.visibility == View.VISIBLE) {
+            saveProgressOverlay.visibility = View.GONE
+        }
+    }
+
+    private data class DownloadProgressSnapshot(
+        val status: Int?,
+        val downloadedBytes: Long,
+        val totalBytes: Long
+    )
+
+    private fun getDownloadProgress(downloadId: Long): DownloadProgressSnapshot? {
+        return runCatching {
+            val downloadManager = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+            downloadManager.query(DownloadManager.Query().setFilterById(downloadId))?.use { cursor ->
+                if (!cursor.moveToFirst()) return@use null
+                val statusIndex = cursor.getColumnIndex(DownloadManager.COLUMN_STATUS)
+                val downloadedIndex = cursor.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR)
+                val totalIndex = cursor.getColumnIndex(DownloadManager.COLUMN_TOTAL_SIZE_BYTES)
+                DownloadProgressSnapshot(
+                    status = if (statusIndex >= 0) cursor.getInt(statusIndex) else null,
+                    downloadedBytes = if (downloadedIndex >= 0) cursor.getLong(downloadedIndex) else 0L,
+                    totalBytes = if (totalIndex >= 0) cursor.getLong(totalIndex) else -1L
+                )
+            }
+        }.getOrNull()
+    }
+
+    private fun getDownloadStatus(downloadId: Long): Int? {
+        return getDownloadProgress(downloadId)?.status
+    }
+
+    private fun shareVideo() {
+        val item = currentItem
+        if (item.url.isEmpty()) return
+        val currentVideoSize = player?.videoSize
+        val resolvedWidth = item.width.takeIf { it > 0 } ?: currentVideoSize?.width?.takeIf { it > 0 } ?: 0
+        val resolvedHeight = item.height.takeIf { it > 0 } ?: currentVideoSize?.height?.takeIf { it > 0 } ?: 0
+        val resolvedDuration = item.duration.takeIf { it > 0 }
+            ?: player?.duration?.takeIf { it > 0L }
+                ?.div(1000L)
+                ?.coerceAtMost(Int.MAX_VALUE.toLong())
+                ?.toInt()
+            ?: 0
+        val mimeType = item.mimeType.trim().lowercase(Locale.US).takeIf { it.startsWith("video/") }
+            ?: VideoShareRefinementContract.mimeTypeFromUrl(item.url)
+        val filename = item.filename.takeIf { it.isNotBlank() }
+            ?: VideoShareRefinementContract.filenameFromUrl(item.url, mimeType)
+        val attachment = AttachmentInfo(
+            url = item.url,
+            thumb = item.thumbnailUrl,
+            width = resolvedWidth,
+            height = resolvedHeight,
+            filename = filename,
+            filetype = mimeType,
+            size = item.size,
+            duration = resolvedDuration
+        )
+        try {
+            val targetIntent = Intent(Intent.ACTION_SEND).apply {
+                type = mimeType
+            }
+            val mezonComponent = ComponentName(context, MainActivity::class.java)
+            val mezonIntent = Intent(targetIntent).apply {
+                component = mezonComponent
+                putExtra(VideoShareRefinementContract.EXTRA_INTERNAL_TARGET, true)
+            }
+            val chooser = Intent.createChooser(targetIntent, context.getString(R.string.action_share_video)).apply {
+                putExtra(
+                    Intent.EXTRA_CHOOSER_REFINEMENT_INTENT_SENDER,
+                    VideoShareRefinementContract.createIntentSender(context, attachment)
+                )
+                putExtra(Intent.EXTRA_INITIAL_INTENTS, arrayOf(mezonIntent))
+                putExtra(Intent.EXTRA_EXCLUDE_COMPONENTS, arrayOf(mezonComponent))
+            }
+            context.startActivity(chooser)
+        } catch (_: Exception) {
+            if (isShowing) {
+                showToast(ToastOverlay.ToastType.ERROR, R.string.message_toast_share_failed)
+            }
+        }
+    }
+
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun onBackPressed() {
-        dismiss()
+        dismissWithAnimation()
     }
 }

--- a/app/src/main/java/com/mezon/mobile/home/chat/ViewerHeaderDateFormatter.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ViewerHeaderDateFormatter.kt
@@ -1,0 +1,34 @@
+package com.mezon.mobile.home.chat
+
+import android.content.Context
+import com.mezon.mobile.R
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+
+internal fun formatViewerHeaderDate(context: Context, timestampSeconds: Long): String? {
+    if (timestampSeconds <= 0) return null
+
+    val timestampMillis = timestampSeconds * 1000L
+    val messageCalendar = Calendar.getInstance().apply { timeInMillis = timestampMillis }
+    val currentCalendar = Calendar.getInstance().apply { timeInMillis = System.currentTimeMillis() }
+    val messageYear = messageCalendar.get(Calendar.YEAR)
+    val messageDay = messageCalendar.get(Calendar.DAY_OF_YEAR)
+    val currentYear = currentCalendar.get(Calendar.YEAR)
+    val currentDay = currentCalendar.get(Calendar.DAY_OF_YEAR)
+    val isToday = messageYear == currentYear && messageDay == currentDay
+    val isYesterday =
+        (messageYear == currentYear && messageDay == currentDay - 1) ||
+            (currentDay == 1 &&
+                messageYear == currentYear - 1 &&
+                messageDay == messageCalendar.getActualMaximum(Calendar.DAY_OF_YEAR))
+    val locale = Locale.getDefault()
+    val time = SimpleDateFormat("h:mm a", locale).format(Date(timestampMillis))
+
+    return when {
+        isToday -> "${context.getString(R.string.common_today_at)} $time"
+        isYesterday -> "${context.getString(R.string.common_yesterday_at)} $time"
+        else -> SimpleDateFormat("MMM d, h:mm a", locale).format(Date(timestampMillis))
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/ChannelMediaGalleryAdapter.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/ChannelMediaGalleryAdapter.kt
@@ -226,17 +226,17 @@ internal class ChannelMediaGalleryAdapter(
             }
         root.addView(videoDimmer, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT))
 
-        val playSize = LayoutHelper.dp(30f)
+        val playSize = LayoutHelper.dp(28f)
         val play =
             ImageView(ctx).apply {
                 visibility = View.GONE
-                val d = MezonIcon.playCircleIcon.getDrawable(context).mutate()
+                val d = MezonIcon.playIcon.getDrawable(context).mutate()
                 DrawableCompat.setTint(d, Color.WHITE)
                 setImageDrawable(d)
             }
         root.addView(
             play,
-            LayoutHelper.createFrame(playSize, playSize, Gravity.CENTER)
+            FrameLayout.LayoutParams(playSize, playSize, Gravity.CENTER)
         )
 
         val avPad = LayoutHelper.dp(26f)
@@ -343,7 +343,11 @@ internal class ChannelMediaGalleryAdapter(
         slot.thumb.setSize(cs, cs)
 
         val displayUrl = galleryThumbLoadUrl(item, cs)
-        slot.thumb.setImage(displayUrl)
+        if (displayUrl == null) {
+            slot.thumb.cancelLoad()
+        } else {
+            slot.thumb.setImage(displayUrl)
+        }
     }
 
     private fun onMediaCellClicked(tapped: ChannelGalleryMediaItem) {
@@ -451,9 +455,9 @@ internal class ChannelMediaGalleryAdapter(
     )
 }
 
-private fun galleryThumbLoadUrl(item: ChannelGalleryMediaItem, cellPx: Int): String {
-    val u = item.url.trim()
-    if (u.isEmpty()) return u
+private fun galleryThumbLoadUrl(item: ChannelGalleryMediaItem, cellPx: Int): String? {
+    val u = if (item.isVideo) item.thumbnail.trim() else item.url.trim()
+    if (u.isEmpty()) return null
     val ft = item.filetype.lowercase(Locale.US)
     val pathLower = u.lowercase(Locale.US)
     val isGif =

--- a/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/ChannelMediaGalleryAdapter.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/ChannelMediaGalleryAdapter.kt
@@ -384,8 +384,42 @@ internal class ChannelMediaGalleryAdapter(
                 }
 
         when {
-            tapped.isVideo ->
-                VideoPlayerDialog(ctx).play(url)
+            tapped.isVideo -> {
+                val member = members()[tapped.uploaderId]
+                val senderName = if (tapped.uploaderId == anonymousUserId) {
+                    ctx.getString(com.mezon.mobile.R.string.advanced_anonymous)
+                } else if (isDm) {
+                    member?.displayName?.takeIf { it.isNotBlank() }
+                        ?: member?.username?.takeIf { it.isNotBlank() }
+                        ?: "User"
+                } else {
+                    member?.clanNick?.takeIf { it.isNotBlank() }
+                        ?: member?.displayName?.takeIf { it.isNotBlank() }
+                        ?: member?.username?.takeIf { it.isNotBlank() }
+                        ?: "User"
+                }
+                val senderAvatar = if (isDm) {
+                    member?.avatarUrl
+                } else {
+                    member?.clanAvatar?.takeIf { it.isNotBlank() } ?: member?.avatarUrl
+                }
+                VideoPlayerDialog(ctx).play(
+                    VideoPlayerDialog.VideoItem(
+                        url = url,
+                        senderName = senderName,
+                        senderAvatarUrl = senderAvatar,
+                        timestamp = tapped.createTimeSeconds.toLong(),
+                        uploaderId = tapped.uploaderId,
+                        thumbnailUrl = tapped.thumbnail,
+                        filename = tapped.filename,
+                        mimeType = tapped.filetype,
+                        width = tapped.width,
+                        height = tapped.height,
+                        size = tapped.size,
+                        duration = tapped.duration
+                    )
+                )
+            }
 
             tapped.filetype.contains("gif", true) -> {
                 val item = orderedImages.firstOrNull { it.url == url } ?: PhotoViewer.GalleryItem(url, "User", null, 0)

--- a/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/ChannelMediaGalleryAdapter.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/ChannelMediaGalleryAdapter.kt
@@ -226,17 +226,17 @@ internal class ChannelMediaGalleryAdapter(
             }
         root.addView(videoDimmer, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT))
 
-        val playSize = LayoutHelper.dp(28f)
+        val playSize = LayoutHelper.dp(30f)
         val play =
             ImageView(ctx).apply {
                 visibility = View.GONE
-                val d = MezonIcon.playIcon.getDrawable(context).mutate()
+                val d = MezonIcon.playCircleIcon.getDrawable(context).mutate()
                 DrawableCompat.setTint(d, Color.WHITE)
                 setImageDrawable(d)
             }
         root.addView(
             play,
-            FrameLayout.LayoutParams(playSize, playSize, Gravity.CENTER)
+            LayoutHelper.createFrame(playSize, playSize, Gravity.CENTER)
         )
 
         val avPad = LayoutHelper.dp(26f)
@@ -343,11 +343,7 @@ internal class ChannelMediaGalleryAdapter(
         slot.thumb.setSize(cs, cs)
 
         val displayUrl = galleryThumbLoadUrl(item, cs)
-        if (displayUrl == null) {
-            slot.thumb.cancelLoad()
-        } else {
-            slot.thumb.setImage(displayUrl)
-        }
+        slot.thumb.setImage(displayUrl)
     }
 
     private fun onMediaCellClicked(tapped: ChannelGalleryMediaItem) {
@@ -455,9 +451,9 @@ internal class ChannelMediaGalleryAdapter(
     )
 }
 
-private fun galleryThumbLoadUrl(item: ChannelGalleryMediaItem, cellPx: Int): String? {
-    val u = if (item.isVideo) item.thumbnail.trim() else item.url.trim()
-    if (u.isEmpty()) return null
+private fun galleryThumbLoadUrl(item: ChannelGalleryMediaItem, cellPx: Int): String {
+    val u = item.url.trim()
+    if (u.isEmpty()) return u
     val ft = item.filetype.lowercase(Locale.US)
     val pathLower = u.lowercase(Locale.US)
     val isGif =

--- a/app/src/main/java/com/mezon/mobile/home/sharing/SharingFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/sharing/SharingFragment.kt
@@ -9,6 +9,7 @@ import android.graphics.PorterDuffColorFilter
 import android.graphics.Typeface
 import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.RippleDrawable
+import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.os.Handler
 import android.os.Looper
@@ -60,15 +61,18 @@ import com.mezon.mobile.search.SearchController
 import com.mezon.mobile.session.SessionManager
 import com.mezon.mobile.ui.MezonToast
 import com.mezon.mobile.ui.cells.AvatarView
+import com.mezon.mobile.ui.cells.BackupImageView
 import com.mezon.mobile.ui.cells.MezonIcon
 import com.mezon.mobile.ui.cells.PopupMenu
 import com.mezon.mobile.ui.cells.ToastOverlay
 import com.mezon.mobile.util.parseContentPreview
 import com.mezon.mobile.util.parseMarkdownAndStrip
 import android.util.Log
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.json.JSONObject
 
 class SharingFragment(
@@ -82,6 +86,7 @@ class SharingFragment(
     private lateinit var sessionManager: SessionManager
     private lateinit var appScope: CoroutineScope
     private lateinit var ioDispatcher: CoroutineDispatcher
+    private lateinit var mainDispatcher: CoroutineDispatcher
     private lateinit var channelController: ChannelController
     private lateinit var friendController: FriendController
     private lateinit var permissionPolicy: PermissionPolicy
@@ -113,6 +118,9 @@ class SharingFragment(
 
     private val sharedUris: List<Uri>
         get() = (payload as? SharingPayload.FromDevice)?.uris ?: emptyList()
+
+    private val existingAttachment: AttachmentInfo?
+        get() = (payload as? SharingPayload.FromExistingAttachment)?.attachment
 
     private val sharedText: String?
         get() = (payload as? SharingPayload.FromDevice)?.text
@@ -146,6 +154,7 @@ class SharingFragment(
     private var currentFilter = FilterType.ALL
     private var displayLimit = LOCAL_PAGE_SIZE
     private var isSending = false
+    private var pendingDeviceShareKey: Pair<Long, Long>? = null
 
     private val debounceHandler = Handler(Looper.getMainLooper())
     private var debounceRunnable: Runnable? = null
@@ -158,6 +167,7 @@ class SharingFragment(
         sessionManager = entryPoint.sessionManager()
         appScope = entryPoint.applicationScope()
         ioDispatcher = entryPoint.ioDispatcher()
+        mainDispatcher = entryPoint.mainDispatcher()
         channelController = entryPoint.channelController()
         friendController = entryPoint.friendController()
         permissionPolicy = entryPoint.permissionPolicy()
@@ -204,13 +214,23 @@ class SharingFragment(
             val changedClanId = args.firstOrNull() as? Long ?: return@observe
             if (hasTargetForClan(changedClanId)) refreshSendButtonEnabled()
         }
-        observe(NotificationCenter.pendingMessageSent) { _, _, _ ->
-            if (fragmentView == null || !isSending || isForwardMode) return@observe
+        observe(NotificationCenter.pendingMessageSent) { _, _, args ->
+            if (fragmentView == null || !isSending || payload !is SharingPayload.FromDevice) return@observe
+            val expected = pendingDeviceShareKey ?: return@observe
+            val channelId = args.getOrNull(0) as? Long ?: return@observe
+            val tempId = args.getOrNull(1) as? Long ?: return@observe
+            if (expected.first != channelId || expected.second != tempId) return@observe
+            pendingDeviceShareKey = null
             isSending = false
             finishFragment()
         }
-        observe(NotificationCenter.pendingMessageError) { _, _, _ ->
-            if (fragmentView == null || !isSending || isForwardMode) return@observe
+        observe(NotificationCenter.pendingMessageError) { _, _, args ->
+            if (fragmentView == null || !isSending || payload !is SharingPayload.FromDevice) return@observe
+            val expected = pendingDeviceShareKey ?: return@observe
+            val channelId = args.getOrNull(0) as? Long ?: return@observe
+            val tempId = args.getOrNull(1) as? Long ?: return@observe
+            if (expected.first != channelId || expected.second != tempId) return@observe
+            pendingDeviceShareKey = null
             isSending = false
             setSendingState(false)
             showErrorToast()
@@ -677,8 +697,8 @@ class SharingFragment(
             }
             loadThumbnail(img, uri)
 
-            val mime = sharedMimeType ?: getParentActivity()?.contentResolver?.getType(uri)
-            if (mime != null && mime.startsWith("video/")) {
+            val mime = resolveSharedMimeType(context.contentResolver, uri)
+            if (mime.startsWith("video/", ignoreCase = true)) {
                 val playOverlay = ImageView(context).apply {
                     val d = MezonIcon.playIcon.getDrawable(context)
                     d.colorFilter = PorterDuffColorFilter(Color.WHITE, PorterDuff.Mode.SRC_IN)
@@ -691,8 +711,27 @@ class SharingFragment(
             if (index > 0) lp.leftMargin = LayoutHelper.dp(8)
             thumbRow.addView(frame, lp)
         }
+        existingAttachment?.let { attachment ->
+            val frame = FrameLayout(context)
+            val image = BackupImageView(context).apply {
+                setAspectFill(true)
+                setRoundRadius(LayoutHelper.dp(8))
+                setBackgroundColor(themeColors.tertiary)
+                attachment.thumb.takeIf { it.isNotBlank() && it != attachment.url }?.let {
+                    setImage(it)
+                }
+            }
+            frame.addView(image, LayoutHelper.createFrame(60, 60))
+            val playOverlay = ImageView(context).apply {
+                val drawable = MezonIcon.playIcon.getDrawable(context)
+                drawable.colorFilter = PorterDuffColorFilter(Color.WHITE, PorterDuff.Mode.SRC_IN)
+                setImageDrawable(drawable)
+            }
+            frame.addView(playOverlay, LayoutHelper.createFrame(20, 20, Gravity.CENTER))
+            thumbRow.addView(frame, LinearLayout.LayoutParams(LayoutHelper.dp(60), LayoutHelper.dp(60)))
+        }
         thumbScroll.addView(thumbRow)
-        if (sharedUris.isNotEmpty()) {
+        if (sharedUris.isNotEmpty() || existingAttachment != null) {
             area.addView(thumbScroll, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT))
         }
 
@@ -1153,30 +1192,72 @@ class SharingFragment(
         }
         AndroidUtilities.hideKeyboard(captionInput)
 
-        val contentResolver = getParentActivity()?.contentResolver ?: run {
-            finishFragment()
-            return
-        }
-
         val caption = captionInput.text?.toString()?.trim() ?: sharedText ?: ""
         val mdResult = parseMarkdownAndStrip(caption)
         val cleanedText = mdResult.cleanedText
         val mdMarkers = mdResult.markers.ifEmpty { null }
 
-        if (sharedUris.isNotEmpty()) {
+        existingAttachment?.let { attachment ->
             setSendingState(true)
-            val attachments = buildAttachments(contentResolver)
-            chatController.shareMediaToChannel(
+            chatController.shareExistingMediaToChannel(
                 channelId = target.channelId,
                 clanId = target.clanId,
                 channelType = target.channelType,
                 isChannelPrivate = target.isPrivate,
                 text = cleanedText,
-                attachments = attachments,
-                contentResolver = contentResolver,
+                attachment = attachment,
                 markdownMarkers = mdMarkers,
                 parentId = target.parentId
-            )
+            ) { ok ->
+                if (fragmentView == null) return@shareExistingMediaToChannel
+                setSendingState(false)
+                if (ok) {
+                    finishFragment()
+                } else {
+                    showErrorToast()
+                }
+            }
+            return
+        }
+
+        if (sharedUris.isNotEmpty()) {
+            val activity = getParentActivity() ?: run {
+                showErrorToast()
+                return
+            }
+            pendingDeviceShareKey = null
+            setSendingState(true)
+            val contentResolver = activity.contentResolver
+            val metadataContext = activity.applicationContext
+            fragmentScope.launch(mainDispatcher) {
+                val attachments = try {
+                    withContext(ioDispatcher) {
+                        buildAttachments(metadataContext, contentResolver)
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (_: Exception) {
+                    if (fragmentView != null) {
+                        pendingDeviceShareKey = null
+                        setSendingState(false)
+                        showErrorToast()
+                    }
+                    return@launch
+                }
+                if (fragmentView == null || !isSending) return@launch
+                val tempId = chatController.shareMediaToChannel(
+                    channelId = target.channelId,
+                    clanId = target.clanId,
+                    channelType = target.channelType,
+                    isChannelPrivate = target.isPrivate,
+                    text = cleanedText,
+                    attachments = attachments,
+                    contentResolver = contentResolver,
+                    markdownMarkers = mdMarkers,
+                    parentId = target.parentId
+                )
+                pendingDeviceShareKey = target.channelId to tempId
+            }
         } else if (cleanedText.isNotBlank()) {
             if (target.isClanChannel) {
                 chatController.openChannel(target.channelId, target.clanId, target.channelType, target.isPrivate)
@@ -1193,20 +1274,27 @@ class SharingFragment(
         }
     }
 
-    private fun buildAttachments(contentResolver: ContentResolver): List<AttachmentPickerItem> {
+    private fun buildAttachments(context: Context, contentResolver: ContentResolver): List<AttachmentPickerItem> {
         return sharedUris.mapIndexed { index, uri ->
-            val mimeType = sharedMimeType ?: contentResolver.getType(uri) ?: "application/octet-stream"
+            val mimeType = resolveSharedMimeType(contentResolver, uri)
             val filename = resolveFilename(contentResolver, uri, index, mimeType)
             val size = resolveFileSize(contentResolver, uri)
             var width = 0
             var height = 0
-            if (mimeType.startsWith("image/")) {
+            var duration = 0
+            if (mimeType.startsWith("image/", ignoreCase = true)) {
                 try {
                     val opts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
                     contentResolver.openInputStream(uri)?.use { BitmapFactory.decodeStream(it, null, opts) }
                     width = opts.outWidth
                     height = opts.outHeight
                 } catch (_: Exception) {}
+            } else if (mimeType.startsWith("video/", ignoreCase = true)) {
+                resolveVideoMetadata(context, uri)?.let { metadata ->
+                    width = metadata.width
+                    height = metadata.height
+                    duration = metadata.durationSeconds
+                }
             }
             AttachmentPickerItem(
                 id = index.toLong(),
@@ -1217,9 +1305,62 @@ class SharingFragment(
                 width = width,
                 height = height,
                 size = size,
-                duration = 0,
-                isVideo = mimeType.startsWith("video/")
+                duration = duration,
+                isVideo = mimeType.startsWith("video/", ignoreCase = true)
             )
+        }
+    }
+
+    private fun resolveSharedMimeType(contentResolver: ContentResolver, uri: Uri): String {
+        val uriMimeType = runCatching { contentResolver.getType(uri) }
+            .getOrNull()
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+        val intentMimeType = sharedMimeType
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+        return listOfNotNull(uriMimeType, intentMimeType)
+            .maxByOrNull(::mimeTypeSpecificity)
+            ?.takeIf { mimeTypeSpecificity(it) > 0 }
+            ?: "application/octet-stream"
+    }
+
+    private fun mimeTypeSpecificity(mimeType: String): Int {
+        if (mimeType.equals("application/octet-stream", ignoreCase = true)) return 0
+        val type = mimeType.substringBefore('/', "").trim()
+        val subtype = mimeType.substringAfter('/', "").trim()
+        if (type.isEmpty() || type == "*" || subtype.isEmpty()) return 0
+        return if (subtype == "*") 1 else 2
+    }
+
+    private data class VideoMetadata(
+        val width: Int,
+        val height: Int,
+        val durationSeconds: Int
+    )
+
+    private fun resolveVideoMetadata(context: Context, uri: Uri): VideoMetadata? {
+        val retriever = MediaMetadataRetriever()
+        return try {
+            retriever.setDataSource(context, uri)
+            val rawWidth = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)
+                ?.toIntOrNull() ?: 0
+            val rawHeight = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)
+                ?.toIntOrNull() ?: 0
+            val rotation = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)
+                ?.toIntOrNull() ?: 0
+            val durationMs = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+                ?.toLongOrNull() ?: 0L
+            val swapDimensions = rotation % 180 != 0
+            VideoMetadata(
+                width = if (swapDimensions) rawHeight else rawWidth,
+                height = if (swapDimensions) rawWidth else rawHeight,
+                durationSeconds = (durationMs / 1000L).coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+            )
+        } catch (_: Exception) {
+            null
+        } finally {
+            runCatching { retriever.release() }
         }
     }
 
@@ -1265,5 +1406,8 @@ class SharingFragment(
 
         fun fromDevice(uris: List<Uri>, text: String?, mimeType: String?) =
             SharingFragment(SharingPayload.FromDevice(uris, text, mimeType))
+
+        fun fromExistingAttachment(attachment: AttachmentInfo) =
+            SharingFragment(SharingPayload.FromExistingAttachment(attachment))
     }
 }

--- a/app/src/main/java/com/mezon/mobile/home/sharing/SharingFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/sharing/SharingFragment.kt
@@ -720,7 +720,6 @@ class SharingFragment(
             val image = BackupImageView(context).apply {
                 setAspectFill(true)
                 setRoundRadius(LayoutHelper.dp(8))
-                setOmitEmptyPlaceholder(true)
                 setBackgroundColor(themeColors.tertiary)
                 attachment.thumb.takeIf { it.isNotBlank() && it != attachment.url }?.let {
                     setImage(it)

--- a/app/src/main/java/com/mezon/mobile/home/sharing/SharingFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/sharing/SharingFragment.kt
@@ -720,6 +720,7 @@ class SharingFragment(
             val image = BackupImageView(context).apply {
                 setAspectFill(true)
                 setRoundRadius(LayoutHelper.dp(8))
+                setOmitEmptyPlaceholder(true)
                 setBackgroundColor(themeColors.tertiary)
                 attachment.thumb.takeIf { it.isNotBlank() && it != attachment.url }?.let {
                     setImage(it)

--- a/app/src/main/java/com/mezon/mobile/home/sharing/SharingPayload.kt
+++ b/app/src/main/java/com/mezon/mobile/home/sharing/SharingPayload.kt
@@ -1,12 +1,17 @@
 package com.mezon.mobile.home.sharing
 
 import android.net.Uri
+import com.mezon.mobile.home.chat.AttachmentInfo
 
 sealed class SharingPayload {
     data class FromDevice(
         val uris: List<Uri>,
         val text: String?,
         val mimeType: String?
+    ) : SharingPayload()
+
+    data class FromExistingAttachment(
+        val attachment: AttachmentInfo
     ) : SharingPayload()
 
     data class ForwardFromChat(

--- a/app/src/main/java/com/mezon/mobile/home/sharing/VideoShareRefinementActivity.kt
+++ b/app/src/main/java/com/mezon/mobile/home/sharing/VideoShareRefinementActivity.kt
@@ -1,17 +1,13 @@
 package com.mezon.mobile.home.sharing
 
-import android.app.Activity
-import android.app.PendingIntent
 import android.content.ClipData
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.graphics.Color
 import android.graphics.drawable.GradientDrawable
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
-import android.os.ResultReceiver
-import android.util.Log
 import android.view.Gravity
 import android.view.ViewGroup
 import android.widget.FrameLayout
@@ -19,7 +15,10 @@ import android.widget.LinearLayout
 import android.widget.ProgressBar
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.OnBackPressedCallback
 import androidx.core.content.FileProvider
+import com.mezon.mobile.MainActivity
 import com.mezon.mobile.R
 import com.mezon.mobile.core.LayoutHelper
 import com.mezon.mobile.home.chat.AttachmentInfo
@@ -70,11 +69,9 @@ internal object ExistingVideoShareStore {
 }
 
 internal object VideoShareRefinementContract {
-    const val LOG_TAG = "VideoShareRoute"
     const val EXTRA_INTERNAL_SHARE_TOKEN = "com.mezon.mobile.extra.INTERNAL_VIDEO_SHARE_TOKEN"
-    const val EXTRA_INTERNAL_TARGET = "com.mezon.mobile.extra.INTERNAL_VIDEO_SHARE_TARGET"
 
-    private const val ACTION_REFINE = "com.mezon.mobile.action.REFINE_VIDEO_SHARE"
+    private const val ACTION_PREPARE = "com.mezon.mobile.action.PREPARE_VIDEO_SHARE"
     private const val EXTRA_URL = "video_url"
     private const val EXTRA_THUMB = "video_thumb"
     private const val EXTRA_WIDTH = "video_width"
@@ -84,11 +81,11 @@ internal object VideoShareRefinementContract {
     private const val EXTRA_SIZE = "video_size"
     private const val EXTRA_DURATION = "video_duration"
 
-    fun createIntentSender(context: Context, attachment: AttachmentInfo): android.content.IntentSender {
+    fun createPreparationIntent(context: Context, attachment: AttachmentInfo): Intent {
         val nonce = UUID.randomUUID().toString()
-        val refinementIntent = Intent(context, VideoShareRefinementActivity::class.java).apply {
-            action = ACTION_REFINE
-            data = Uri.parse("mezon://video-share-refinement/$nonce")
+        return Intent(context, VideoShareRefinementActivity::class.java).apply {
+            action = ACTION_PREPARE
+            data = Uri.parse("mezon://video-share-preparation/$nonce")
             putExtra(EXTRA_URL, attachment.url)
             putExtra(EXTRA_THUMB, attachment.thumb)
             putExtra(EXTRA_WIDTH, attachment.width)
@@ -98,8 +95,6 @@ internal object VideoShareRefinementContract {
             putExtra(EXTRA_SIZE, attachment.size)
             putExtra(EXTRA_DURATION, attachment.duration)
         }
-        val flags = PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_MUTABLE
-        return PendingIntent.getActivity(context, nonce.hashCode(), refinementIntent, flags).intentSender
     }
 
     fun readAttachment(intent: Intent): AttachmentInfo? {
@@ -169,7 +164,7 @@ internal object VideoShareRefinementContract {
     }
 }
 
-class VideoShareRefinementActivity : Activity() {
+class VideoShareRefinementActivity : ComponentActivity() {
     private companion object {
         const val CONNECT_TIMEOUT_MS = 15_000
         const val READ_TIMEOUT_MS = 30_000
@@ -177,40 +172,28 @@ class VideoShareRefinementActivity : Activity() {
     }
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
-    private var resultReceiver: ResultReceiver? = null
     @Volatile
     private var activeConnection: HttpURLConnection? = null
 
     @Volatile
     private var partialFile: File? = null
-    private var resultSent = false
+    private var flowCompleted = false
+    private var isResumed = false
+    private var pendingChooser: Intent? = null
     private lateinit var progressLabel: TextView
     private lateinit var progressBar: ProgressBar
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        val selectedIntent = intent.parcelableExtra(Intent.EXTRA_INTENT, Intent::class.java)
-        resultReceiver = intent.parcelableExtra(Intent.EXTRA_RESULT_RECEIVER, ResultReceiver::class.java)
-        val attachment = VideoShareRefinementContract.readAttachment(intent)
-        if (selectedIntent == null || resultReceiver == null || attachment == null) {
-            sendCanceledAndFinish()
-            return
-        }
-
-        val selectedPackage = selectedIntent.component?.packageName ?: selectedIntent.`package`
-        val hasInternalExtra = selectedIntent.getBooleanExtra(
-            VideoShareRefinementContract.EXTRA_INTERNAL_TARGET,
-            false
-        )
-        val packageMatches = selectedPackage == packageName
-        val isInternalTarget = hasInternalExtra || packageMatches
-        if (isInternalTarget) {
-            val token = ExistingVideoShareStore.put(attachment)
-            val refined = Intent(selectedIntent).apply {
-                putExtra(VideoShareRefinementContract.EXTRA_INTERNAL_SHARE_TOKEN, token)
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                cancelPreparationAndFinish()
             }
-            sendRefinedIntentAndFinish(refined)
+        })
+
+        val attachment = VideoShareRefinementContract.readAttachment(intent)
+        if (attachment == null) {
+            cancelPreparationAndFinish()
             return
         }
 
@@ -225,18 +208,26 @@ class VideoShareRefinementActivity : Activity() {
                     "$packageName.fileprovider",
                     downloaded
                 )
-                partialFile = null
-                val refined = Intent(selectedIntent).apply {
+                val targetIntent = Intent(Intent.ACTION_SEND).apply {
+                    type = attachment.filetype
                     putExtra(Intent.EXTRA_STREAM, uri)
                     clipData = ClipData.newRawUri("video", uri)
                     addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 }
-                sendRefinedIntentAndFinish(refined)
+                val mezonComponent = ComponentName(this@VideoShareRefinementActivity, MainActivity::class.java)
+                val chooser = Intent.createChooser(
+                    targetIntent,
+                    getString(R.string.action_share_video)
+                ).apply {
+                    putExtra(Intent.EXTRA_EXCLUDE_COMPONENTS, arrayOf(mezonComponent))
+                }
+                pendingChooser = chooser
+                openChooserIfReady()
             } catch (e: CancellationException) {
                 throw e
             } catch (_: Exception) {
                 Toast.makeText(this@VideoShareRefinementActivity, R.string.message_toast_share_failed, Toast.LENGTH_SHORT).show()
-                sendCanceledAndFinish()
+                cancelPreparationAndFinish()
             }
         }
     }
@@ -336,7 +327,11 @@ class VideoShareRefinementActivity : Activity() {
                 }
             }
             currentCoroutineContext().ensureActive()
-            trimShareCache(directory, destination.length(), destination)
+            try {
+                trimShareCache(directory, destination.length(), destination)
+            } catch (_: Exception) {
+                // Cache cleanup must not invalidate a completed download.
+            }
             return destination
         } catch (e: Exception) {
             partialFile?.delete()
@@ -377,47 +372,46 @@ class VideoShareRefinementActivity : Activity() {
         error("Unable to trim shared video cache")
     }
 
-    private fun sendRefinedIntentAndFinish(refined: Intent) {
-        if (resultSent) return
-        resultSent = true
-        val result = Bundle().apply { putParcelable(Intent.EXTRA_INTENT, refined) }
-        resultReceiver?.send(RESULT_OK, result)
-        finish()
-    }
-
-    private fun sendCanceledAndFinish() {
-        if (!resultSent) {
-            resultSent = true
-            resultReceiver?.send(RESULT_CANCELED, Bundle.EMPTY)
+    private fun openChooserIfReady() {
+        if (flowCompleted || !isResumed) return
+        val chooser = pendingChooser ?: return
+        try {
+            startActivity(chooser)
+            pendingChooser = null
+            partialFile = null
+            flowCompleted = true
+            finish()
+        } catch (_: Exception) {
+            Toast.makeText(this, R.string.message_toast_share_failed, Toast.LENGTH_SHORT).show()
+            cancelPreparationAndFinish()
         }
-        finish()
     }
 
-    @Suppress("OVERRIDE_DEPRECATION")
-    override fun onBackPressed() {
-        scope.cancel()
+    private fun cancelPreparationAndFinish() {
+        if (flowCompleted) return
+        flowCompleted = true
         activeConnection?.disconnect()
         partialFile?.delete()
-        sendCanceledAndFinish()
+        partialFile = null
+        scope.cancel()
+        finish()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        isResumed = true
+        openChooserIfReady()
+    }
+
+    override fun onPause() {
+        isResumed = false
+        super.onPause()
     }
 
     override fun onDestroy() {
-        if (!resultSent && isFinishing) {
-            resultSent = true
-            resultReceiver?.send(RESULT_CANCELED, Bundle.EMPTY)
-        }
         activeConnection?.disconnect()
-        partialFile?.delete()
+        if (!flowCompleted) partialFile?.delete()
         scope.cancel()
         super.onDestroy()
-    }
-
-    private fun <T : android.os.Parcelable> Intent.parcelableExtra(key: String, type: Class<T>): T? {
-        return if (Build.VERSION.SDK_INT >= 33) {
-            getParcelableExtra(key, type)
-        } else {
-            @Suppress("DEPRECATION")
-            getParcelableExtra(key)
-        }
     }
 }

--- a/app/src/main/java/com/mezon/mobile/home/sharing/VideoShareRefinementActivity.kt
+++ b/app/src/main/java/com/mezon/mobile/home/sharing/VideoShareRefinementActivity.kt
@@ -1,0 +1,423 @@
+package com.mezon.mobile.home.sharing
+
+import android.app.Activity
+import android.app.PendingIntent
+import android.content.ClipData
+import android.content.Context
+import android.content.Intent
+import android.graphics.Color
+import android.graphics.drawable.GradientDrawable
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.os.ResultReceiver
+import android.util.Log
+import android.view.Gravity
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.LinearLayout
+import android.widget.ProgressBar
+import android.widget.TextView
+import android.widget.Toast
+import androidx.core.content.FileProvider
+import com.mezon.mobile.R
+import com.mezon.mobile.core.LayoutHelper
+import com.mezon.mobile.home.chat.AttachmentInfo
+import java.io.File
+import java.io.FileOutputStream
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.Locale
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+internal object ExistingVideoShareStore {
+    private const val SESSION_MAX_AGE_MS = 10L * 60L * 1000L
+
+    private data class Entry(
+        val attachment: AttachmentInfo,
+        val createdAt: Long
+    )
+
+    private val entries = ConcurrentHashMap<String, Entry>()
+
+    fun put(attachment: AttachmentInfo): String {
+        val now = System.currentTimeMillis()
+        entries.forEach { (token, entry) ->
+            if (now - entry.createdAt > SESSION_MAX_AGE_MS) entries.remove(token)
+        }
+        return UUID.randomUUID().toString().also { token ->
+            entries[token] = Entry(attachment, now)
+        }
+    }
+
+    fun consume(token: String?): AttachmentInfo? {
+        if (token.isNullOrBlank()) return null
+        val entry = entries.remove(token) ?: return null
+        return entry.attachment.takeIf {
+            System.currentTimeMillis() - entry.createdAt <= SESSION_MAX_AGE_MS
+        }
+    }
+}
+
+internal object VideoShareRefinementContract {
+    const val LOG_TAG = "VideoShareRoute"
+    const val EXTRA_INTERNAL_SHARE_TOKEN = "com.mezon.mobile.extra.INTERNAL_VIDEO_SHARE_TOKEN"
+    const val EXTRA_INTERNAL_TARGET = "com.mezon.mobile.extra.INTERNAL_VIDEO_SHARE_TARGET"
+
+    private const val ACTION_REFINE = "com.mezon.mobile.action.REFINE_VIDEO_SHARE"
+    private const val EXTRA_URL = "video_url"
+    private const val EXTRA_THUMB = "video_thumb"
+    private const val EXTRA_WIDTH = "video_width"
+    private const val EXTRA_HEIGHT = "video_height"
+    private const val EXTRA_FILENAME = "video_filename"
+    private const val EXTRA_FILETYPE = "video_filetype"
+    private const val EXTRA_SIZE = "video_size"
+    private const val EXTRA_DURATION = "video_duration"
+
+    fun createIntentSender(context: Context, attachment: AttachmentInfo): android.content.IntentSender {
+        val nonce = UUID.randomUUID().toString()
+        val refinementIntent = Intent(context, VideoShareRefinementActivity::class.java).apply {
+            action = ACTION_REFINE
+            data = Uri.parse("mezon://video-share-refinement/$nonce")
+            putExtra(EXTRA_URL, attachment.url)
+            putExtra(EXTRA_THUMB, attachment.thumb)
+            putExtra(EXTRA_WIDTH, attachment.width)
+            putExtra(EXTRA_HEIGHT, attachment.height)
+            putExtra(EXTRA_FILENAME, attachment.filename)
+            putExtra(EXTRA_FILETYPE, attachment.filetype)
+            putExtra(EXTRA_SIZE, attachment.size)
+            putExtra(EXTRA_DURATION, attachment.duration)
+        }
+        val flags = PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_MUTABLE
+        return PendingIntent.getActivity(context, nonce.hashCode(), refinementIntent, flags).intentSender
+    }
+
+    fun readAttachment(intent: Intent): AttachmentInfo? {
+        val url = intent.getStringExtra(EXTRA_URL)?.trim().orEmpty()
+        if (url.isEmpty()) return null
+        val mimeType = intent.getStringExtra(EXTRA_FILETYPE)
+            ?.trim()
+            ?.lowercase(Locale.US)
+            ?.takeIf { it.startsWith("video/") }
+            ?: mimeTypeFromUrl(url)
+        val filename = intent.getStringExtra(EXTRA_FILENAME)
+            ?.takeIf { it.isNotBlank() }
+            ?: filenameFromUrl(url, mimeType)
+        return AttachmentInfo(
+            url = url,
+            thumb = intent.getStringExtra(EXTRA_THUMB).orEmpty(),
+            width = intent.getIntExtra(EXTRA_WIDTH, 0),
+            height = intent.getIntExtra(EXTRA_HEIGHT, 0),
+            filename = filename,
+            filetype = mimeType,
+            size = intent.getIntExtra(EXTRA_SIZE, 0),
+            duration = intent.getIntExtra(EXTRA_DURATION, 0)
+        )
+    }
+
+    fun mimeTypeFromUrl(url: String): String = when (extensionFromUrl(url)) {
+        "m4v" -> "video/x-m4v"
+        "mov" -> "video/quicktime"
+        "webm" -> "video/webm"
+        "mkv" -> "video/x-matroska"
+        "3gp" -> "video/3gpp"
+        "3g2" -> "video/3gpp2"
+        "mpg", "mpeg" -> "video/mpeg"
+        "ogv" -> "video/ogg"
+        "ts" -> "video/mp2t"
+        "avi" -> "video/x-msvideo"
+        "flv" -> "video/x-flv"
+        else -> "video/mp4"
+    }
+
+    fun filenameFromUrl(url: String, mimeType: String): String {
+        val remoteName = Uri.parse(url).lastPathSegment?.takeIf { it.isNotBlank() }
+        return remoteName ?: "video_${System.currentTimeMillis()}.${extensionForMimeType(mimeType)}"
+    }
+
+    fun extensionForMimeType(mimeType: String): String = when (mimeType.lowercase(Locale.US)) {
+        "video/x-m4v" -> "m4v"
+        "video/quicktime" -> "mov"
+        "video/webm" -> "webm"
+        "video/x-matroska" -> "mkv"
+        "video/3gpp" -> "3gp"
+        "video/3gpp2" -> "3g2"
+        "video/mpeg" -> "mpg"
+        "video/ogg" -> "ogv"
+        "video/mp2t" -> "ts"
+        "video/x-msvideo" -> "avi"
+        "video/x-flv" -> "flv"
+        else -> "mp4"
+    }
+
+    private fun extensionFromUrl(url: String): String {
+        return Uri.parse(url).lastPathSegment
+            ?.substringAfterLast('.', "")
+            ?.lowercase(Locale.US)
+            ?.takeIf { it.isNotBlank() }
+            ?: "mp4"
+    }
+}
+
+class VideoShareRefinementActivity : Activity() {
+    private companion object {
+        const val CONNECT_TIMEOUT_MS = 15_000
+        const val READ_TIMEOUT_MS = 30_000
+        const val SHARE_CACHE_MAX_BYTES = 512L * 1024L * 1024L
+    }
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private var resultReceiver: ResultReceiver? = null
+    @Volatile
+    private var activeConnection: HttpURLConnection? = null
+
+    @Volatile
+    private var partialFile: File? = null
+    private var resultSent = false
+    private lateinit var progressLabel: TextView
+    private lateinit var progressBar: ProgressBar
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val selectedIntent = intent.parcelableExtra(Intent.EXTRA_INTENT, Intent::class.java)
+        resultReceiver = intent.parcelableExtra(Intent.EXTRA_RESULT_RECEIVER, ResultReceiver::class.java)
+        val attachment = VideoShareRefinementContract.readAttachment(intent)
+        if (selectedIntent == null || resultReceiver == null || attachment == null) {
+            sendCanceledAndFinish()
+            return
+        }
+
+        val selectedPackage = selectedIntent.component?.packageName ?: selectedIntent.`package`
+        val hasInternalExtra = selectedIntent.getBooleanExtra(
+            VideoShareRefinementContract.EXTRA_INTERNAL_TARGET,
+            false
+        )
+        val packageMatches = selectedPackage == packageName
+        val isInternalTarget = hasInternalExtra || packageMatches
+        if (isInternalTarget) {
+            val token = ExistingVideoShareStore.put(attachment)
+            val refined = Intent(selectedIntent).apply {
+                putExtra(VideoShareRefinementContract.EXTRA_INTERNAL_SHARE_TOKEN, token)
+            }
+            sendRefinedIntentAndFinish(refined)
+            return
+        }
+
+        showProgressOverlay()
+        scope.launch {
+            try {
+                val downloaded = withContext(Dispatchers.IO) {
+                    downloadForExternalTarget(attachment)
+                }
+                val uri = FileProvider.getUriForFile(
+                    this@VideoShareRefinementActivity,
+                    "$packageName.fileprovider",
+                    downloaded
+                )
+                partialFile = null
+                val refined = Intent(selectedIntent).apply {
+                    putExtra(Intent.EXTRA_STREAM, uri)
+                    clipData = ClipData.newRawUri("video", uri)
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                }
+                sendRefinedIntentAndFinish(refined)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                Toast.makeText(this@VideoShareRefinementActivity, R.string.message_toast_share_failed, Toast.LENGTH_SHORT).show()
+                sendCanceledAndFinish()
+            }
+        }
+    }
+
+    private fun showProgressOverlay() {
+        val root = FrameLayout(this).apply {
+            setBackgroundColor(0x99000000.toInt())
+            isClickable = true
+        }
+        val card = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            gravity = Gravity.CENTER_HORIZONTAL
+            setPadding(LayoutHelper.dp(28), LayoutHelper.dp(24), LayoutHelper.dp(28), LayoutHelper.dp(24))
+            background = GradientDrawable().apply {
+                setColor(0xFF20212B.toInt())
+                cornerRadius = LayoutHelper.dpf(16f)
+            }
+        }
+        val spinner = ProgressBar(this).apply { isIndeterminate = true }
+        card.addView(spinner, LinearLayout.LayoutParams(LayoutHelper.dp(40), LayoutHelper.dp(40)))
+
+        progressLabel = TextView(this).apply {
+            setText(R.string.video_share_preparing)
+            setTextColor(Color.WHITE)
+            textSize = 16f
+            gravity = Gravity.CENTER
+        }
+        card.addView(
+            progressLabel,
+            LinearLayout.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
+                topMargin = LayoutHelper.dp(14)
+            }
+        )
+        progressBar = ProgressBar(this, null, android.R.attr.progressBarStyleHorizontal).apply {
+            max = 100
+            isIndeterminate = true
+        }
+        card.addView(
+            progressBar,
+            LinearLayout.LayoutParams(LayoutHelper.dp(240), LayoutHelper.dp(8)).apply {
+                topMargin = LayoutHelper.dp(16)
+            }
+        )
+        root.addView(
+            card,
+            FrameLayout.LayoutParams(LayoutHelper.dp(300), ViewGroup.LayoutParams.WRAP_CONTENT, Gravity.CENTER)
+        )
+        setContentView(root)
+    }
+
+    private suspend fun downloadForExternalTarget(attachment: AttachmentInfo): File {
+        currentCoroutineContext().ensureActive()
+        val directory = File(cacheDir, "shared_videos")
+        if (!directory.exists() && !directory.mkdirs()) error("Unable to create share cache")
+
+        val source = URL(attachment.url)
+        require(source.protocol == "https" || source.protocol == "http") { "Unsupported video URL" }
+        val connection = (source.openConnection() as HttpURLConnection).apply {
+            connectTimeout = CONNECT_TIMEOUT_MS
+            readTimeout = READ_TIMEOUT_MS
+        }
+        activeConnection = connection
+        try {
+            connection.connect()
+            if (connection.responseCode !in 200..299) error("HTTP ${connection.responseCode}")
+
+            val totalBytes = connection.contentLengthLong.takeIf { it > 0L }
+                ?: attachment.size.toLong().takeIf { it > 0L }
+                ?: 0L
+            trimShareCache(directory, totalBytes)
+            if (totalBytes > 0L && directory.usableSpace < totalBytes) {
+                error("Insufficient storage for shared video")
+            }
+
+            val extension = VideoShareRefinementContract.extensionForMimeType(attachment.filetype)
+            val destination = File(directory, "share_${System.currentTimeMillis()}_${UUID.randomUUID()}.$extension")
+            partialFile = destination
+            var copiedBytes = 0L
+            var lastProgressPercent = -1
+            connection.inputStream.use { input ->
+                FileOutputStream(destination).use { output ->
+                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                    while (true) {
+                        currentCoroutineContext().ensureActive()
+                        val read = input.read(buffer)
+                        if (read < 0) break
+                        output.write(buffer, 0, read)
+                        copiedBytes += read
+                        if (totalBytes > 0L) {
+                            val percent = ((copiedBytes * 100L) / totalBytes).toInt().coerceIn(0, 100)
+                            if (percent != lastProgressPercent) {
+                                lastProgressPercent = percent
+                                withContext(Dispatchers.Main.immediate) { updateProgress(percent) }
+                            }
+                        }
+                    }
+                }
+            }
+            currentCoroutineContext().ensureActive()
+            trimShareCache(directory, destination.length(), destination)
+            return destination
+        } catch (e: Exception) {
+            partialFile?.delete()
+            partialFile = null
+            currentCoroutineContext().ensureActive()
+            throw e
+        } finally {
+            if (activeConnection === connection) activeConnection = null
+            connection.disconnect()
+        }
+    }
+
+    private fun updateProgress(percent: Int) {
+        if (isFinishing || isDestroyed) return
+        progressBar.isIndeterminate = false
+        progressBar.progress = percent
+        progressLabel.text = getString(R.string.video_share_preparing_progress, percent)
+    }
+
+    private fun trimShareCache(directory: File, incomingBytes: Long, retainedFile: File? = null) {
+        val cachedFiles = directory.listFiles()
+            ?.filter { file ->
+                file.isFile && file.name.startsWith("share_") && file != retainedFile
+            }
+            ?.sortedBy { it.lastModified() }
+            .orEmpty()
+        var cachedBytes = cachedFiles.sumOf { it.length() }
+        val allowedCachedBytes = (SHARE_CACHE_MAX_BYTES - incomingBytes).coerceAtLeast(0L)
+        if (cachedBytes <= allowedCachedBytes) return
+
+        for (file in cachedFiles) {
+            val fileBytes = file.length()
+            if (runCatching { file.delete() }.getOrDefault(false)) {
+                cachedBytes -= fileBytes
+            }
+            if (cachedBytes <= allowedCachedBytes) return
+        }
+        error("Unable to trim shared video cache")
+    }
+
+    private fun sendRefinedIntentAndFinish(refined: Intent) {
+        if (resultSent) return
+        resultSent = true
+        val result = Bundle().apply { putParcelable(Intent.EXTRA_INTENT, refined) }
+        resultReceiver?.send(RESULT_OK, result)
+        finish()
+    }
+
+    private fun sendCanceledAndFinish() {
+        if (!resultSent) {
+            resultSent = true
+            resultReceiver?.send(RESULT_CANCELED, Bundle.EMPTY)
+        }
+        finish()
+    }
+
+    @Suppress("OVERRIDE_DEPRECATION")
+    override fun onBackPressed() {
+        scope.cancel()
+        activeConnection?.disconnect()
+        partialFile?.delete()
+        sendCanceledAndFinish()
+    }
+
+    override fun onDestroy() {
+        if (!resultSent && isFinishing) {
+            resultSent = true
+            resultReceiver?.send(RESULT_CANCELED, Bundle.EMPTY)
+        }
+        activeConnection?.disconnect()
+        partialFile?.delete()
+        scope.cancel()
+        super.onDestroy()
+    }
+
+    private fun <T : android.os.Parcelable> Intent.parcelableExtra(key: String, type: Class<T>): T? {
+        return if (Build.VERSION.SDK_INT >= 33) {
+            getParcelableExtra(key, type)
+        } else {
+            @Suppress("DEPRECATION")
+            getParcelableExtra(key)
+        }
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/ui/cells/PopupMenu.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/cells/PopupMenu.kt
@@ -7,6 +7,7 @@ import android.graphics.PorterDuffColorFilter
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.GradientDrawable
+import android.text.TextUtils
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
@@ -21,7 +22,11 @@ import androidx.core.content.ContextCompat
 import com.mezon.mobile.core.LayoutHelper
 import com.mezon.mobile.core.ThemeColors
 
-class PopupMenu(private val context: Context, private val theme: ThemeColors) {
+class PopupMenu(
+    private val context: Context,
+    private val theme: ThemeColors,
+    private val fullWidthDividers: Boolean = false
+) {
 
     private val items = ArrayList<MenuItem>()
     private var popupWindow: PopupWindow? = null
@@ -59,7 +64,7 @@ class PopupMenu(private val context: Context, private val theme: ThemeColors) {
 
         items.forEachIndexed { index, item ->
             val cell = PopupItemCell(context, theme)
-            cell.bind(item, index < items.size - 1)
+            cell.bind(item, index < items.size - 1, fullWidthDividers)
             cell.setOnClickListener {
                 onItemClick?.invoke(index)
                 dismiss()
@@ -120,6 +125,7 @@ class PopupMenu(private val context: Context, private val theme: ThemeColors) {
 
         private var menuItem: MenuItem? = null
         private var needDivider = false
+        private var fullWidthDivider = false
         private val cellHeight = LayoutHelper.dp(44)
         private val iconSize = LayoutHelper.dp(16)
         private val iconTextGap = LayoutHelper.dp(12)
@@ -136,9 +142,10 @@ class PopupMenu(private val context: Context, private val theme: ThemeColors) {
             }
         }
 
-        fun bind(item: MenuItem, divider: Boolean) {
+        fun bind(item: MenuItem, divider: Boolean, fullWidthDivider: Boolean) {
             menuItem = item
             needDivider = divider
+            this.fullWidthDivider = fullWidthDivider
             invalidate()
         }
 
@@ -171,13 +178,21 @@ class PopupMenu(private val context: Context, private val theme: ThemeColors) {
 
             val textX = if (item.icon != null) leftPad + iconSize + iconTextGap else leftPad
             val textY = cellHeight / 2f - (textPaint.descent() + textPaint.ascent()) / 2
-            canvas.drawText(item.text, textX.toFloat(), textY, textPaint)
+            val availableTextWidth = (width - textX - leftPad).coerceAtLeast(0)
+            val displayText = TextUtils.ellipsize(
+                item.text,
+                textPaint,
+                availableTextWidth.toFloat(),
+                TextUtils.TruncateAt.END
+            )
+            canvas.drawText(displayText, 0, displayText.length, textX.toFloat(), textY, textPaint)
 
             textPaint.color = theme.onSurface
 
             if (needDivider) {
                 canvas.drawRect(
-                    leftPad.toFloat(), cellHeight.toFloat(),
+                    if (fullWidthDivider) 0f else leftPad.toFloat(),
+                    cellHeight.toFloat(),
                     width.toFloat(), (cellHeight + 1).toFloat(),
                     theme.dividerPaint
                 )

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1652,6 +1652,13 @@
     <string name="action_save_media">Lưu ảnh</string>
     <string name="action_copy_image">Sao chép ảnh</string>
     <string name="action_share_image">Chia sẻ ảnh</string>
+    <string name="action_save_video">Lưu video</string>
+    <string name="action_share_video">Chia sẻ video</string>
+    <string name="video_share_preparing">Đang chuẩn bị video…</string>
+    <string name="video_share_preparing_progress">Đang chuẩn bị video… %1$d%%</string>
+    <string name="video_save_downloading">Đang tải video…</string>
+    <string name="video_save_downloading_progress">Đang tải video… %1$d%%</string>
     <string name="message_toast_save_success">Lưu thành công</string>
     <string name="message_toast_save_failed">Lưu thất bại</string>
+    <string name="message_toast_share_failed">Chia sẻ thất bại</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1658,6 +1658,8 @@
     <string name="action_share_image">Chia sẻ ảnh</string>
     <string name="action_save_video">Lưu video</string>
     <string name="action_share_video">Chia sẻ video</string>
+    <string name="action_share_video_to_mezon">Chia sẻ đến Mezon</string>
+    <string name="action_share_video_to_other_apps">Chia sẻ đến ứng dụng khác</string>
     <string name="video_share_preparing">Đang chuẩn bị video…</string>
     <string name="video_share_preparing_progress">Đang chuẩn bị video… %1$d%%</string>
     <string name="video_save_downloading">Đang tải video…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -381,6 +381,12 @@
     <string name="action_copy_link">Copy Media Link</string>
     <string name="action_copy_image">Copy Image</string>
     <string name="action_share_image">Share Image</string>
+    <string name="action_save_video">Save Video</string>
+    <string name="action_share_video">Share Video</string>
+    <string name="video_share_preparing">Preparing video…</string>
+    <string name="video_share_preparing_progress">Preparing video… %1$d%%</string>
+    <string name="video_save_downloading">Downloading video…</string>
+    <string name="video_save_downloading_progress">Downloading video… %1$d%%</string>
     <string name="message_slide_to_cancel">Slide to cancel</string>
     <string name="message_voice_record_failed">Could not start voice recording.</string>
     <string name="message_voice_record_too_short">Recording is too short.</string>
@@ -1773,4 +1779,5 @@
 
     <string name="message_toast_save_success">Save successfully</string>
     <string name="message_toast_save_failed">Save failed</string>
+    <string name="message_toast_share_failed">Share failed</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -387,6 +387,8 @@
     <string name="action_share_image">Share Image</string>
     <string name="action_save_video">Save Video</string>
     <string name="action_share_video">Share Video</string>
+    <string name="action_share_video_to_mezon">Share to Mezon</string>
+    <string name="action_share_video_to_other_apps">Share to other apps</string>
     <string name="video_share_preparing">Preparing video…</string>
     <string name="video_share_preparing_progress">Preparing video… %1$d%%</string>
     <string name="video_save_downloading">Downloading video…</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -12,6 +12,14 @@
         <item name="postSplashScreenTheme">@style/Theme.Mezon</item>
     </style>
 
+    <style name="Theme.Mezon.VideoShareRefinement" parent="Theme.Mezon">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowFullscreen">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
+    </style>
+
     <style name="MezonRecyclerListView" parent="android:Widget">
         <item name="android:scrollbars">vertical</item>
         <item name="android:fadeScrollbars">true</item>


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-275
Root Cause
The legacy video viewer lacked the image-viewer UI structure, lifecycle handling, save progress, and target-aware video sharing.

Solution
Implemented a new video viewer matching the image viewer UI, with video-specific controls, lifecycle-safe playback, save progress, and optimized internal/external share flows.

Test Cases
Open a video from a chat and verify that the viewer displays correctly.
Open a video from Channel Media and verify that the same viewer is displayed.
Verify that the sender name, avatar, and sent time are correct.
Verify that play, pause, seek, and 15-second skip controls work correctly.
Verify that users cannot swipe left or right to change videos.
Verify that no media selection bar appears at the bottom.
Tap the three-dot button and verify that only Save Video and Share Video are shown.
Save a video and verify that download progress and a success message are displayed.
Close the viewer while saving, reopen it, and verify that saving again works normally.
Share a video to Mezon and verify that the channel selection screen opens immediately.
Share a video to another app and verify that the preparation progress appears after selecting the app.
Cancel while preparing a video and verify that the viewer remains usable.
Put the app in the background and return to verify that playback continues from the previous position.
Repeat the main scenarios on Android 11, Android 12, Android 14, and Android 16.