### PR TITLE
260819-ANDROID-Update new business of type attachment 

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/ChannelGalleryController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChannelGalleryController.kt
@@ -8,6 +8,8 @@ import com.mezon.mobile.di.ApplicationScope
 import com.mezon.mobile.di.IoDispatcher
 import com.mezon.mobile.home.chat.AttachmentInfo
 import com.mezon.mobile.home.chat.MessageEntity
+import com.mezon.mobile.home.chat.isImageAttachmentType
+import com.mezon.mobile.home.chat.isVideoAttachmentType
 import com.mezon.mobile.network.ApiCacheTracker
 import com.mezon.mobile.network.MezonApi
 import com.mezon.mobile.network.apiCacheKey
@@ -34,7 +36,7 @@ data class ChannelGalleryMediaItem(
     val uploaderId: Long,
     val messageId: Long
 ) {
-    val isVideo: Boolean get() = filetype.lowercase(Locale.US).startsWith("video/")
+    val isVideo: Boolean get() = isVideoAttachmentType(filetype)
 }
 
 private class ChannelGalleryState {
@@ -401,9 +403,8 @@ private fun MessageEntity.toGalleryMediaItems(): List<ChannelGalleryMediaItem> {
 }
 
 private fun AttachmentInfo.toGalleryMediaItem(message: MessageEntity, index: Int): ChannelGalleryMediaItem? {
-    val ft = filetype.lowercase(Locale.US)
-    val image = ft.startsWith("image/")
-    val video = ft.startsWith("video/")
+    val image = isImageAttachmentType(filetype)
+    val video = isVideoAttachmentType(filetype)
     if (!image && !video) return null
 
     val u = url.trim()
@@ -422,9 +423,8 @@ private fun AttachmentInfo.toGalleryMediaItem(message: MessageEntity, index: Int
 }
 
 private fun ChannelAttachment.toFilteredMediaOrNull(): ChannelGalleryMediaItem? {
-    val ft = filetype.lowercase(Locale.US)
-    val image = ft.startsWith("image/")
-    val video = ft.startsWith("video/")
+    val image = isImageAttachmentType(filetype)
+    val video = isVideoAttachmentType(filetype)
     if (!image && !video) return null
 
     val u = url

--- a/app/src/main/java/com/mezon/mobile/home/ChatController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChatController.kt
@@ -14,6 +14,9 @@ import com.mezon.mobile.home.chat.canEditMessage
 import com.mezon.mobile.home.chat.ForwardDestination
 import com.mezon.mobile.home.chat.applyReactionEvent
 import com.mezon.mobile.home.chat.mergeChannelContentMentionsAndRefs
+import com.mezon.mobile.home.chat.isGifAttachment
+import com.mezon.mobile.home.chat.isImageAttachmentType
+import com.mezon.mobile.home.chat.isVideoAttachmentType
 import com.mezon.mobile.home.chat.toMessageEntity
 import com.mezon.mobile.network.ApiCacheTracker
 import com.mezon.mobile.network.CODE_CHAT_REMOVE
@@ -2296,7 +2299,7 @@ class ChatController @Inject constructor(
         val attachment = messageAttachment {
             this.filename = item.filename
             this.url = presigned.cdnUrl
-            this.filetype = item.mimeType
+            this.filetype = AttachmentUploader.attachmentTypeForUpload(item.mimeType)
             this.size = item.size.toInt()
             this.width = item.width
             this.height = item.height
@@ -2333,7 +2336,7 @@ class ChatController @Inject constructor(
         val attachment = messageAttachment {
             this.filename = item.filename
             this.url = presigned.cdnUrl
-            this.filetype = item.mimeType
+            this.filetype = AttachmentUploader.attachmentTypeForUpload(item.mimeType)
             this.size = fileSize.toInt()
             this.width = item.width
             this.height = item.height
@@ -2512,7 +2515,7 @@ class ChatController @Inject constructor(
         }
         val firstItem = allItems.first()
         val messageType = when {
-            uploadedByIndex.getOrNull(0) != null -> resolveOptimisticTypeFromMime(uploadedByIndex[0]!!.filetype)
+            uploadedByIndex.getOrNull(0) != null -> resolveOptimisticTypeFromAttachment(uploadedByIndex[0]!!)
             else -> resolveOptimisticType(firstItem)
         }
         val extraArr = org.json.JSONArray()
@@ -2542,7 +2545,7 @@ class ChatController @Inject constructor(
         val tail = if (uploaded.size > 1) uploaded.subList(1, uploaded.size) else emptyList()
         val firstItem = pendingLocal.firstOrNull()
         val messageType = when {
-            first != null -> resolveOptimisticTypeFromMime(first.filetype)
+            first != null -> resolveOptimisticTypeFromAttachment(first)
             firstItem != null -> resolveOptimisticType(firstItem)
             else -> MessageEntity.TYPE_TEXT
         }
@@ -2573,12 +2576,11 @@ class ChatController @Inject constructor(
         val messageType: Int,
     )
 
-    private fun resolveOptimisticTypeFromMime(mimeType: String): Int {
-        val ft = mimeType.lowercase()
+    private fun resolveOptimisticTypeFromAttachment(attachment: MessageAttachment): Int {
         return when {
-            ft.startsWith("image/gif") -> MessageEntity.TYPE_GIF
-            ft.startsWith("image/") -> MessageEntity.TYPE_PHOTO
-            ft.startsWith("video/") -> MessageEntity.TYPE_VIDEO
+            isGifAttachment(attachment.filetype, attachment.filename, attachment.url) -> MessageEntity.TYPE_GIF
+            isImageAttachmentType(attachment.filetype) -> MessageEntity.TYPE_PHOTO
+            isVideoAttachmentType(attachment.filetype) -> MessageEntity.TYPE_VIDEO
             else -> MessageEntity.TYPE_FILE
         }
     }

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -2067,13 +2067,15 @@ open class ChatFragment : BaseFragment() {
                 val url = att.url
                 if (url.isEmpty()) return
 
-                val isVideo = att.filetype.startsWith("video/")
+                val isVideo = isVideoAttachmentType(att.filetype)
                 val thumbBmp = cell.getMediaBitmap(attachmentIndex)
 
                 if (isVideo) {
                     VideoPlayerDialog(context).play(url)
                 } else {
-                    val seed = allMedia.filter { !it.filetype.startsWith("video/") && it.url.isNotEmpty() }.map { it.url }
+                    val seed = allMedia.filter {
+                        !isVideoAttachmentType(it.filetype) && it.url.isNotEmpty()
+                    }.map { it.url }
                     openChannelPhotoViewer(context, url, thumbBmp, seed, msg)
                 }
             }
@@ -6498,8 +6500,9 @@ open class ChatFragment : BaseFragment() {
         val showEditMessage = msg.canEditMessage(userId)
         val allMedia = msg.allImageAttachments
         val hasMedia = allMedia.isNotEmpty() ||
-            msg.attachmentUrl.isNotEmpty() && (msg.attachmentFiletype.startsWith("image/") || msg.attachmentFiletype.startsWith("video/"))
-        val hasImage = allMedia.any { it.filetype.startsWith("image/") }
+            msg.attachmentUrl.isNotEmpty() &&
+            (isImageAttachmentType(msg.attachmentFiletype) || isVideoAttachmentType(msg.attachmentFiletype))
+        val hasImage = allMedia.any { isImageAttachmentType(it.filetype) }
         val allowFwd = !msg.isPollMessage
 
         val sheet = MessageActionBottomSheet(

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
@@ -1017,13 +1017,12 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             receiver.setCenterCrop(true)
             val isStickerAttachment = att.filetype.equals("sticker", ignoreCase = true) ||
                 att.url.contains("/stickers/", ignoreCase = true)
-            val isAnimated = att.filetype.contains("gif", true) ||
-                att.url.contains("tenor.com", true) ||
+            val isAnimated = isGifAttachment(att.filetype, att.filename, att.url) ||
                 isStickerAttachment
             applyMediaCornerRadius(receiver)
             receiver.setRequestedSize(pw, ph)
             val isLocalUri = att.url.startsWith("content://") || att.url.startsWith("file://")
-            val isVideo = att.filetype.startsWith("video/", true)
+            val isVideo = isVideoAttachmentType(att.filetype)
             slotIsVideo[i] = isVideo
             slotPresignPending[i] = msg.isPresignAttachmentPending(att.url, filter, snapshot.allPresignFinished)
             slotUploadPending[i] = !slotPresignPending[i] && msg.isAttachmentUploadPending(att.url, filter)

--- a/app/src/main/java/com/mezon/mobile/home/chat/ImageClipboardCoordinator.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ImageClipboardCoordinator.kt
@@ -48,14 +48,15 @@ class ImageClipboardCoordinator @Inject constructor(
 
     fun resolvePrimaryImageUrlForCopy(msg: MessageEntity): String? {
         val imgs = msg.allImageAttachments.filter { att ->
-            val ft = att.filetype.lowercase(Locale.US)
-            if (ft.startsWith("video/")) return@filter false
-            ft.startsWith("image/") || ft.contains("gif") || att.url.contains("tenor.com", ignoreCase = true)
+            if (isVideoAttachmentType(att.filetype)) return@filter false
+            isImageAttachmentType(att.filetype) ||
+                isGifAttachment(att.filetype, att.filename, att.url)
         }
         if (imgs.isNotEmpty()) return imgs.firstOrNull()?.url?.takeIf { it.isNotBlank() }
         if (msg.attachmentUrl.isNotBlank() && msg.hasMedia) {
-            val ft = msg.attachmentFiletype.lowercase(Locale.US)
-            if (ft.startsWith("image/") || ft.contains("gif") || msg.attachmentUrl.contains("tenor.com", ignoreCase = true)) {
+            if (isImageAttachmentType(msg.attachmentFiletype) ||
+                isGifAttachment(msg.attachmentFiletype, msg.attachmentFilename, msg.attachmentUrl)
+            ) {
                 return msg.attachmentUrl
             }
         }

--- a/app/src/main/java/com/mezon/mobile/home/chat/MessageEntity.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/MessageEntity.kt
@@ -142,8 +142,10 @@ data class MessageEntity(
     val hasAnyMedia: Boolean
         get() {
             if (hasMedia) return true
-            if (attachmentUrl.isNotEmpty() && isMediaAttachment(attachmentFiletype, attachmentUrl)) return true
-            return extraAttachments.any { isMediaAttachment(it.filetype, it.url) }
+            if (attachmentUrl.isNotEmpty() &&
+                isMediaAttachment(attachmentFiletype, attachmentUrl, attachmentFilename)
+            ) return true
+            return extraAttachments.any { isMediaAttachment(it.filetype, it.url, it.filename) }
         }
 
     data class DisplayAttachmentSnapshot(
@@ -217,7 +219,7 @@ data class MessageEntity(
         get() = messageType == TYPE_FILE && attachmentUrl.isNotEmpty()
 
     val isAudioAttachment: Boolean
-        get() = attachmentUrl.isNotEmpty() && attachmentFiletype.startsWith("audio", ignoreCase = true)
+        get() = attachmentUrl.isNotEmpty() && isAudioAttachmentType(attachmentFiletype)
 
     val hasReactions: Boolean
         get() = reactionsJson.isNotEmpty() && reactionsJson != "[]"
@@ -329,14 +331,16 @@ data class MessageEntity(
 
     val allFileAttachments: List<AttachmentInfo>
         get() {
-            val isFile = { ft: String, url: String ->
-                !isMediaAttachment(ft, url) && !ft.startsWith("audio/", true)
+            val isFile = { ft: String, url: String, filename: String ->
+                !isMediaAttachment(ft, url, filename) && !isAudioAttachmentType(ft)
             }
-            val first = if (attachmentUrl.isNotEmpty() && isFile(attachmentFiletype, attachmentUrl))
+            val first = if (attachmentUrl.isNotEmpty() &&
+                isFile(attachmentFiletype, attachmentUrl, attachmentFilename)
+            )
                 listOf(AttachmentInfo(attachmentUrl, attachmentThumb, attachmentWidth, attachmentHeight,
                     attachmentFilename, attachmentFiletype, attachmentSize, attachmentDuration))
             else emptyList()
-            return first + extraAttachments.filter { isFile(it.filetype, it.url) }
+            return first + extraAttachments.filter { isFile(it.filetype, it.url, it.filename) }
         }
 
     val hasFileAttachments: Boolean
@@ -344,11 +348,15 @@ data class MessageEntity(
 
     val allImageAttachments: List<AttachmentInfo>
         get() {
-            val first = if (attachmentUrl.isNotEmpty() && isMediaAttachment(attachmentFiletype, attachmentUrl))
+            val first = if (attachmentUrl.isNotEmpty() &&
+                isMediaAttachment(attachmentFiletype, attachmentUrl, attachmentFilename)
+            )
                 listOf(AttachmentInfo(attachmentUrl, attachmentThumb, attachmentWidth, attachmentHeight,
                     attachmentFilename, attachmentFiletype, attachmentSize, attachmentDuration))
             else emptyList()
-            return first + extraAttachments.filter { isMediaAttachment(it.filetype, it.url) }
+            return first + extraAttachments.filter {
+                isMediaAttachment(it.filetype, it.url, it.filename)
+            }
         }
 
     fun isLocalAttachmentUrl(url: String): Boolean {
@@ -725,22 +733,46 @@ private fun mergeReferencesIntoContent(content: String, referencesBytes: com.goo
     }
 }
 
-internal fun isMediaAttachment(filetype: String, url: String): Boolean =
-    filetype.startsWith("image/", true) || filetype.startsWith("video/", true) ||
-        filetype.contains("gif", true) || filetype.equals("sticker", true) ||
-        url.contains("tenor.com", true) || url.contains("/stickers/", true)
+private fun normalizedAttachmentType(filetype: String): String =
+    filetype.substringBefore(';').trim().lowercase()
+
+internal fun isImageAttachmentType(filetype: String): Boolean {
+    val type = normalizedAttachmentType(filetype)
+    return type == "image" || type.startsWith("image/")
+}
+
+internal fun isVideoAttachmentType(filetype: String): Boolean {
+    val type = normalizedAttachmentType(filetype)
+    return type == "video" || type.startsWith("video/")
+}
+
+internal fun isAudioAttachmentType(filetype: String): Boolean {
+    val type = normalizedAttachmentType(filetype)
+    return type == "audio" || type.startsWith("audio/")
+}
+
+private fun hasGifExtension(value: String): Boolean =
+    value.substringBefore('?').substringBefore('#').endsWith(".gif", ignoreCase = true)
+
+internal fun isGifAttachment(filetype: String, filename: String = "", url: String = ""): Boolean =
+    normalizedAttachmentType(filetype).contains("gif") ||
+        hasGifExtension(filename) || hasGifExtension(url) ||
+        url.contains("tenor.com", ignoreCase = true)
+
+internal fun isMediaAttachment(filetype: String, url: String, filename: String = ""): Boolean =
+    isImageAttachmentType(filetype) || isVideoAttachmentType(filetype) ||
+        isGifAttachment(filetype, filename, url) || filetype.equals("sticker", true) ||
+        url.contains("/stickers/", true)
 
 private fun resolveMessageType(attachment: ParsedAttachment?): Int {
     if (attachment == null || attachment.url.isEmpty()) return MessageEntity.TYPE_TEXT
-    val ft = attachment.filetype.lowercase()
     val url = attachment.url.lowercase()
     return when {
-        ft.startsWith("image/gif") -> MessageEntity.TYPE_GIF
-        ft == "sticker" -> MessageEntity.TYPE_GIF
-        url.contains("tenor.com") -> MessageEntity.TYPE_GIF
+        isGifAttachment(attachment.filetype, attachment.filename, attachment.url) -> MessageEntity.TYPE_GIF
+        attachment.filetype.equals("sticker", ignoreCase = true) -> MessageEntity.TYPE_GIF
         url.contains("/stickers/") -> MessageEntity.TYPE_GIF
-        ft.startsWith("image/") -> MessageEntity.TYPE_PHOTO
-        ft.startsWith("video/") -> MessageEntity.TYPE_VIDEO
+        isImageAttachmentType(attachment.filetype) -> MessageEntity.TYPE_PHOTO
+        isVideoAttachmentType(attachment.filetype) -> MessageEntity.TYPE_VIDEO
         else -> MessageEntity.TYPE_FILE
     }
 }

--- a/app/src/main/java/com/mezon/mobile/home/chat/PinMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/PinMessageCell.kt
@@ -262,12 +262,11 @@ private fun PinMessageData.toMessageEntity(): MessageEntity {
     val type = when {
         pollCode == MessageEntity.CODE_POLL -> MessageEntity.TYPE_TEXT
         first == null || first.url.isEmpty() -> MessageEntity.TYPE_TEXT
-        first.filetype.startsWith("image/gif", true) -> MessageEntity.TYPE_GIF
+        isGifAttachment(first.filetype, first.filename, first.url) -> MessageEntity.TYPE_GIF
         first.filetype.equals("sticker", true) -> MessageEntity.TYPE_GIF
-        first.url.contains("tenor.com", true) -> MessageEntity.TYPE_GIF
         first.url.contains("/stickers/") -> MessageEntity.TYPE_GIF
-        first.filetype.startsWith("image/", true) -> MessageEntity.TYPE_PHOTO
-        first.filetype.startsWith("video/", true) -> MessageEntity.TYPE_VIDEO
+        isImageAttachmentType(first.filetype) -> MessageEntity.TYPE_PHOTO
+        isVideoAttachmentType(first.filetype) -> MessageEntity.TYPE_VIDEO
         first.url.isNotEmpty() -> MessageEntity.TYPE_FILE
         else -> MessageEntity.TYPE_TEXT
     }

--- a/app/src/main/java/com/mezon/mobile/home/chat/thread/CreateThreadFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/thread/CreateThreadFragment.kt
@@ -68,6 +68,9 @@ import com.mezon.mobile.home.chat.HashtagSpan
 import com.mezon.mobile.home.chat.ImageClipboardCoordinator
 import com.mezon.mobile.home.chat.MediaController
 import com.mezon.mobile.home.chat.MessageEntity
+import com.mezon.mobile.home.chat.isGifAttachment
+import com.mezon.mobile.home.chat.isImageAttachmentType
+import com.mezon.mobile.home.chat.isVideoAttachmentType
 import com.mezon.mobile.home.chat.PasteImagePasteTooltipContent
 import com.mezon.mobile.home.chat.StickerItem
 import com.mezon.mobile.home.chat.ThumbnailCache
@@ -792,10 +795,9 @@ class CreateThreadFragment : BaseFragment() {
         var fil = 0
         for (a in all) {
             when {
-                a.filetype.startsWith("image/", ignoreCase = true) ||
-                    a.filetype.contains("gif", ignoreCase = true) ||
-                    a.url.contains("tenor.com", ignoreCase = true) -> img++
-                a.filetype.startsWith("video/", ignoreCase = true) -> vid++
+                isGifAttachment(a.filetype, a.filename, a.url) ||
+                    isImageAttachmentType(a.filetype) -> img++
+                isVideoAttachmentType(a.filetype) -> vid++
                 else -> fil++
             }
         }

--- a/app/src/main/java/com/mezon/mobile/home/sharing/SharingFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/sharing/SharingFragment.kt
@@ -46,6 +46,10 @@ import com.mezon.mobile.home.chat.AttachmentPickerItem
 import com.mezon.mobile.home.chat.ForwardDestination
 import com.mezon.mobile.home.chat.ForwardNavigationStash
 import com.mezon.mobile.home.chat.MessageEntity
+import com.mezon.mobile.home.chat.isGifAttachment
+import com.mezon.mobile.home.chat.isImageAttachmentType
+import com.mezon.mobile.home.chat.isMediaAttachment
+import com.mezon.mobile.home.chat.isVideoAttachmentType
 import com.mezon.mobile.home.clans.CHANNEL_TYPE_VOICE
 import com.mezon.mobile.home.clans.ChannelController
 import com.mezon.mobile.home.clans.ClansController
@@ -1050,10 +1054,9 @@ class SharingFragment(
         var fil = 0
         for (a in all) {
             when {
-                a.filetype.startsWith("image/", ignoreCase = true) ||
-                    a.filetype.contains("gif", ignoreCase = true) ||
-                    a.url.contains("tenor.com", ignoreCase = true) -> img++
-                a.filetype.startsWith("video/", ignoreCase = true) -> vid++
+                isGifAttachment(a.filetype, a.filename, a.url) ||
+                    isImageAttachmentType(a.filetype) -> img++
+                isVideoAttachmentType(a.filetype) -> vid++
                 else -> fil++
             }
         }
@@ -1077,12 +1080,7 @@ class SharingFragment(
             previewFilesRow.visibility = View.GONE
         }
 
-        val mediaOnly = all.filter {
-            it.filetype.startsWith("image/", ignoreCase = true) ||
-                it.filetype.startsWith("video/", ignoreCase = true) ||
-                it.filetype.contains("gif", ignoreCase = true) ||
-                it.url.contains("tenor.com", ignoreCase = true)
-        }
+        val mediaOnly = all.filter { isMediaAttachment(it.filetype, it.url, it.filename) }
         if (mediaOnly.isNotEmpty()) {
             val a0 = mediaOnly[0]
             previewThumbHost.bind(a0.url, a0.thumb.takeIf { it.isNotBlank() } ?: a0.url)

--- a/app/src/main/java/com/mezon/mobile/util/AttachmentUploader.kt
+++ b/app/src/main/java/com/mezon/mobile/util/AttachmentUploader.kt
@@ -32,6 +32,16 @@ object AttachmentUploader {
     private const val MULTIPART_MIN_FILE_SIZE = 50L * 1024 * 1024
     private const val MULTIPART_UPLOAD_ENABLED = true
 
+    internal fun attachmentTypeForUpload(filetype: String): String {
+        val normalized = filetype.lowercase()
+        return when {
+            normalized.contains("image") -> "image"
+            normalized.contains("video") -> "video"
+            normalized.contains("audio") -> "audio"
+            else -> "doc"
+        }
+    }
+
     private class MultipartNotApplicable : Exception()
 
     @Volatile
@@ -290,7 +300,7 @@ object AttachmentUploader {
             }
         }
         val presign = api.uploadAttachmentFile(
-            apiUrl, token, uploadFilename, mimeType, sizeBytes.toInt(), width, height,
+            apiUrl, token, uploadFilename, attachmentTypeForUpload(mimeType), sizeBytes.toInt(), width, height,
         )
         val cdnUrl = "$cdnBaseUrl/${presign.filename}"
         Log.d(TAG, "presign bytes file=$uploadFilename cdnUrl=$cdnUrl minioUrl=${presign.url}")
@@ -325,7 +335,7 @@ object AttachmentUploader {
             }
         }
         val presign = api.uploadAttachmentFile(
-            apiUrl, token, uploadFilename, mimeType, fileSize.toInt(), width, height,
+            apiUrl, token, uploadFilename, attachmentTypeForUpload(mimeType), fileSize.toInt(), width, height,
         )
         val cdnUrl = "$cdnBaseUrl/${presign.filename}"
         Log.d(TAG, "presign file=$uploadFilename cdnUrl=$cdnUrl minioUrl=${presign.url}")
@@ -487,7 +497,7 @@ object AttachmentUploader {
     ): PresignedFileResult {
         val requestedPartCount = multipartPartCount(sizeBytes.toLong())
         val start = api.multipartUploadAttachmentFileStart(
-            apiUrl, token, uploadFilename, mimeType, sizeBytes, width, height,
+            apiUrl, token, uploadFilename, attachmentTypeForUpload(mimeType), sizeBytes, width, height,
             partCount = requestedPartCount,
         )
         val urls = start.urlsList
@@ -535,7 +545,7 @@ object AttachmentUploader {
     ): PresignedFileResult {
         val requestedPartCount = multipartPartCount(sizeBytes.toLong())
         val start = api.multipartUploadAttachmentFileStart(
-            apiUrl, token, uploadFilename, mimeType, sizeBytes, width, height,
+            apiUrl, token, uploadFilename, attachmentTypeForUpload(mimeType), sizeBytes, width, height,
             partCount = requestedPartCount,
         )
         val urls = start.urlsList


### PR DESCRIPTION
Root Cause
The backend changed attachment types from detailed values such as image/png to general values such as image, but Android still expected the old format, causing images to fall back to file rendering.
Solution
Android now sends the new attachment categories during upload and supports both new and legacy attachment types when displaying media, while GIFs are identified by their type, filename, or URL to preserve animation.

Test Cases
- Upload an image from the gallery and verify it appears as an image before and after reopening the chat.
- Paste an image into the message box and verify it appears as an image after sending.
- Receive an image sent from Web and verify it appears as an image instead of a file.
- Open an older message containing an image and verify it still displays correctly.
- Send and receive a video and verify it appears with the video preview and can be played.
- Send and receive an audio file and verify it appears with the audio player.
- Send a document and verify it still appears as a downloadable file.
- Send a GIF and verify it remains animated in the message and image viewer.
- Open the media gallery and verify images and videos are listed correctly.
- Forward or pin a message containing media and verify its preview displays correctly.