### PR TITLE
260821-ANDROID-Sync business type attachment

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/ChannelFilesController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChannelFilesController.kt
@@ -7,6 +7,7 @@ import com.mezon.mobile.di.ApplicationScope
 import com.mezon.mobile.di.IoDispatcher
 import com.mezon.mobile.home.chat.AttachmentInfo
 import com.mezon.mobile.home.chat.MessageEntity
+import com.mezon.mobile.home.chat.isAudioAttachmentType
 import com.mezon.mobile.home.chat.channelinfo.ChannelDocumentItem
 import com.mezon.mobile.network.ApiCacheTracker
 import com.mezon.mobile.network.MezonApi
@@ -24,6 +25,16 @@ import javax.inject.Singleton
 private const val TAG = "ChannelFilesController"
 private const val FILES_CACHE_TTL_MS = 60 * 60 * 1_000L
 
+enum class ChannelFilesType(val apiValue: String) {
+    DOC("doc"),
+    AUDIO("audio")
+}
+
+private data class ChannelFilesKey(
+    val channelId: Long,
+    val filesType: ChannelFilesType
+)
+
 @Singleton
 class ChannelFilesController @Inject constructor(
     private val api: MezonApi,
@@ -34,9 +45,9 @@ class ChannelFilesController @Inject constructor(
     @ApplicationScope private val appScope: CoroutineScope
 ) {
 
-    private val docsByChannel = HashMap<Long, ArrayList<ChannelDocumentItem>>()
-    private val loadFailed = Collections.synchronizedSet(HashSet<Long>())
-    private val loadingChannels = Collections.synchronizedSet(HashSet<Long>())
+    private val filesByType = HashMap<ChannelFilesKey, ArrayList<ChannelDocumentItem>>()
+    private val loadFailed = Collections.synchronizedSet(HashSet<ChannelFilesKey>())
+    private val loadingFiles = Collections.synchronizedSet(HashSet<ChannelFilesKey>())
 
     private val messageObserver = object : NotificationCenter.NotificationCenterDelegate {
         override fun didReceivedNotification(id: Int, account: Int, vararg args: Any?) {
@@ -56,9 +67,11 @@ class ChannelFilesController @Inject constructor(
                 NotificationCenter.messageDidDelete -> {
                     val channelId = args.getOrNull(0) as? Long ?: return
                     val messageId = args.getOrNull(1) as? Long ?: return
-                    if (removeByMessageId(channelId, messageId)) {
-                        apiCacheTracker.invalidate(apiCacheKey("channelFiles", channelId))
-                        notifyFilesChanged(channelId)
+                    ChannelFilesType.entries.forEach { filesType ->
+                        if (removeByMessageId(channelId, messageId, filesType)) {
+                            apiCacheTracker.invalidate(filesCacheKey(ChannelFilesKey(channelId, filesType)))
+                            notifyFilesChanged(channelId, filesType)
+                        }
                     }
                 }
             }
@@ -71,66 +84,101 @@ class ChannelFilesController @Inject constructor(
         notificationCenter.addObserver(messageObserver, NotificationCenter.messageDidDelete)
     }
 
-    fun getDocuments(channelId: Long): List<ChannelDocumentItem> {
+    fun getDocuments(
+        channelId: Long,
+        filesType: ChannelFilesType = ChannelFilesType.DOC
+    ): List<ChannelDocumentItem> {
         synchronized(this) {
-            return docsByChannel[channelId]?.toList() ?: emptyList()
+            return filesByType[ChannelFilesKey(channelId, filesType)]?.toList() ?: emptyList()
         }
     }
 
-    fun hadLoadError(channelId: Long): Boolean = synchronized(loadFailed) { channelId in loadFailed }
+    fun hadLoadError(
+        channelId: Long,
+        filesType: ChannelFilesType = ChannelFilesType.DOC
+    ): Boolean = synchronized(loadFailed) { ChannelFilesKey(channelId, filesType) in loadFailed }
 
-    fun isFetching(channelId: Long): Boolean = synchronized(loadingChannels) { channelId in loadingChannels }
+    fun isFetching(
+        channelId: Long,
+        filesType: ChannelFilesType = ChannelFilesType.DOC
+    ): Boolean = synchronized(loadingFiles) { ChannelFilesKey(channelId, filesType) in loadingFiles }
 
-    fun loadChannelFiles(channelId: Long, clanId: Long, forceRefresh: Boolean = false) {
-        val cacheKey = apiCacheKey("channelFiles", channelId)
+    fun loadChannelFiles(
+        channelId: Long,
+        clanId: Long,
+        forceRefresh: Boolean = false,
+        filesType: ChannelFilesType = ChannelFilesType.DOC
+    ) {
+        val key = ChannelFilesKey(channelId, filesType)
+        val cacheKey = filesCacheKey(key)
         if (!forceRefresh &&
             apiCacheTracker.shouldCall(cacheKey, ttlMs = FILES_CACHE_TTL_MS) == ApiCacheTracker.ShouldCall.SKIP &&
-            synchronized(this@ChannelFilesController) { docsByChannel.containsKey(channelId) }
+            synchronized(this@ChannelFilesController) { filesByType.containsKey(key) }
         ) {
-            notificationCenter.postNotificationOnMainThread(NotificationCenter.channelFilesDidLoad, channelId)
+            notificationCenter.postNotificationOnMainThread(NotificationCenter.channelFilesDidLoad, channelId, filesType)
             return
         }
-        synchronized(loadingChannels) {
-            if (!loadingChannels.add(channelId)) return
+        synchronized(loadingFiles) {
+            if (!loadingFiles.add(key)) return
         }
         appScope.launch {
             try {
                 sessionManager.withAutoRefresh { session ->
                     val raw = withContext(ioDispatcher) {
-                        api.listChannelAttachments(session.apiUrl, session.token, clanId, channelId, limit = 100)
+                        api.listChannelAttachments(
+                            session.apiUrl,
+                            session.token,
+                            clanId,
+                            channelId,
+                            limit = 100,
+                            fileType = filesType.apiValue
+                        )
                     }
-                    val list = raw.attachmentsList.mapNotNull { it.toFilteredDocumentOrNull() }
+                    val list = raw.attachmentsList.mapNotNull { it.toFilteredDocumentOrNull(filesType) }
                         .distinctBy { it.stableId }
                     synchronized(this@ChannelFilesController) {
-                        docsByChannel[channelId] = ArrayList(list)
+                        filesByType[key] = ArrayList(list)
                     }
-                    synchronized(loadFailed) { loadFailed.remove(channelId) }
+                    synchronized(loadFailed) { loadFailed.remove(key) }
                     apiCacheTracker.markCalled(cacheKey, ttlMs = FILES_CACHE_TTL_MS)
-                    notificationCenter.postNotificationOnMainThread(NotificationCenter.channelFilesDidLoad, channelId)
+                    notificationCenter.postNotificationOnMainThread(NotificationCenter.channelFilesDidLoad, channelId, filesType)
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "listChannelAttachments failed channel=$channelId", e)
-                synchronized(loadFailed) { loadFailed.add(channelId) }
+                synchronized(loadFailed) { loadFailed.add(key) }
                 apiCacheTracker.invalidate(cacheKey)
-                notificationCenter.postNotificationOnMainThread(NotificationCenter.channelFilesLoadError, channelId)
+                notificationCenter.postNotificationOnMainThread(NotificationCenter.channelFilesLoadError, channelId, filesType)
             } finally {
-                synchronized(loadingChannels) { loadingChannels.remove(channelId) }
+                synchronized(loadingFiles) { loadingFiles.remove(key) }
             }
         }
     }
 
     private fun mergeFilesFromMessage(message: MessageEntity, replaceExisting: Boolean) {
         if (message.code != MessageEntity.CODE_CHAT && message.code != MessageEntity.CODE_CHAT_UPDATE) return
+        val attachments = message.allAttachmentsInfo
+        if (!replaceExisting && attachments.isEmpty()) return
 
-        val channelId = message.channelId
-        val newItems = message.toChannelDocumentItems()
+        ChannelFilesType.entries.forEach { filesType ->
+            mergeFilesFromMessage(message, attachments, replaceExisting, filesType)
+        }
+    }
+
+    private fun mergeFilesFromMessage(
+        message: MessageEntity,
+        attachments: List<AttachmentInfo>,
+        replaceExisting: Boolean,
+        filesType: ChannelFilesType
+    ) {
+        val key = ChannelFilesKey(message.channelId, filesType)
+        val newItems = attachments.mapNotNull { it.toChannelDocumentItem(message, filesType) }
         if (!replaceExisting && newItems.isEmpty()) return
 
-        val cacheKey = apiCacheKey("channelFiles", channelId)
+        val cacheKey = filesCacheKey(key)
         var changed = false
 
         synchronized(this) {
-            val current = docsByChannel[channelId]
+            val current = filesByType[key]
             if (current == null) {
                 apiCacheTracker.invalidate(cacheKey)
                 return
@@ -151,34 +199,38 @@ class ChannelFilesController @Inject constructor(
 
         if (changed) {
             apiCacheTracker.invalidate(cacheKey)
-            notifyFilesChanged(channelId)
+            notifyFilesChanged(message.channelId, filesType)
         }
     }
 
-    private fun removeByMessageId(channelId: Long, messageId: Long): Boolean = synchronized(this) {
-        val current = docsByChannel[channelId] ?: return@synchronized false
+    private fun removeByMessageId(
+        channelId: Long,
+        messageId: Long,
+        filesType: ChannelFilesType
+    ): Boolean = synchronized(this) {
+        val current = filesByType[ChannelFilesKey(channelId, filesType)] ?: return@synchronized false
         current.removeAll { it.messageId == messageId }
     }
 
-    private fun notifyFilesChanged(channelId: Long) {
-        notificationCenter.postNotificationOnMainThread(NotificationCenter.channelFilesDidLoad, channelId)
+    private fun notifyFilesChanged(channelId: Long, filesType: ChannelFilesType) {
+        notificationCenter.postNotificationOnMainThread(NotificationCenter.channelFilesDidLoad, channelId, filesType)
     }
+
+    private fun filesCacheKey(key: ChannelFilesKey): String =
+        apiCacheKey("channelFiles", key.channelId, key.filesType.apiValue)
 
     fun cleanup() {
-        synchronized(this) { docsByChannel.clear() }
+        synchronized(this) { filesByType.clear() }
         synchronized(loadFailed) { loadFailed.clear() }
-        synchronized(loadingChannels) { loadingChannels.clear() }
+        synchronized(loadingFiles) { loadingFiles.clear() }
     }
 }
 
-private fun MessageEntity.toChannelDocumentItems(): List<ChannelDocumentItem> {
-    return allAttachmentsInfo.mapNotNull { attachment ->
-        attachment.toChannelDocumentItem(this)
-    }
-}
-
-private fun AttachmentInfo.toChannelDocumentItem(message: MessageEntity): ChannelDocumentItem? {
-    if (!filetype.isDocumentFiletype()) return null
+private fun AttachmentInfo.toChannelDocumentItem(
+    message: MessageEntity,
+    filesType: ChannelFilesType
+): ChannelDocumentItem? {
+    if (!filetype.matchesFilesType(filesType)) return null
 
     val urlStr = url.trim()
     if (urlStr.isEmpty() || urlStr.startsWith("content://") || urlStr.startsWith("file://")) return null
@@ -194,8 +246,8 @@ private fun AttachmentInfo.toChannelDocumentItem(message: MessageEntity): Channe
     )
 }
 
-private fun ChannelAttachment.toFilteredDocumentOrNull(): ChannelDocumentItem? {
-    if (!filetype.isDocumentFiletype()) return null
+private fun ChannelAttachment.toFilteredDocumentOrNull(filesType: ChannelFilesType): ChannelDocumentItem? {
+    if (!filetype.matchesFilesType(filesType)) return null
     val urlStr = url
     if (urlStr.isEmpty()) return null
     val msgId = messageId
@@ -214,5 +266,12 @@ private fun String.isDocumentFiletype(): Boolean {
     val normalized = lowercase(Locale.US)
     return !normalized.startsWith("image") &&
         !normalized.startsWith("video") &&
+        !isAudioAttachmentType(this) &&
         normalized != "sticker"
 }
+
+private fun String.matchesFilesType(filesType: ChannelFilesType): Boolean =
+    when (filesType) {
+        ChannelFilesType.DOC -> isDocumentFiletype()
+        ChannelFilesType.AUDIO -> isAudioAttachmentType(this)
+    }

--- a/app/src/main/java/com/mezon/mobile/home/ChannelGalleryController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/ChannelGalleryController.kt
@@ -39,6 +39,16 @@ data class ChannelGalleryMediaItem(
     val isVideo: Boolean get() = isVideoAttachmentType(filetype)
 }
 
+enum class ChannelGalleryMediaType(val apiValue: String) {
+    IMAGE("image"),
+    VIDEO("video")
+}
+
+private data class ChannelGalleryKey(
+    val channelId: Long,
+    val mediaType: ChannelGalleryMediaType
+)
+
 private class ChannelGalleryState {
     val items = ArrayList<ChannelGalleryMediaItem>()
     var hasMoreBefore = true
@@ -57,9 +67,9 @@ class ChannelGalleryController @Inject constructor(
     @ApplicationScope private val appScope: CoroutineScope
 ) {
 
-    private val stateByChannel = HashMap<Long, ChannelGalleryState>()
-    private val mutexByChannel = HashMap<Long, Mutex>()
-    private val loadingChannels = Collections.synchronizedSet(HashSet<Long>())
+    private val stateByGallery = HashMap<ChannelGalleryKey, ChannelGalleryState>()
+    private val mutexByGallery = HashMap<ChannelGalleryKey, Mutex>()
+    private val loadingGalleries = Collections.synchronizedSet(HashSet<ChannelGalleryKey>())
 
     private val messageObserver = object : NotificationCenter.NotificationCenterDelegate {
         override fun didReceivedNotification(id: Int, account: Int, vararg args: Any?) {
@@ -96,108 +106,142 @@ class ChannelGalleryController @Inject constructor(
         notificationCenter.addObserver(messageObserver, NotificationCenter.messageDidDelete)
     }
 
-    fun getItems(channelId: Long): List<ChannelGalleryMediaItem> =
-        synchronized(stateByChannel) {
-            stateByChannel[channelId]?.items?.toList() ?: emptyList()
+    fun getItems(
+        channelId: Long,
+        mediaType: ChannelGalleryMediaType = ChannelGalleryMediaType.IMAGE
+    ): List<ChannelGalleryMediaItem> =
+        synchronized(stateByGallery) {
+            stateByGallery[ChannelGalleryKey(channelId, mediaType)]?.items?.toList() ?: emptyList()
         }
 
-    fun hasMoreBefore(channelId: Long): Boolean =
-        synchronized(stateByChannel) {
-            stateByChannel[channelId]?.hasMoreBefore != false
+    fun hasMoreBefore(
+        channelId: Long,
+        mediaType: ChannelGalleryMediaType = ChannelGalleryMediaType.IMAGE
+    ): Boolean =
+        synchronized(stateByGallery) {
+            stateByGallery[ChannelGalleryKey(channelId, mediaType)]?.hasMoreBefore != false
         }
 
-    fun isInitialLoading(channelId: Long): Boolean =
-        synchronized(stateByChannel) {
-            stateByChannel[channelId]?.initialLoading ?: false
+    fun isInitialLoading(
+        channelId: Long,
+        mediaType: ChannelGalleryMediaType = ChannelGalleryMediaType.IMAGE
+    ): Boolean =
+        synchronized(stateByGallery) {
+            stateByGallery[ChannelGalleryKey(channelId, mediaType)]?.initialLoading ?: false
         }
 
-    fun isPagingLoading(channelId: Long): Boolean =
-        synchronized(stateByChannel) {
-            stateByChannel[channelId]?.pagingLoading ?: false
+    fun isPagingLoading(
+        channelId: Long,
+        mediaType: ChannelGalleryMediaType = ChannelGalleryMediaType.IMAGE
+    ): Boolean =
+        synchronized(stateByGallery) {
+            stateByGallery[ChannelGalleryKey(channelId, mediaType)]?.pagingLoading ?: false
         }
 
-    fun isInitialLoadFinished(channelId: Long): Boolean =
-        synchronized(stateByChannel) {
-            stateByChannel[channelId]?.initialLoadFinished == true
+    fun isInitialLoadFinished(
+        channelId: Long,
+        mediaType: ChannelGalleryMediaType = ChannelGalleryMediaType.IMAGE
+    ): Boolean =
+        synchronized(stateByGallery) {
+            stateByGallery[ChannelGalleryKey(channelId, mediaType)]?.initialLoadFinished == true
         }
 
-    fun isFetching(channelId: Long): Boolean = synchronized(loadingChannels) { channelId in loadingChannels }
+    fun isFetching(
+        channelId: Long,
+        mediaType: ChannelGalleryMediaType = ChannelGalleryMediaType.IMAGE
+    ): Boolean =
+        synchronized(loadingGalleries) { ChannelGalleryKey(channelId, mediaType) in loadingGalleries }
 
-    fun ensureLoaded(channelId: Long, clanId: Long, forceRefresh: Boolean = false) {
-        val cacheKey = apiCacheKey("channelGallery", channelId)
+    fun ensureLoaded(
+        channelId: Long,
+        clanId: Long,
+        forceRefresh: Boolean = false,
+        mediaType: ChannelGalleryMediaType = ChannelGalleryMediaType.IMAGE
+    ) {
+        val key = ChannelGalleryKey(channelId, mediaType)
+        val cacheKey = galleryCacheKey(key)
         if (!forceRefresh &&
             apiCacheTracker.shouldCall(cacheKey) == ApiCacheTracker.ShouldCall.SKIP &&
-            isInitialLoadFinished(channelId)
+            isInitialLoadFinished(channelId, mediaType)
         ) {
-            notificationCenter.postNotificationOnMainThread(NotificationCenter.channelGalleryDidLoad, channelId)
+            notificationCenter.postNotificationOnMainThread(NotificationCenter.channelGalleryDidLoad, channelId, mediaType)
             return
         }
-        synchronized(loadingChannels) {
-            if (!loadingChannels.add(channelId)) return
+        synchronized(loadingGalleries) {
+            if (!loadingGalleries.add(key)) return
         }
         if (forceRefresh) {
             apiCacheTracker.invalidate(cacheKey)
-            resetState(channelId)
-        } else if (isInitialLoadFinished(channelId)) {
-            resetState(channelId)
+            resetState(key)
+        } else if (isInitialLoadFinished(channelId, mediaType)) {
+            resetState(key)
         } else {
-            synchronized(stateByChannel) {
-                stateByChannel.getOrPut(channelId) { ChannelGalleryState() }
+            synchronized(stateByGallery) {
+                stateByGallery.getOrPut(key) { ChannelGalleryState() }
             }
         }
         appScope.launch {
             try {
-                mutexFor(channelId).withLock {
-                    loadImpl(channelId, clanId, isInitial = true)
+                mutexFor(key).withLock {
+                    loadImpl(key, clanId, isInitial = true)
                 }
             } finally {
-                synchronized(loadingChannels) { loadingChannels.remove(channelId) }
+                synchronized(loadingGalleries) { loadingGalleries.remove(key) }
             }
         }
     }
 
-    fun clearAndReload(channelId: Long, clanId: Long) {
-        ensureLoaded(channelId, clanId, forceRefresh = true)
+    fun clearAndReload(
+        channelId: Long,
+        clanId: Long,
+        mediaType: ChannelGalleryMediaType = ChannelGalleryMediaType.IMAGE
+    ) {
+        ensureLoaded(channelId, clanId, forceRefresh = true, mediaType = mediaType)
     }
 
-    private fun resetState(channelId: Long) {
-        synchronized(stateByChannel) {
-            val st = stateByChannel[channelId] ?: ChannelGalleryState()
+    private fun resetState(key: ChannelGalleryKey) {
+        synchronized(stateByGallery) {
+            val st = stateByGallery[key] ?: ChannelGalleryState()
             st.items.clear()
             st.hasMoreBefore = true
             st.initialLoadFinished = false
             st.initialLoading = false
             st.pagingLoading = false
-            stateByChannel[channelId] = st
+            stateByGallery[key] = st
         }
     }
 
-    fun fetchOlderIfNeeded(channelId: Long, clanId: Long) {
+    fun fetchOlderIfNeeded(
+        channelId: Long,
+        clanId: Long,
+        mediaType: ChannelGalleryMediaType = ChannelGalleryMediaType.IMAGE
+    ) {
+        val key = ChannelGalleryKey(channelId, mediaType)
         appScope.launch {
-            mutexFor(channelId).withLock {
+            mutexFor(key).withLock {
                 val st =
-                    synchronized(stateByChannel) {
-                        stateByChannel[channelId]
+                    synchronized(stateByGallery) {
+                        stateByGallery[key]
                     } ?: return@withLock
 
                 if (!st.initialLoadFinished || st.pagingLoading || !st.hasMoreBefore || st.initialLoading) return@withLock
 
                 if (st.items.isEmpty()) return@withLock
 
-                loadImpl(channelId, clanId, isInitial = false)
+                loadImpl(key, clanId, isInitial = false)
             }
         }
     }
 
-    private fun mutexFor(channelId: Long): Mutex =
-        synchronized(mutexByChannel) {
-            mutexByChannel.getOrPut(channelId) { Mutex() }
+    private fun mutexFor(key: ChannelGalleryKey): Mutex =
+        synchronized(mutexByGallery) {
+            mutexByGallery.getOrPut(key) { Mutex() }
         }
 
-    private suspend fun loadImpl(channelId: Long, clanId: Long, isInitial: Boolean) {
+    private suspend fun loadImpl(key: ChannelGalleryKey, clanId: Long, isInitial: Boolean) {
         val state =
-            synchronized(stateByChannel) {
-                stateByChannel.getOrPut(channelId) { ChannelGalleryState() }
+            synchronized(stateByGallery) {
+                stateByGallery.getOrPut(key) { ChannelGalleryState() }
             }
 
         val shouldProceed =
@@ -234,13 +278,15 @@ class ChannelGalleryController @Inject constructor(
                         apiUrl = session.apiUrl,
                         token = session.token,
                         clanId = clanId,
-                        channelId = channelId,
+                        channelId = key.channelId,
                         limit = PAGE_LIMIT,
+                        fileType = key.mediaType.apiValue,
                         beforeTimeSeconds = beforeSecs
                     )
                 }
 
                 val batchSorted = raw.attachmentsList.mapNotNull { it.toFilteredMediaOrNull() }
+                    .filter { (key.mediaType == ChannelGalleryMediaType.VIDEO) == it.isVideo }
                     .distinctBy { it.id }
                     .sortedWith(
                         compareByDescending<ChannelGalleryMediaItem> { it.createTimeSeconds }.thenByDescending { it.id }
@@ -284,29 +330,37 @@ class ChannelGalleryController @Inject constructor(
                     val hm = synchronized(state) { state.hasMoreBefore }
                     Log.d(
                         TAG,
-                        "loadMore ch=$channelId initial=$isInitial before=$beforeSecs " +
+                        "loadMore ch=${key.channelId} initial=$isInitial before=$beforeSecs " +
                             "raw=${raw.attachmentsList.size} batch=${batchSorted.size} " +
                             "appended=$appendedCount hasMoreBefore=$hm"
                     )
                 }
 
                 if (isInitial) {
-                    apiCacheTracker.markCalled(apiCacheKey("channelGallery", channelId))
+                    apiCacheTracker.markCalled(galleryCacheKey(key))
                 }
 
-                notificationCenter.postNotificationOnMainThread(NotificationCenter.channelGalleryDidLoad, channelId)
+                notificationCenter.postNotificationOnMainThread(
+                    NotificationCenter.channelGalleryDidLoad,
+                    key.channelId,
+                    key.mediaType
+                )
             }
         } catch (e: Exception) {
-            Log.e(TAG, "listChannelAttachments channel=$channelId", e)
+            Log.e(TAG, "listChannelAttachments channel=${key.channelId}", e)
             synchronized(state) {
                 if (isInitial) state.initialLoadFinished = true
             }
 
             if (isInitial) {
-                apiCacheTracker.invalidate(apiCacheKey("channelGallery", channelId))
+                apiCacheTracker.invalidate(galleryCacheKey(key))
             }
 
-            notificationCenter.postNotificationOnMainThread(NotificationCenter.channelGalleryLoadError, channelId)
+            notificationCenter.postNotificationOnMainThread(
+                NotificationCenter.channelGalleryLoadError,
+                key.channelId,
+                key.mediaType
+            )
         } finally {
             synchronized(state) {
                 when {
@@ -322,64 +376,77 @@ class ChannelGalleryController @Inject constructor(
         if (!message.isRenderable) return false
         if (message.code != MessageEntity.CODE_CHAT && message.code != MessageEntity.CODE_CHAT_UPDATE) return false
 
-        val channelId = message.channelId
-        val cacheKey = apiCacheKey("channelGallery", channelId)
-        if (!isInitialLoadFinished(channelId)) {
-            apiCacheTracker.invalidate(cacheKey)
-            return false
-        }
-
         val batch = message.toGalleryMediaItems()
         if (batch.isEmpty()) return false
 
         var changed = false
-        synchronized(stateByChannel) {
-            val state = stateByChannel[channelId] ?: return false
-            val existingUrls = state.items.mapTo(HashSet(state.items.size)) { it.url }
-            val existingIds = state.items.mapTo(HashSet(state.items.size)) { it.id }
+        batch.groupBy { if (it.isVideo) ChannelGalleryMediaType.VIDEO else ChannelGalleryMediaType.IMAGE }
+            .forEach typeLoop@{ (mediaType, mediaItems) ->
+                val key = ChannelGalleryKey(message.channelId, mediaType)
+                val state = synchronized(stateByGallery) { stateByGallery[key] }
+                if (state == null || !state.initialLoadFinished) {
+                    apiCacheTracker.invalidate(galleryCacheKey(key))
+                    return@typeLoop
+                }
 
-            batch.forEach { candidate ->
-                if (candidate.url in existingUrls || candidate.id in existingIds) return@forEach
-                state.items.add(candidate)
-                existingUrls.add(candidate.url)
-                existingIds.add(candidate.id)
-                changed = true
-            }
+                var stateChanged = false
+                synchronized(state) {
+                    val existingUrls = state.items.mapTo(HashSet(state.items.size)) { it.url }
+                    val existingIds = state.items.mapTo(HashSet(state.items.size)) { it.id }
 
-            if (changed) {
-                state.items.sortWith(
-                    compareByDescending<ChannelGalleryMediaItem> { it.createTimeSeconds }
-                        .thenByDescending { it.id }
-                )
+                    mediaItems.forEach candidateLoop@{ candidate ->
+                        if (candidate.url in existingUrls || candidate.id in existingIds) return@candidateLoop
+                        state.items.add(candidate)
+                        existingUrls.add(candidate.url)
+                        existingIds.add(candidate.id)
+                        stateChanged = true
+                        changed = true
+                    }
+
+                    if (stateChanged) {
+                        state.items.sortWith(
+                            compareByDescending<ChannelGalleryMediaItem> { it.createTimeSeconds }
+                                .thenByDescending { it.id }
+                        )
+                    }
+                }
+                if (stateChanged) apiCacheTracker.invalidate(galleryCacheKey(key))
             }
-        }
 
         if (!changed) return false
 
-        apiCacheTracker.invalidate(cacheKey)
-        notificationCenter.postNotificationOnMainThread(NotificationCenter.channelGalleryDidLoad, channelId)
+        notificationCenter.postNotificationOnMainThread(NotificationCenter.channelGalleryDidLoad, message.channelId)
         return true
     }
 
     private fun removeByMessageId(channelId: Long, messageId: Long): Boolean {
-        synchronized(stateByChannel) {
-            val state = stateByChannel[channelId] ?: return false
-            if (!state.initialLoadFinished) return false
-            val before = state.items.size
-            state.items.removeAll { it.messageId == messageId }
-            return state.items.size != before
+        synchronized(stateByGallery) {
+            var changed = false
+            stateByGallery
+                .filterKeys { it.channelId == channelId }
+                .values
+                .filter { it.initialLoadFinished }
+                .forEach { state ->
+                    val before = state.items.size
+                    state.items.removeAll { it.messageId == messageId }
+                    if (state.items.size != before) changed = true
+                }
+            return changed
         }
     }
 
+    private fun galleryCacheKey(key: ChannelGalleryKey): String =
+        apiCacheKey("channelGallery", key.channelId, key.mediaType.apiValue)
+
     fun cleanup() {
-        synchronized(stateByChannel) {
-            stateByChannel.clear()
+        synchronized(stateByGallery) {
+            stateByGallery.clear()
         }
-        synchronized(mutexByChannel) {
-            mutexByChannel.clear()
+        synchronized(mutexByGallery) {
+            mutexByGallery.clear()
         }
-        synchronized(loadingChannels) {
-            loadingChannels.clear()
+        synchronized(loadingGalleries) {
+            loadingGalleries.clear()
         }
     }
 }

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -327,6 +327,7 @@ open class ChatFragment : BaseFragment() {
     private var topicRootHeader: TopicRootHeaderView? = null
     private var activePhotoViewer: PhotoViewer? = null
     private var photoViewerSelectedUrl = ""
+    private var photoViewerSourceMessage: MessageEntity? = null
     private var cachedTopicRootMessage: MessageEntity? = null
     private val messageListKey: Long
         get() = if (topicId != 0L) topicId else channelId
@@ -2890,7 +2891,7 @@ open class ChatFragment : BaseFragment() {
                     if (sticker.isForSale && sticker.src.isBlank()) return
                     val url = resolveStickerSourceUrl(sticker.id, sticker.src)
                     if (url.isBlank()) return
-                    val filetype = if (isAudio) "audio/mpeg" else "image/gif"
+                    val filetype = if (isAudio) "audio/mpeg" else "sticker"
                     val references = buildReplyReferences()
                     chatController.sendDirectAttachment(
                         channelId, clanId, channelType, resolveChannelPrivate(),
@@ -2900,13 +2901,12 @@ open class ChatFragment : BaseFragment() {
                     hideEmojiView()
                 }
 
-                override fun onGifSelected(gifUrl: String, width: Int, height: Int) {
+                override fun onGifSelected(gifUrl: String) {
                     if (!ensureCanSendMessageOrNotify()) return
                     val references = buildReplyReferences()
                     chatController.sendDirectAttachment(
                         channelId, clanId, channelType, resolveChannelPrivate(),
-                        gifUrl, "image/gif", references = references, topicId = topicId,
-                        width = width, height = height
+                        gifUrl, "sticker", references = references, topicId = topicId
                     )
                     clearReplyState()
                     hideEmojiView()
@@ -3013,6 +3013,7 @@ open class ChatFragment : BaseFragment() {
         activePhotoViewer?.setOnDismissListener(null)
         activePhotoViewer?.dismiss()
         activePhotoViewer = null
+        photoViewerSourceMessage = null
         dismissPasteImagePopup()
         waitingForKeyboardOpen = false
         AndroidUtilities.cancelRunOnUIThread(openKeyboardRunnable)
@@ -3974,10 +3975,14 @@ open class ChatFragment : BaseFragment() {
         val viewer = PhotoViewer(context)
         activePhotoViewer = viewer
         photoViewerSelectedUrl = url
+        photoViewerSourceMessage = msg
         viewer.onCurrentUrlChanged = { photoViewerSelectedUrl = it }
         viewer.onReachedOldestEdge = { channelGalleryController.fetchOlderIfNeeded(channelId, clanId) }
         viewer.setOnDismissListener {
-            if (activePhotoViewer === viewer) activePhotoViewer = null
+            if (activePhotoViewer === viewer) {
+                activePhotoViewer = null
+                photoViewerSourceMessage = null
+            }
         }
         val initial = buildPhotoViewerItems(url, seedUrls, msg)
         val idx = initial.indexOfFirst { it.url == url }.coerceAtLeast(0)
@@ -4002,7 +4007,7 @@ open class ChatFragment : BaseFragment() {
 
     private fun refreshActivePhotoViewerGallery() {
         val viewer = activePhotoViewer ?: return
-        val items = buildPhotoViewerItems(photoViewerSelectedUrl)
+        val items = buildPhotoViewerItems(photoViewerSelectedUrl, msg = photoViewerSourceMessage)
         if (items.isEmpty()) return
         viewer.updateGallery(items, photoViewerSelectedUrl)
     }

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
@@ -1038,7 +1038,12 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             } else if (isLocalUri) {
                 receiver.setLocalUri(android.net.Uri.parse(att.url), context)
             } else if (isAnimated || isStickerAttachment) {
-                receiver.setImage(att.url, att.thumb.ifEmpty { null }, context, forceAnimated = isAnimated)
+                val mainUrl = if (isStickerAttachment) {
+                    createImgproxyUrl(att.url, pw, ph, "fit")
+                } else {
+                    att.url
+                }
+                receiver.setImage(mainUrl, att.thumb.ifEmpty { null }, context, forceAnimated = isAnimated)
             } else if (isVideo) {
                 val thumb = att.thumb.ifEmpty { null }
                 if (thumb != null) {

--- a/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/ChannelInfoFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/ChannelInfoFragment.kt
@@ -33,7 +33,9 @@ import com.mezon.mobile.home.ClanMember
 import com.mezon.mobile.home.clans.ChannelCanvasController
 import com.mezon.mobile.home.clans.ChannelMuteBottomSheet
 import com.mezon.mobile.home.ChannelFilesController
+import com.mezon.mobile.home.ChannelFilesType
 import com.mezon.mobile.home.ChannelGalleryController
+import com.mezon.mobile.home.ChannelGalleryMediaType
 import com.mezon.mobile.home.DialogsController
 import com.mezon.mobile.home.DmGroupAvatarUploadResult
 import com.mezon.mobile.home.MemberResolver
@@ -212,12 +214,14 @@ class ChannelInfoFragment : BaseFragment() {
         observe(NotificationCenter.channelFilesDidLoad) { _, _, args ->
             if (isPaused) return@observe
             val ch = args.firstOrNull() as? Long ?: return@observe
-            if (ch == channelId) filesTab?.onRemoteChannelFiles(ch)
+            val filesType = args.getOrNull(1) as? ChannelFilesType ?: ChannelFilesType.DOC
+            if (ch == channelId) filesTab?.onRemoteChannelFiles(ch, filesType)
         }
         observe(NotificationCenter.channelFilesLoadError) { _, _, args ->
             if (isPaused) return@observe
             val ch = args.firstOrNull() as? Long ?: return@observe
-            if (ch == channelId) filesTab?.onRemoteChannelFiles(ch)
+            val filesType = args.getOrNull(1) as? ChannelFilesType ?: ChannelFilesType.DOC
+            if (ch == channelId) filesTab?.onRemoteChannelFiles(ch, filesType)
         }
         observe(NotificationCenter.channelPermissionsDidLoad) { _, _, args ->
             if (isPaused) return@observe
@@ -245,11 +249,12 @@ class ChannelInfoFragment : BaseFragment() {
             if (fragmentView == null) return@observe
             val ch = args.firstOrNull() as? Long ?: return@observe
             if (ch != channelId) return@observe
+            val mediaType = args.getOrNull(1) as? ChannelGalleryMediaType ?: ChannelGalleryMediaType.IMAGE
             if (isPaused) {
-                pendingGalleryError = true
+                pendingGalleryError = mediaType
                 return@observe
             }
-            fragmentView?.context?.let { ctx -> mediaTab?.onGalleryLoadFailure(ctx) }
+            fragmentView?.context?.let { ctx -> mediaTab?.onGalleryLoadFailure(ctx, mediaType) }
         }
 
         observe(NotificationCenter.channelCanvasesDidLoad) { _, _, args ->
@@ -270,16 +275,16 @@ class ChannelInfoFragment : BaseFragment() {
         return true
     }
 
-    private var pendingGalleryError = false
+    private var pendingGalleryError: ChannelGalleryMediaType? = null
 
     override fun onBecomeFullyVisible() {
         super.onBecomeFullyVisible()
-        if (channelGalleryController.isInitialLoadFinished(channelId)) {
-            fragmentView?.context?.let { ctx -> mediaTab?.syncFromApi(ctx) }
-        } else if (pendingGalleryError) {
-            fragmentView?.context?.let { ctx -> mediaTab?.onGalleryLoadFailure(ctx) }
+        filesTab?.reload()
+        fragmentView?.context?.let { ctx ->
+            mediaTab?.syncFromApi(ctx)
+            pendingGalleryError?.let { mediaType -> mediaTab?.onGalleryLoadFailure(ctx, mediaType) }
         }
-        pendingGalleryError = false
+        pendingGalleryError = null
     }
 
     override fun dismissDialogOnPause(dialog: Dialog): Boolean {

--- a/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/FilesTabHelper.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/FilesTabHelper.kt
@@ -3,8 +3,10 @@ package com.mezon.mobile.home.chat.channelinfo
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.graphics.Color
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
+import android.graphics.Typeface
 import android.graphics.drawable.GradientDrawable
 import android.net.Uri
 import android.os.Handler
@@ -27,6 +29,7 @@ import com.mezon.mobile.core.LayoutHelper
 import com.mezon.mobile.core.RecyclerListView
 import com.mezon.mobile.core.ThemeColors
 import com.mezon.mobile.home.ChannelFilesController
+import com.mezon.mobile.home.ChannelFilesType
 import com.mezon.mobile.home.MemberResolver
 import com.mezon.mobile.ui.cells.MezonIcon
 import java.text.SimpleDateFormat
@@ -50,6 +53,9 @@ class FilesTabHelper(
     private var recyclerView: RecyclerListView? = null
     private var emptyView: View? = null
     private var loadingView: ProgressBar? = null
+    private var docsTab: TextView? = null
+    private var audiosTab: TextView? = null
+    private var selectedFilesType = ChannelFilesType.DOC
     private var searchText: String = ""
     private val debounce = Handler(Looper.getMainLooper())
     private var debounceRun: Runnable? = null
@@ -81,7 +87,20 @@ class FilesTabHelper(
     }
 
     override fun buildView(context: Context): View {
-        val root = FrameLayout(context)
+        val root = LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+        }
+
+        root.addView(
+            buildFilesTypeTabs(context),
+            LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LayoutHelper.dp(42f)).apply {
+                val margin = LayoutHelper.dp(8f)
+                setMargins(margin, margin, margin, margin)
+            }
+        )
+
+        val content = FrameLayout(context)
+        root.addView(content, LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, 0, 1f))
 
         val searchRow = LinearLayout(context).apply {
             orientation = LinearLayout.HORIZONTAL
@@ -112,7 +131,7 @@ class FilesTabHelper(
                 override fun afterTextChanged(s: Editable?) {
                     val txt = s?.toString().orEmpty()
                     debounceRun?.let { debounce.removeCallbacks(it) }
-                    val r = Runnable { applySearchAndDocs(txt) }
+                    val r = Runnable { applySearch(txt) }
                     debounceRun = r
                     debounce.postDelayed(r, 500)
                 }
@@ -120,7 +139,7 @@ class FilesTabHelper(
             searchRow.addView(this, LayoutHelper.createLinear(0, LayoutHelper.WRAP_CONTENT, 1f, Gravity.CENTER_VERTICAL, 8f, 0f, 2f, 0f))
         }
 
-        root.addView(searchRow, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, 40, Gravity.TOP, 10f, 8f, 10f, 0f))
+        content.addView(searchRow, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, 40, Gravity.TOP, 10f, 8f, 10f, 0f))
 
         adapter = ChannelFilesAdapter(themeColors, rowResolver)
         val ad = adapter!!
@@ -130,20 +149,76 @@ class FilesTabHelper(
             clipToPadding = false
             setPadding(LayoutHelper.dp(10f), 0, LayoutHelper.dp(10f), LayoutHelper.dp(6f))
         }
-        root.addView(recyclerView, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT, Gravity.TOP, 0f, 56f, 0f, 0f))
+        content.addView(recyclerView, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT, Gravity.TOP, 0f, 56f, 0f, 0f))
 
         emptyView = buildEmptyView(context)
-        root.addView(emptyView, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT, Gravity.TOP, 0f, 56f, 0f, 0f))
+        content.addView(emptyView, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT, Gravity.TOP, 0f, 56f, 0f, 0f))
 
         loadingView = ProgressBar(context).apply { visibility = View.VISIBLE }
-        root.addView(loadingView, LayoutHelper.createFrame(48, 48, Gravity.CENTER))
+        content.addView(loadingView, LayoutHelper.createFrame(48, 48, Gravity.CENTER))
 
-        channelFilesController.loadChannelFiles(channelId, clanId)
+        channelFilesController.loadChannelFiles(channelId, clanId, filesType = selectedFilesType)
         refreshListUi()
         return root
     }
 
-    private fun applySearchAndDocs(query: String) {
+    private fun buildFilesTypeTabs(context: Context): View {
+        val tabs = LinearLayout(context).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER
+            setPadding(LayoutHelper.dp(4f), LayoutHelper.dp(4f), LayoutHelper.dp(4f), LayoutHelper.dp(4f))
+            background = roundedBackground(themeColors.surfaceVariant, 12f)
+        }
+        docsTab = buildFilesTypeTab(context, getString(R.string.channel_files_docs), ChannelFilesType.DOC)
+        audiosTab = buildFilesTypeTab(context, getString(R.string.channel_files_audios), ChannelFilesType.AUDIO)
+        tabs.addView(docsTab, LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.MATCH_PARENT, 1f))
+        tabs.addView(audiosTab, LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.MATCH_PARENT, 1f))
+        updateFilesTypeTabs()
+        return tabs
+    }
+
+    private fun buildFilesTypeTab(
+        context: Context,
+        label: String,
+        filesType: ChannelFilesType
+    ): TextView = TextView(context).apply {
+        text = label
+        gravity = Gravity.CENTER
+        setTextSize(TypedValue.COMPLEX_UNIT_DIP, 14f)
+        typeface = Typeface.DEFAULT_BOLD
+        setOnClickListener { selectFilesType(filesType) }
+    }
+
+    private fun selectFilesType(filesType: ChannelFilesType) {
+        if (selectedFilesType == filesType) return
+        selectedFilesType = filesType
+        updateFilesTypeTabs()
+        recyclerView?.scrollToPosition(0)
+        channelFilesController.loadChannelFiles(channelId, clanId, filesType = selectedFilesType)
+        refreshListUi()
+    }
+
+    private fun updateFilesTypeTabs() {
+        listOf(
+            docsTab to ChannelFilesType.DOC,
+            audiosTab to ChannelFilesType.AUDIO
+        ).forEach { (tab, filesType) ->
+            val selected = selectedFilesType == filesType
+            tab?.setTextColor(if (selected) Color.WHITE else themeColors.onSurfaceVariant)
+            tab?.background = roundedBackground(
+                if (selected) themeColors.blurple else Color.TRANSPARENT,
+                9f
+            )
+        }
+    }
+
+    private fun roundedBackground(color: Int, radiusDp: Float): GradientDrawable =
+        GradientDrawable().apply {
+            setColor(color)
+            cornerRadius = LayoutHelper.dpf(radiusDp)
+        }
+
+    private fun applySearch(query: String) {
         searchText = query
         refreshListUi()
     }
@@ -153,10 +228,10 @@ class FilesTabHelper(
     }
 
     private fun refreshListUi() {
-        val docs = channelFilesController.getDocuments(channelId)
-        val rows = buildChannelFileRows(docs, searchText, isVietnameseLocale)
+        val files = channelFilesController.getDocuments(channelId, selectedFilesType)
+        val rows = buildChannelFileRows(files, searchText, isVietnameseLocale)
         adapter?.setRows(rows)
-        val fetching = channelFilesController.isFetching(channelId)
+        val fetching = channelFilesController.isFetching(channelId, selectedFilesType)
         loadingView?.visibility = if (fetching) View.VISIBLE else View.GONE
         if (rows.isNotEmpty()) {
             emptyView?.visibility = View.GONE
@@ -189,8 +264,8 @@ class FilesTabHelper(
         return container
     }
 
-    fun onRemoteChannelFiles(forChannelId: Long) {
-        if (forChannelId != channelId) return
+    fun onRemoteChannelFiles(forChannelId: Long, filesType: ChannelFilesType) {
+        if (forChannelId != channelId || filesType != selectedFilesType) return
         refreshListUi()
     }
 }

--- a/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/MediaTabHelper.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/MediaTabHelper.kt
@@ -1,9 +1,15 @@
 package com.mezon.mobile.home.chat.channelinfo
 
 import android.content.Context
+import android.graphics.Color
+import android.graphics.Typeface
+import android.graphics.drawable.GradientDrawable
 import android.util.Log
+import android.view.Gravity
 import android.view.View
 import android.widget.FrameLayout
+import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.mezon.mobile.BuildConfig
@@ -13,6 +19,7 @@ import com.mezon.mobile.core.RecyclerListView
 import com.mezon.mobile.core.ThemeColors
 import com.mezon.mobile.home.ChannelGalleryController
 import com.mezon.mobile.home.ChannelGalleryMediaItem
+import com.mezon.mobile.home.ChannelGalleryMediaType
 import com.mezon.mobile.home.ClanMember
 import com.mezon.mobile.home.MemberResolver
 import com.mezon.mobile.ui.cells.ScreenStateView
@@ -45,6 +52,9 @@ class MediaTabHelper(
     private var recyclerView: RecyclerListView? = null
     private var screenState: ScreenStateView? = null
     private var gallerySkeleton: ChannelMediaGallerySkeletonView? = null
+    private var imageTab: TextView? = null
+    private var videoTab: TextView? = null
+    private var selectedMediaType = ChannelGalleryMediaType.IMAGE
 
     private var lastOlderFetchMs = 0L
 
@@ -62,24 +72,37 @@ class MediaTabHelper(
                 hostContext = hostContext
             )
 
-        val root = FrameLayout(context)
+        val root = LinearLayout(context).apply {
+            orientation = LinearLayout.VERTICAL
+        }
+
+        root.addView(
+            buildMediaTypeTabs(context),
+            LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LayoutHelper.dp(42f)).apply {
+                val margin = LayoutHelper.dp(8f)
+                setMargins(margin, margin, margin, margin)
+            }
+        )
+
+        val content = FrameLayout(context)
+        root.addView(content, LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, 0, 1f))
 
         val screen =
             ScreenStateView(context, themeColors).apply {
                 screenState = this
                 onRetry = {
-                    galleryController.clearAndReload(channelId, clanId)
+                    galleryController.clearAndReload(channelId, clanId, mediaType = selectedMediaType)
                     applySync(context)
                 }
             }
-        root.addView(screen, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT))
+        content.addView(screen, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT))
 
         val skeleton =
             ChannelMediaGallerySkeletonView(context, themeColors) {
                 computeCellSizePx(context)
             }
         gallerySkeleton = skeleton
-        root.addView(skeleton, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT))
+        content.addView(skeleton, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT))
         skeleton.visibility = View.GONE
 
         val lv =
@@ -110,19 +133,76 @@ class MediaTabHelper(
                 })
             }
 
-        root.addView(lv, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT))
+        content.addView(lv, LayoutHelper.createFrame(LayoutHelper.MATCH_PARENT, LayoutHelper.MATCH_PARENT))
 
         recyclerView?.visibility = View.GONE
 
-        galleryController.ensureLoaded(channelId, clanId)
+        galleryController.ensureLoaded(channelId, clanId, mediaType = selectedMediaType)
         applySync(context)
 
         return root
     }
 
+    private fun buildMediaTypeTabs(context: Context): View {
+        val tabs = LinearLayout(context).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER
+            setPadding(LayoutHelper.dp(4f), LayoutHelper.dp(4f), LayoutHelper.dp(4f), LayoutHelper.dp(4f))
+            background = roundedBackground(themeColors.surfaceVariant, 12f)
+        }
+        imageTab = buildMediaTypeTab(context, getString(R.string.channel_gallery_images), ChannelGalleryMediaType.IMAGE)
+        videoTab = buildMediaTypeTab(context, getString(R.string.channel_gallery_videos), ChannelGalleryMediaType.VIDEO)
+        tabs.addView(imageTab, LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.MATCH_PARENT, 1f))
+        tabs.addView(videoTab, LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.MATCH_PARENT, 1f))
+        updateMediaTypeTabs()
+        return tabs
+    }
+
+    private fun buildMediaTypeTab(
+        context: Context,
+        label: String,
+        mediaType: ChannelGalleryMediaType
+    ): TextView = TextView(context).apply {
+        text = label
+        gravity = Gravity.CENTER
+        setTextSize(android.util.TypedValue.COMPLEX_UNIT_DIP, 14f)
+        typeface = Typeface.DEFAULT_BOLD
+        setOnClickListener { selectMediaType(context, mediaType) }
+    }
+
+    private fun selectMediaType(context: Context, mediaType: ChannelGalleryMediaType) {
+        if (selectedMediaType == mediaType) return
+        selectedMediaType = mediaType
+        lastOlderFetchMs = 0L
+        updateMediaTypeTabs()
+        recyclerView?.scrollToPosition(0)
+        galleryController.ensureLoaded(channelId, clanId, mediaType = selectedMediaType)
+        applySync(context)
+    }
+
+    private fun updateMediaTypeTabs() {
+        listOf(
+            imageTab to ChannelGalleryMediaType.IMAGE,
+            videoTab to ChannelGalleryMediaType.VIDEO
+        ).forEach { (tab, mediaType) ->
+            val selected = selectedMediaType == mediaType
+            tab?.setTextColor(if (selected) Color.WHITE else themeColors.onSurfaceVariant)
+            tab?.background = roundedBackground(
+                if (selected) themeColors.blurple else Color.TRANSPARENT,
+                9f
+            )
+        }
+    }
+
+    private fun roundedBackground(color: Int, radiusDp: Float): GradientDrawable =
+        GradientDrawable().apply {
+            setColor(color)
+            cornerRadius = LayoutHelper.dpf(radiusDp)
+        }
+
     override fun reload() {
         val ctx = hostContext() ?: return
-        galleryController.ensureLoaded(channelId, clanId)
+        galleryController.ensureLoaded(channelId, clanId, mediaType = selectedMediaType)
         recyclerView?.visibility = View.GONE
         applySync(ctx)
     }
@@ -131,7 +211,8 @@ class MediaTabHelper(
         applySync(context)
     }
 
-    fun onGalleryLoadFailure(context: Context) {
+    fun onGalleryLoadFailure(context: Context, mediaType: ChannelGalleryMediaType) {
+        if (mediaType != selectedMediaType) return
         gallerySkeleton?.visibility = View.GONE
         screenState?.showError(context.getString(R.string.channel_gallery_load_error))
         recyclerView?.visibility = View.GONE
@@ -145,10 +226,11 @@ class MediaTabHelper(
     private fun applySync(context: Context) {
         val screen = screenState ?: return
 
-        val items = galleryController.getItems(channelId)
-        val paging = galleryController.isPagingLoading(channelId)
-        val initialDone = galleryController.isInitialLoadFinished(channelId)
-        val fetching = galleryController.isFetching(channelId) || galleryController.isInitialLoading(channelId)
+        val items = galleryController.getItems(channelId, selectedMediaType)
+        val paging = galleryController.isPagingLoading(channelId, selectedMediaType)
+        val initialDone = galleryController.isInitialLoadFinished(channelId, selectedMediaType)
+        val fetching = galleryController.isFetching(channelId, selectedMediaType) ||
+            galleryController.isInitialLoading(channelId, selectedMediaType)
 
         val resolverIds = LinkedHashSet<Long>()
         items.forEach {
@@ -186,15 +268,15 @@ class MediaTabHelper(
     }
 
     private fun tryLoadOlder() {
-        if (!galleryController.hasMoreBefore(channelId)) {
+        if (!galleryController.hasMoreBefore(channelId, selectedMediaType)) {
             dbgTryLoadOlderSkip("hasMoreBefore_false")
             return
         }
-        if (galleryController.isPagingLoading(channelId)) {
+        if (galleryController.isPagingLoading(channelId, selectedMediaType)) {
             dbgTryLoadOlderSkip("paging_loading")
             return
         }
-        if (galleryController.isInitialLoading(channelId)) {
+        if (galleryController.isInitialLoading(channelId, selectedMediaType)) {
             dbgTryLoadOlderSkip("initial_loading")
             return
         }
@@ -208,7 +290,7 @@ class MediaTabHelper(
             Log.d(DBG_TAG, "tryLoadOlder fetch ch=$channelId clan=$clanId")
         }
 
-        galleryController.fetchOlderIfNeeded(channelId, clanId)
+        galleryController.fetchOlderIfNeeded(channelId, clanId, mediaType = selectedMediaType)
         lastOlderFetchMs = now
     }
 

--- a/app/src/main/java/com/mezon/mobile/home/chat/emoji/EmojiView.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/emoji/EmojiView.kt
@@ -54,7 +54,7 @@ class EmojiView(
     interface EmojiViewDelegate {
         fun onEmojiSelected(emoji: EmojiItem)
         fun onStickerSelected(sticker: StickerItem, isAudio: Boolean)
-        fun onGifSelected(gifUrl: String, width: Int = 0, height: Int = 0)
+        fun onGifSelected(gifUrl: String)
         fun onBackspace()
         fun onSearchFocusChanged(focused: Boolean) {}
         fun onDismissRequested() {}
@@ -478,7 +478,7 @@ class EmojiView(
                 }
                 if (gifGrid == null) {
                     gifAdapter = GifGridAdapter(themeColors) { gif ->
-                        delegate?.onGifSelected(gif.gifUrl, gif.width, gif.height)
+                        delegate?.onGifSelected(gif.gifUrl)
                     }
                     gifGrid = RecyclerListView(context).apply {
                         layoutManager = androidx.recyclerview.widget.StaggeredGridLayoutManager(2, androidx.recyclerview.widget.StaggeredGridLayoutManager.VERTICAL)

--- a/app/src/main/java/com/mezon/mobile/home/chat/thread/CreateThreadFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/thread/CreateThreadFragment.kt
@@ -1517,15 +1517,15 @@ class CreateThreadFragment : BaseFragment() {
                     if (sticker.isForSale && sticker.src.isBlank()) return
                     val url = resolveStickerSourceUrl(sticker.id, sticker.src)
                     if (url.isBlank()) return
-                    val filetype = if (isAudio) "audio/mpeg" else "image/gif"
+                    val filetype = if (isAudio) "audio/mpeg" else "sticker"
                     pendingStickerSend = PendingStickerSend(url, filetype, sticker.id.toString())
                     hideEmojiView(animated = false)
                     updateSendButtonState()
                 }
 
-                override fun onGifSelected(gifUrl: String, width: Int, height: Int) {
+                override fun onGifSelected(gifUrl: String) {
                     if (gifUrl.isBlank()) return
-                    pendingStickerSend = PendingStickerSend(gifUrl, "image/gif", null)
+                    pendingStickerSend = PendingStickerSend(gifUrl, "sticker", null)
                     hideEmojiView(animated = false)
                     updateSendButtonState()
                 }

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -967,6 +967,8 @@
     <string name="channel_app_launch">Khởi chạy ứng dụng</string>
     <string name="channel_app_help">Trợ giúp</string>
     <string name="channel_app_launch_unavailable">Không mở được ứng dụng. Hãy thử lại.</string>
+    <string name="channel_gallery_images">Hình ảnh</string>
+    <string name="channel_gallery_videos">Video</string>
     <string name="channel_gallery_empty">Chưa có ảnh hoặc video được chia sẻ.</string>
     <string name="channel_gallery_load_error">Không tải được nội dung media. Hãy thử lại.</string>
     <!-- Edit Profile -->
@@ -1262,6 +1264,8 @@
     <string name="system_msg_thread_sentence_see">Xem</string>
     <string name="system_msg_all_threads">tất cả chủ đề</string>
     <string name="channel_files_search_placeholder">Tìm kiếm tệp</string>
+    <string name="channel_files_docs">Tài liệu</string>
+    <string name="channel_files_audios">Âm thanh</string>
     <string name="channel_files_media_empty_description">Chúng tôi đã tìm kiếm rất xa. Thật không may, không có kết quả được tìm thấy</string>
     <string name="channel_files_shared_by">Được chia sẻ bởi %1$s</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -363,10 +363,14 @@
     <string name="unpin_message_confirm_title">Unpin Message</string>
     <string name="unpin_message_confirm_description">Please confirm if you would like to remove this pinned message?</string>
     <string name="pin_message_empty">This channel doesn\'t have any pinned messages\u2026 yet.</string>
+    <string name="channel_gallery_images">Images</string>
+    <string name="channel_gallery_videos">Videos</string>
     <string name="channel_gallery_empty">No shared photos or videos yet.</string>
     <string name="channel_gallery_load_error">Couldn\'t load media. Try again.</string>
 
     <string name="channel_files_search_placeholder">Search Files</string>
+    <string name="channel_files_docs">Docs</string>
+    <string name="channel_files_audios">Audios</string>
     <string name="channel_canvas_search_placeholder">Search Canvas</string>
     <string name="channel_canvas_untitled">Untitled</string>
     <string name="channel_canvas_link_copied">Canvas link copied!</string>


### PR DESCRIPTION
task: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-309
Root Cause: Media and Files mixed attachment types in the same view, and their loading and pagination states were shared.
Solution: Added separate Images/Videos and Docs/Audios sub-tabs, with independent data states while preserving search, pagination, and older MIME support.

Test Cases:
1. Open Media and verify Images is selected by default and only images are displayed.
2. Select Videos and verify only videos are displayed.
3. Scroll to the bottom of each Media sub-tab and verify older items load without duplicates or repeated loading.
4. Open Files and verify Docs is selected by default and only documents are displayed.
5. Select Audios and verify only audio files are displayed.
6. Search in Docs and Audios and verify the results match the selected sub-tab.
7. Switch between sub-tabs and verify the content and scroll behavior remain correct.
8. Add, update, or delete an attachment and verify the correct sub-tab updates.
9. Verify attachments using older MIME formats appear in the correct sub-tab when returned by the server.
10. Open an older-format image from a message and verify the viewer shows complete sender and time information.
11. Verify loading, empty, error, and retry states work correctly for every sub-tab.
12. Verify Media and Files work normally in channels, direct messages, groups, and threads.