### PR TITLE
260826-ANDROID-Fix search DM

### DIFF
--- a/app/src/main/java/com/mezon/mobile/search/GlobalSearchFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/search/GlobalSearchFragment.kt
@@ -124,7 +124,8 @@ class GlobalSearchFragment : BaseFragment() {
     private var filterChannelId = 0L
     private var filterChannelName = ""
     private var hideChannelsTab = false
-    private var visibleTabs = listOf(TAB_MEMBERS, TAB_CHANNELS, TAB_MESSAGES)
+    private var isDirectMessageSearch = false
+    private var visibleTabs = listOf(TAB_MEMBERS, TAB_CHANNELS)
     private var argClanId = 0L
     private var argChannelType = 0
     private var channelScopedMembers: List<SearchMember>? = null
@@ -161,14 +162,16 @@ class GlobalSearchFragment : BaseFragment() {
             filterChannelId = argChannelId
             filterChannelName = argChannelName
             hideChannelsTab = true
+            isDirectMessageSearch = argClanId == 0L
             buildChannelScopedMembers()
         }
 
-        visibleTabs = if (hideChannelsTab) {
-            listOf(TAB_MEMBERS, TAB_MESSAGES)
-        } else {
-            listOf(TAB_MEMBERS, TAB_CHANNELS, TAB_MESSAGES)
+        visibleTabs = when {
+            isDirectMessageSearch -> listOf(TAB_MESSAGES)
+            hideChannelsTab -> listOf(TAB_MEMBERS, TAB_MESSAGES)
+            else -> listOf(TAB_MEMBERS, TAB_CHANNELS)
         }
+        currentTab = visibleTabs.first()
 
         observe(NotificationCenter.searchMembersDidLoad) { _, _, _ ->
             if (fragmentView == null || isPaused) return@observe
@@ -365,6 +368,7 @@ class GlobalSearchFragment : BaseFragment() {
         }
         tabHeader = SearchTabHeader(context, themeColors).apply {
             setTabs(tabLabels)
+            visibility = if (visibleTabs.size == 1) View.GONE else View.VISIBLE
             onTabSelected = { visualIndex ->
                 searchRunnable?.let { handler.removeCallbacks(it) }
                 currentTab = visibleTabs.getOrElse(visualIndex) { TAB_MEMBERS }
@@ -479,7 +483,7 @@ class GlobalSearchFragment : BaseFragment() {
         if (channelScopedMembers != null) {
             loadingView.visibility = View.GONE
             recyclerView.visibility = View.VISIBLE
-            updateMembersList()
+            updateCurrentTab()
             updateTabCounts()
         } else {
             loadingView.visibility = View.VISIBLE
@@ -657,6 +661,7 @@ class GlobalSearchFragment : BaseFragment() {
                 isLoadingMore = true
                 searchController.loadMoreMessages(
                     channelId = filterChannelId,
+                    clanId = argClanId,
                     content = searchText,
                     username = filterUsername(),
                     mentionUserId = filterMentionUserId()
@@ -711,7 +716,9 @@ class GlobalSearchFragment : BaseFragment() {
     }
 
     private fun updateFilterButtonVisibility() {
-        val showFilter = (currentTab == TAB_MEMBERS || currentTab == TAB_MESSAGES) &&
+        val showFilter = hideChannelsTab &&
+            !isDirectMessageSearch &&
+            (currentTab == TAB_MEMBERS || currentTab == TAB_MESSAGES) &&
             !isChannelPickerMode &&
             !isPickingFilterUser
         filterButton?.visibility = if (showFilter) View.VISIBLE else View.GONE
@@ -945,6 +952,7 @@ class GlobalSearchFragment : BaseFragment() {
     private fun searchMessages() {
         searchController.searchMessagesApi(
             channelId = filterChannelId,
+            clanId = argClanId,
             content = searchText,
             username = filterUsername(),
             mentionUserId = filterMentionUserId()

--- a/app/src/main/java/com/mezon/mobile/search/SearchController.kt
+++ b/app/src/main/java/com/mezon/mobile/search/SearchController.kt
@@ -258,7 +258,8 @@ class SearchController @Inject constructor(
     private var messageSearchGeneration = 0L
 
     fun searchMessagesApi(
-        channelId: Long = 0L,
+        channelId: Long,
+        clanId: Long,
         content: String = "",
         username: String = "",
         mentionUserId: Long = 0L,
@@ -278,8 +279,6 @@ class SearchController @Inject constructor(
         appScope.launch(ioDispatcher) {
             try {
                 sessionManager.withAutoRefresh { session ->
-                    val clanId = clansController.selectedClanId.value
-
                     val filters = ArrayList<Pair<String, String>>()
                     filters.add("channel_id" to channelId.toString())
                     filters.add("clan_id" to clanId.toString())
@@ -309,7 +308,8 @@ class SearchController @Inject constructor(
     }
 
     fun loadMoreMessages(
-        channelId: Long = 0L,
+        channelId: Long,
+        clanId: Long,
         content: String = "",
         username: String = "",
         mentionUserId: Long = 0L
@@ -321,6 +321,7 @@ class SearchController @Inject constructor(
         }
         searchMessagesApi(
             channelId = channelId,
+            clanId = clanId,
             content = content,
             username = username,
             mentionUserId = mentionUserId,


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-382
Root cause: Global Search reused channel-search controls, and DM message search sent the currently selected clan instead of the DM scope.
Solution: Show controls based on search context and send the actual channel clan, using clan ID 0 for DMs.
Test cases:
- Open Global Search and confirm that only Members and Channels are shown without the filter button.
- Search for a member in Global Search and confirm that matching members are displayed.
- Search for a channel in Global Search and confirm that matching channels are displayed.
- Open search inside a clan channel and confirm that Members, Messages, and the filter button are available.
- Open search inside a direct message and confirm that the tab bar and filter button are hidden.
- Enter a keyword from an existing direct message and confirm that matching messages are displayed.
- Change the selected clan, open a direct message, and confirm that message search still works.
- Scroll through multiple message results and confirm that more results load correctly.