### PR TITLE
260828-ANDROID-Handle fallback download file

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -2166,7 +2166,16 @@ open class ChatFragment : BaseFragment() {
                         val dm = context.getSystemService(android.content.Context.DOWNLOAD_SERVICE) as android.app.DownloadManager
                         dm.enqueue(request)
                         MezonToast.show(this@ChatFragment, ToastOverlay.ToastType.INFO, "Downloading $filename")
-                    } catch (_: Exception) {}
+                    } catch (_: Exception) {
+                        runCatching {
+                            context.startActivity(
+                                android.content.Intent(
+                                    android.content.Intent.ACTION_VIEW,
+                                    android.net.Uri.parse(url)
+                                )
+                            )
+                        }
+                    }
                 }
             }
             override fun didLongPress(cell: ChatMessageCell, msg: MessageEntity) {


### PR DESCRIPTION
task: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-420
Root Cause: When a file could not be opened or downloaded, the error was ignored and no alternative action was provided.
Solution: Open the file’s CDN link in the browser when the download cannot start.
Test Cases:
1. Tap a supported file in chat and verify it opens or downloads normally.
2. Tap an unsupported file such as a .deb file and verify its CDN link opens in the browser when downloading fails.
3. Open a file from the Files tab and verify the CDN link opens normally.
4. Verify the browser is not opened twice when the file opens successfully.