### PR TITLE
260831-ANDROID-Send sound effect and handle fallback show duration sound 

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/chat/AudioDurationResolver.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/AudioDurationResolver.kt
@@ -1,0 +1,60 @@
+package com.mezon.mobile.home.chat
+
+import android.media.MediaMetadataRetriever
+import android.util.LruCache
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+internal object AudioDurationResolver {
+    private const val MAX_CACHE_ENTRIES = 128
+
+    private val lock = Any()
+    private val cache = LruCache<String, Long>(MAX_CACHE_ENTRIES)
+    private val inFlight = HashMap<String, Deferred<Long>>()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    suspend fun resolve(url: String): Long {
+        val key = url.trim()
+        if (!key.startsWith("http://", true) && !key.startsWith("https://", true)) return 0L
+        return getOrStart(key).await()
+    }
+
+    private fun getOrStart(url: String): Deferred<Long> = synchronized(lock) {
+        cache.get(url)?.let { return@synchronized CompletableDeferred(it) }
+        inFlight[url]?.let { return@synchronized it }
+
+        val result = CompletableDeferred<Long>()
+        inFlight[url] = result
+        scope.launch {
+            val durationMs = readDurationMs(url)
+            synchronized(lock) {
+                if (durationMs > 0L) cache.put(url, durationMs)
+                inFlight.remove(url)
+            }
+            result.complete(durationMs)
+        }
+        result
+    }
+
+    private fun readDurationMs(url: String): Long {
+        val retriever = MediaMetadataRetriever()
+        return try {
+            retriever.setDataSource(url, emptyMap())
+            retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+                ?.toLongOrNull()
+                ?.coerceAtLeast(0L)
+                ?: 0L
+        } catch (_: Exception) {
+            0L
+        } finally {
+            try {
+                retriever.release()
+            } catch (_: Exception) {
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -1277,12 +1277,14 @@ open class ChatFragment : BaseFragment() {
         }
 
         observe(NotificationCenter.audioPlaybackStateChanged) { _, _, args ->
-            if (fragmentView == null || isPaused) return@observe
+            if (fragmentView == null) return@observe
             val messageId = args.getOrNull(0) as? Long ?: return@observe
             val isPlaying = args.getOrNull(1) as? Boolean ?: false
             val isLoading = args.getOrNull(2) as? Boolean ?: false
             val positionMs = args.getOrNull(3) as? Long ?: 0L
             val durationMs = args.getOrNull(4) as? Long ?: 0L
+            val isStopped = !isPlaying && !isLoading && positionMs == 0L && durationMs == 0L
+            if (isPaused && !isStopped) return@observe
             for (i in 0 until recyclerView.childCount) {
                 val child = recyclerView.getChildAt(i) as? ChatMessageCell ?: continue
                 child.applyAudioPlayback(messageId, isPlaying, isLoading, positionMs, durationMs)

--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
@@ -274,6 +274,10 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
     private var audioIsLoading = false
     private var audioPositionMs: Long = 0
     private var audioDurationMs: Long = 0
+    private var audioPlaybackDurationMs: Long = 0
+    private var audioLockedDisplaySeconds: Int = 0
+    private var audioDurationProbeJob: Job? = null
+    private var audioDurationProbeUrl = ""
     private var audioWaveTimeMs: Long = 0
     private var audioLastFrameTimeMs: Long = 0
     private val audioWavePath = Path()
@@ -417,6 +421,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             pendingMessage = null
             update(0, msg)
         }
+        messageEntity?.let { resolveAudioDurationIfNeeded(it) }
     }
 
     override fun onDetachedFromWindow() {
@@ -443,6 +448,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         avatarCancellable?.cancel()
         avatarCancellable = null
         senderRoleIconCancellable?.cancel()
+        cancelAudioDurationProbe()
         senderRoleIconCancellable = null
         reactionEmojiCancellables.forEach { it?.cancel() }
         cancelEmojiLoads()
@@ -633,6 +639,8 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             audioIsLoading = false
             audioPositionMs = 0L
             audioDurationMs = (msg.attachmentDuration * 1000L).coerceAtLeast(0L)
+            audioPlaybackDurationMs = 0L
+            audioLockedDisplaySeconds = msg.attachmentDuration.coerceAtLeast(0)
             audioWaveTimeMs = 0L
             audioLastFrameTimeMs = 0L
             drawForwardHeader = msg.isForwarded
@@ -2035,6 +2043,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
 
     private fun buildAudioLayouts(msg: MessageEntity) {
         if (!drawAudioAttachment) {
+            cancelAudioDurationProbe()
             audioTimeLayout = null
             audioDurationSec = 0
             audioPillWidth = 0
@@ -2051,18 +2060,61 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
             AUDIO_WAVE_WIDTH +
             AUDIO_TIME_GAP +
             LayoutHelper.dp(38)
+        resolveAudioDurationIfNeeded(msg)
+    }
+
+    private fun resolveAudioDurationIfNeeded(msg: MessageEntity) {
+        if (!attachedToWindow || !drawAudioAttachment || msg.attachmentDuration > 0) {
+            cancelAudioDurationProbe()
+            return
+        }
+        val url = msg.attachmentUrl.trim()
+        if (url.isEmpty() || audioDurationMs > 0L) return
+        if (audioDurationProbeUrl == url && audioDurationProbeJob?.isActive == true) return
+
+        cancelAudioDurationProbe()
+        audioDurationProbeUrl = url
+        audioDurationProbeJob = AUDIO_DURATION_UI_SCOPE.launch {
+            val durationMs = AudioDurationResolver.resolve(url)
+            if (durationMs <= 0L || messageEntity?.attachmentUrl?.trim() != url || !drawAudioAttachment) {
+                return@launch
+            }
+            audioDurationMs = durationMs
+            rebuildAudioTimeLayout()
+            invalidate()
+        }
+    }
+
+    private fun cancelAudioDurationProbe() {
+        audioDurationProbeJob?.cancel()
+        audioDurationProbeJob = null
+        audioDurationProbeUrl = ""
     }
 
     private fun audioDisplayTime(): String {
-        val remainingMs = when {
-            audioIsPlaying && audioDurationMs > 0 -> (audioDurationMs - audioPositionMs).coerceAtLeast(0L)
-            audioPositionMs in 1 until audioDurationMs -> (audioDurationMs - audioPositionMs).coerceAtLeast(0L)
-            audioDurationMs > 0 -> audioDurationMs
-            audioDurationSec > 0 -> audioDurationSec * 1000L
-            else -> 0L
+        val rawTotalDurationMs = maxOf(audioDurationMs, audioDurationSec * 1000L)
+        if (rawTotalDurationMs > 0L) {
+            val roundedSeconds = ((rawTotalDurationMs + 999L) / 1000L).toInt()
+            audioLockedDisplaySeconds = maxOf(audioLockedDisplaySeconds, roundedSeconds)
         }
-        if (remainingMs <= 0L && audioDurationSec <= 0) return "--:--"
-        val totalSeconds = (remainingMs / 1000).toInt()
+        val totalDurationMs = maxOf(
+            rawTotalDurationMs,
+            audioLockedDisplaySeconds * 1000L
+        )
+        val progress = if (audioPlaybackDurationMs > 0L) {
+            (audioPositionMs.toDouble() / audioPlaybackDurationMs.toDouble())
+                .coerceIn(0.0, 1.0)
+        } else {
+            0.0
+        }
+        val remainingMs = when {
+            totalDurationMs <= 0L -> 0.0
+            audioIsPlaying || progress > 0.001 ->
+                (totalDurationMs.toDouble() * (1.0 - progress)).coerceAtLeast(0.0)
+            else -> totalDurationMs.toDouble()
+        }
+        if (totalDurationMs <= 0L) return "--:--"
+        val totalSeconds = ceil(remainingMs / 1000.0).toInt()
         val minutes = totalSeconds / 60
         val seconds = totalSeconds % 60
         val sb = StringBuilder(6).append(minutes).append(':')
@@ -2080,7 +2132,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
     ) {
         val msg = messageEntity ?: return
         if (msg.id != messageId) {
-            if (audioIsPlaying || audioIsLoading) {
+            if (audioIsPlaying || audioIsLoading || audioPositionMs > 0L) {
                 audioIsPlaying = false
                 audioIsLoading = false
                 audioPositionMs = 0L
@@ -2092,7 +2144,10 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
         audioIsPlaying = isPlaying
         audioIsLoading = isLoading
         audioPositionMs = positionMs
-        if (durationMs > 0) audioDurationMs = durationMs
+        if (durationMs > 0) {
+            audioPlaybackDurationMs = durationMs
+            audioDurationMs = maxOf(audioDurationMs, durationMs, audioDurationSec * 1000L)
+        }
         rebuildAudioTimeLayout()
         invalidate()
     }
@@ -4887,6 +4942,7 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
 
         private const val VIDEO_THUMB_TIMEOUT_MS = 8_000L
         private val VIDEO_THUMB_SCOPE = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        private val AUDIO_DURATION_UI_SCOPE = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
         private val EMBED_INPUT_HEIGHT = LayoutHelper.dp(40)
         private val EMBED_TEXTAREA_HEIGHT = LayoutHelper.dp(80)
         private val BUBBLE_RIGHT_INSET = LayoutHelper.dp(28)

--- a/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/ChannelFileDocumentRowView.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/channelinfo/ChannelFileDocumentRowView.kt
@@ -11,6 +11,7 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import com.mezon.mobile.core.LayoutHelper
 import com.mezon.mobile.core.ThemeColors
+import com.mezon.mobile.home.chat.isAudioAttachmentType
 import com.mezon.mobile.ui.cells.MezonIcon
 
 class ChannelFileDocumentRowView(
@@ -63,7 +64,12 @@ class ChannelFileDocumentRowView(
         timeLabel: String
     ) {
         iconView.clearColorFilter()
-        iconView.setImageDrawable(MezonIcon.fileIconNew.getDrawable(context))
+        val icon = if (isAudioAttachmentType(item.filetype)) {
+            MezonIcon.musicNoteIcon.getDrawable(context, theme.onSurface)
+        } else {
+            MezonIcon.fileIconNew.getDrawable(context)
+        }
+        iconView.setImageDrawable(icon)
         nameView.text = item.filename
         nameView.setTextColor(theme.blurple)
         nameView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, 14f)

--- a/app/src/main/java/com/mezon/mobile/home/chat/emoji/EmojiView.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/emoji/EmojiView.kt
@@ -8,6 +8,8 @@ import android.graphics.Paint
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
 import android.graphics.RectF
+import android.media.AudioAttributes
+import android.media.MediaPlayer
 import android.os.Handler
 import android.os.Looper
 import android.text.Editable
@@ -37,6 +39,7 @@ import com.mezon.mobile.network.KlipyCategory
 import com.mezon.mobile.network.KlipyGif
 import com.mezon.mobile.ui.cells.MezonIcon
 import com.mezon.mobile.R
+import com.mezon.mobile.util.resolveStickerSourceUrl
 
 private const val TAB_EMOJI = 0
 private const val TAB_GIF = 1
@@ -44,6 +47,7 @@ private const val TAB_STICKER = 2
 private const val SEARCH_DEBOUNCE_MS = 300L
 private const val EMOJI_COLUMNS = 9
 private const val STICKER_COLUMNS = 5
+private const val SOUND_STICKER_COLUMNS = 2
 
 class EmojiView(
     context: Context,
@@ -78,6 +82,7 @@ class EmojiView(
     private val tabGif: TextView
     private val tabSticker: TextView
     private val searchField: EditText
+    private val soundFilterButton: ImageView
     private val contentContainer: FrameLayout
     private val backspaceButton: ImageView
 
@@ -92,6 +97,11 @@ class EmojiView(
     private var gifCategoryGrid: RecyclerListView? = null
     private var emojiAdapter: EmojiGridAdapter? = null
     private var stickerAdapter: StickerGridAdapter? = null
+    private var soundStickerMode = false
+    private var soundPreviewPlayer: MediaPlayer? = null
+    private var soundPreviewId: String? = null
+    private var soundPreviewPrepared = false
+    private var soundPreviewShouldPlay = false
     private var gifCategoryAdapter: GifCategoryAdapter? = null
     private var gifSearchActive = false
     private var gifAdapter: GifGridAdapter? = null
@@ -187,6 +197,29 @@ class EmojiView(
             setImageDrawable(d)
             scaleType = ImageView.ScaleType.FIT_CENTER
         }
+        soundFilterButton = ImageView(context).apply {
+            val d = MezonIcon.voiceWaveDoubleIcon.getDrawable(context).mutate()
+            setImageDrawable(d)
+            scaleType = ImageView.ScaleType.FIT_CENTER
+            setPadding(LayoutHelper.dp(10f), LayoutHelper.dp(10f), LayoutHelper.dp(10f), LayoutHelper.dp(10f))
+            contentDescription = context.getString(R.string.clan_settings_sound)
+            visibility = View.GONE
+            setOnClickListener {
+                stopSoundPreview()
+                searchRunnable?.let { handler.removeCallbacks(it) }
+                searchRunnable = null
+                soundStickerMode = !soundStickerMode
+                ignoreTextChange = true
+                searchField.text?.clear()
+                ignoreTextChange = false
+                updateSoundFilterAppearance()
+                loadStickerData(useDiff = false) {
+                    updateStickerGridColumns()
+                    (stickerGrid?.layoutManager as? GridLayoutManager)
+                        ?.scrollToPositionWithOffset(0, 0)
+                }
+            }
+        }
         searchBar.addView(searchField, FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.MATCH_PARENT, LayoutHelper.dp(40f)
         ))
@@ -195,6 +228,9 @@ class EmojiView(
         ).apply {
             leftMargin = LayoutHelper.dp(10f)
         })
+        searchBar.addView(soundFilterButton, FrameLayout.LayoutParams(
+            LayoutHelper.dp(40f), LayoutHelper.dp(40f), Gravity.END or Gravity.CENTER_VERTICAL
+        ))
         root.addView(searchBar, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT))
 
         categoryHeaderContainer = LinearLayout(context).apply {
@@ -315,10 +351,12 @@ class EmojiView(
             TAB_GIF -> loadGifData()
         }
         backspaceButton.visibility = if (currentTab == TAB_EMOJI) View.VISIBLE else View.GONE
+        updateSoundFilterVisibility()
     }
 
     private fun switchTab(tab: Int) {
         if (currentTab == tab) return
+        if (currentTab == TAB_STICKER) stopSoundPreview()
         currentTab = tab
         updateTabSelection()
         ignoreTextChange = true
@@ -338,6 +376,7 @@ class EmojiView(
             TAB_GIF -> loadGifData()
         }
         backspaceButton.visibility = if (tab == TAB_EMOJI) View.VISIBLE else View.GONE
+        updateSoundFilterVisibility()
     }
 
     private fun updateGifGridVisibility() {
@@ -438,14 +477,22 @@ class EmojiView(
                 contentContainer.addView(emojiGrid, matchLp)
             }
             TAB_STICKER -> if (stickerGrid == null) {
-                stickerAdapter = StickerGridAdapter(themeColors) { sticker ->
-                    if (sticker.isForSale && sticker.src.isBlank()) return@StickerGridAdapter
-                    delegate?.onStickerSelected(sticker, sticker.isAudio)
-                }
-                val lm = GridLayoutManager(context, STICKER_COLUMNS)
+                stickerAdapter = StickerGridAdapter(
+                    themeColors = themeColors,
+                    onStickerClick = { sticker ->
+                        if (sticker.isForSale && sticker.src.isBlank()) return@StickerGridAdapter
+                        if (sticker.isAudio) stopSoundPreview()
+                        delegate?.onStickerSelected(sticker, sticker.isAudio)
+                    },
+                    onSoundPreview = { sticker -> toggleSoundPreview(sticker) }
+                )
+                val lm = GridLayoutManager(
+                    context,
+                    if (soundStickerMode) SOUND_STICKER_COLUMNS else STICKER_COLUMNS
+                )
                 lm.spanSizeLookup = object : GridLayoutManager.SpanSizeLookup() {
                     override fun getSpanSize(position: Int): Int {
-                        return if (stickerAdapter?.isHeader(position) == true) STICKER_COLUMNS else 1
+                        return if (stickerAdapter?.isHeader(position) == true) lm.spanCount else 1
                     }
                 }
                 stickerGrid = RecyclerListView(context).apply {
@@ -579,12 +626,20 @@ class EmojiView(
         emojiAdapter?.setData(data)
     }
 
-    private fun loadStickerData() {
+    private fun loadStickerData(
+        useDiff: Boolean = true,
+        onApplied: (() -> Unit)? = null
+    ) {
         val ctrl = emojiController ?: return
-        val visualOnly = synchronized(ctrl) {
-            ctrl.stickers.filter { !it.isAudio }
+        val items = synchronized(ctrl) {
+            ctrl.stickers.filter { it.isAudio == soundStickerMode }
         }
-        stickerAdapter?.setData(visualOnly)
+        stickerAdapter?.setData(
+            items,
+            includeForSale = !soundStickerMode,
+            useDiff = useDiff,
+            onApplied = onApplied
+        )
     }
 
     private fun performSearch(query: String) {
@@ -604,7 +659,15 @@ class EmojiView(
         }
         when (currentTab) {
             TAB_EMOJI -> emojiAdapter?.setSearchResults(ctrl.searchEmojis(query))
-            TAB_STICKER -> stickerAdapter?.setSearchResults(ctrl.searchStickers(query))
+            TAB_STICKER -> {
+                val results = synchronized(ctrl) {
+                    ctrl.stickers.filter {
+                        it.isAudio == soundStickerMode &&
+                            it.shortname.contains(query, ignoreCase = true)
+                    }
+                }
+                stickerAdapter?.setSearchResults(results)
+            }
             TAB_GIF -> {
                 gifSearchActive = true
                 updateGifGridVisibility()
@@ -640,6 +703,95 @@ class EmojiView(
             TAB_STICKER -> context.getString(R.string.emoji_search_sticker_placeholder)
             else -> context.getString(R.string.common_search)
         }
+    }
+
+    private fun updateSoundFilterVisibility() {
+        val show = currentTab == TAB_STICKER
+        soundFilterButton.visibility = if (show) View.VISIBLE else View.GONE
+        val params = searchField.layoutParams as FrameLayout.LayoutParams
+        params.rightMargin = if (show) LayoutHelper.dp(48f) else 0
+        searchField.layoutParams = params
+        updateSoundFilterAppearance()
+    }
+
+    private fun updateSoundFilterAppearance() {
+        val backgroundColor = if (soundStickerMode) themeColors.primary else themeColors.secondaryLight
+        soundFilterButton.background = android.graphics.drawable.GradientDrawable().apply {
+            setColor(backgroundColor)
+            cornerRadius = LayoutHelper.dp(10f).toFloat()
+        }
+        soundFilterButton.drawable?.colorFilter = PorterDuffColorFilter(
+            if (soundStickerMode) themeColors.onPrimary else themeColors.onSurface,
+            PorterDuff.Mode.SRC_IN
+        )
+    }
+
+    private fun updateStickerGridColumns() {
+        val manager = stickerGrid?.layoutManager as? GridLayoutManager ?: return
+        manager.spanCount = if (soundStickerMode) SOUND_STICKER_COLUMNS else STICKER_COLUMNS
+    }
+
+    private fun toggleSoundPreview(sticker: StickerItem) {
+        val source = resolveStickerSourceUrl(sticker.id, sticker.src).trim()
+        if (!source.startsWith("http://", true) && !source.startsWith("https://", true)) return
+        if (soundPreviewId == sticker.id) {
+            soundPreviewShouldPlay = !soundPreviewShouldPlay
+            if (soundPreviewPrepared) {
+                try {
+                    if (soundPreviewShouldPlay) {
+                        soundPreviewPlayer?.start()
+                    } else {
+                        soundPreviewPlayer?.pause()
+                    }
+                } catch (_: IllegalStateException) {
+                    stopSoundPreview()
+                    return
+                }
+            }
+            stickerAdapter?.setPlayingSoundId(if (soundPreviewShouldPlay) sticker.id else null)
+            return
+        }
+
+        stopSoundPreview(updateUi = false)
+        soundPreviewId = sticker.id
+        soundPreviewPrepared = false
+        soundPreviewShouldPlay = true
+        stickerAdapter?.setPlayingSoundId(sticker.id)
+        try {
+            soundPreviewPlayer = MediaPlayer().apply {
+                setAudioAttributes(
+                    AudioAttributes.Builder()
+                        .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                        .setUsage(AudioAttributes.USAGE_MEDIA)
+                        .build()
+                )
+                setOnPreparedListener {
+                    soundPreviewPrepared = true
+                    if (soundPreviewShouldPlay) it.start()
+                }
+                setOnCompletionListener { stopSoundPreview() }
+                setOnErrorListener { _, _, _ ->
+                    stopSoundPreview()
+                    true
+                }
+                setDataSource(source)
+                prepareAsync()
+            }
+        } catch (_: Exception) {
+            stopSoundPreview()
+        }
+    }
+
+    private fun stopSoundPreview(updateUi: Boolean = true) {
+        soundPreviewPlayer?.setOnPreparedListener(null)
+        soundPreviewPlayer?.setOnCompletionListener(null)
+        soundPreviewPlayer?.setOnErrorListener(null)
+        soundPreviewPlayer?.release()
+        soundPreviewPlayer = null
+        soundPreviewId = null
+        soundPreviewPrepared = false
+        soundPreviewShouldPlay = false
+        if (updateUi) stickerAdapter?.setPlayingSoundId(null)
     }
 
     fun clearSearchFocus() {
@@ -790,10 +942,16 @@ class EmojiView(
     }
 
     override fun onDetachedFromWindow() {
+        stopSoundPreview()
         super.onDetachedFromWindow()
         searchRunnable?.let { handler.removeCallbacks(it) }
         velocityTracker?.recycle()
         velocityTracker = null
+    }
+
+    override fun onVisibilityChanged(changedView: View, visibility: Int) {
+        super.onVisibilityChanged(changedView, visibility)
+        if (changedView === this && visibility != View.VISIBLE) stopSoundPreview()
     }
 
     private class DragHandleView(context: Context, themeColors: ThemeColors) : View(context) {

--- a/app/src/main/java/com/mezon/mobile/home/chat/emoji/SoundStickerCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/emoji/SoundStickerCell.kt
@@ -1,0 +1,150 @@
+package com.mezon.mobile.home.chat.emoji
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
+import android.graphics.RectF
+import android.graphics.drawable.Drawable
+import android.text.TextPaint
+import android.text.TextUtils
+import android.view.MotionEvent
+import android.view.View
+import com.mezon.mobile.core.LayoutHelper
+import com.mezon.mobile.core.ThemeColors
+import com.mezon.mobile.home.chat.StickerItem
+import com.mezon.mobile.ui.cells.MezonIcon
+
+private val CELL_HEIGHT = LayoutHelper.dp(52f)
+private val CELL_INSET = LayoutHelper.dp(2f).toFloat()
+private val CELL_CORNER = LayoutHelper.dp(10f).toFloat()
+private val HORIZONTAL_PADDING = LayoutHelper.dp(10f)
+private val PLAY_SIZE = LayoutHelper.dp(28f)
+private val PLAY_ICON_SIZE = LayoutHelper.dp(12f)
+private val SEND_SIZE = LayoutHelper.dp(32f)
+private val SEND_ICON_SIZE = LayoutHelper.dp(20f)
+private val CONTENT_GAP = LayoutHelper.dp(8f)
+
+class SoundStickerCell(
+    context: Context,
+    private val themeColors: ThemeColors
+) : View(context) {
+
+    var onPreviewTap: (() -> Unit)? = null
+    var onSendTap: (() -> Unit)? = null
+
+    private var sticker: StickerItem? = null
+    private var isPlaying = false
+    private val backgroundRect = RectF()
+    private val playRect = RectF()
+    private val sendRect = RectF()
+
+    private val playDrawable: Drawable = MezonIcon.playIcon.getDrawable(context).mutate().apply {
+        colorFilter = PorterDuffColorFilter(themeColors.blurple, PorterDuff.Mode.SRC_IN)
+    }
+    private val pauseDrawable: Drawable = MezonIcon.pauseIcon.getDrawable(context).mutate().apply {
+        colorFilter = PorterDuffColorFilter(themeColors.blurple, PorterDuff.Mode.SRC_IN)
+    }
+    private val sendDrawable: Drawable = MezonIcon.sendMessageIcon.getDrawable(context).mutate().apply {
+        colorFilter = PorterDuffColorFilter(themeColors.textStrong, PorterDuff.Mode.SRC_IN)
+    }
+
+    fun bind(sticker: StickerItem, playing: Boolean) {
+        this.sticker = sticker
+        isPlaying = playing
+        invalidate()
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        setMeasuredDimension(MeasureSpec.getSize(widthMeasureSpec), CELL_HEIGHT)
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        val item = sticker ?: return
+        val width = measuredWidth.toFloat()
+        val height = measuredHeight.toFloat()
+
+        backgroundRect.set(CELL_INSET, CELL_INSET, width - CELL_INSET, height - CELL_INSET)
+        backgroundPaint.color = themeColors.serverRailBg
+        canvas.drawRoundRect(backgroundRect, CELL_CORNER, CELL_CORNER, backgroundPaint)
+
+        val playLeft = CELL_INSET + HORIZONTAL_PADDING
+        val playTop = (height - PLAY_SIZE) / 2f
+        playRect.set(playLeft, playTop, playLeft + PLAY_SIZE, playTop + PLAY_SIZE)
+        playBackgroundPaint.color = themeColors.channelPanelBg
+        canvas.drawOval(playRect, playBackgroundPaint)
+
+        val actionDrawable = if (isPlaying) pauseDrawable else playDrawable
+        val playIconLeft = (playRect.left + (PLAY_SIZE - PLAY_ICON_SIZE) / 2f).toInt()
+        val playIconTop = (playRect.top + (PLAY_SIZE - PLAY_ICON_SIZE) / 2f).toInt()
+        actionDrawable.setBounds(
+            playIconLeft,
+            playIconTop,
+            playIconLeft + PLAY_ICON_SIZE,
+            playIconTop + PLAY_ICON_SIZE
+        )
+        actionDrawable.draw(canvas)
+
+        val sendLeft = (width - CELL_INSET - HORIZONTAL_PADDING - SEND_SIZE).toInt()
+        val sendTop = ((height - SEND_SIZE) / 2f).toInt()
+        sendRect.set(
+            sendLeft.toFloat(),
+            sendTop.toFloat(),
+            (sendLeft + SEND_SIZE).toFloat(),
+            (sendTop + SEND_SIZE).toFloat()
+        )
+        val sendIconLeft = sendLeft + (SEND_SIZE - SEND_ICON_SIZE) / 2
+        val sendIconTop = sendTop + (SEND_SIZE - SEND_ICON_SIZE) / 2
+        sendDrawable.setBounds(
+            sendIconLeft,
+            sendIconTop,
+            sendIconLeft + SEND_ICON_SIZE,
+            sendIconTop + SEND_ICON_SIZE
+        )
+        sendDrawable.draw(canvas)
+
+        textPaint.color = themeColors.textStrong
+        val textStart = playRect.right + CONTENT_GAP
+        val textEnd = sendRect.left - CONTENT_GAP
+        val availableWidth = (textEnd - textStart).coerceAtLeast(0f)
+        val text = TextUtils.ellipsize(
+            item.shortname,
+            textPaint,
+            availableWidth,
+            TextUtils.TruncateAt.END
+        ).toString()
+        val baseline = height / 2f - (textPaint.ascent() + textPaint.descent()) / 2f
+        canvas.drawText(text, textStart, baseline, textPaint)
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        if (sticker == null) return false
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> return true
+            MotionEvent.ACTION_UP -> {
+                when {
+                    playRect.contains(event.x, event.y) -> onPreviewTap?.invoke()
+                    sendRect.contains(event.x, event.y) -> onSendTap?.invoke()
+                }
+                performClick()
+                return true
+            }
+            MotionEvent.ACTION_CANCEL -> return true
+        }
+        return super.onTouchEvent(event)
+    }
+
+    override fun performClick(): Boolean {
+        super.performClick()
+        return true
+    }
+
+    companion object {
+        private val backgroundPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+        private val playBackgroundPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+        private val textPaint = TextPaint(Paint.ANTI_ALIAS_FLAG).apply {
+            textSize = LayoutHelper.dp(14f).toFloat()
+        }
+    }
+}

--- a/app/src/main/java/com/mezon/mobile/home/chat/emoji/StickerGridAdapter.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/emoji/StickerGridAdapter.kt
@@ -17,12 +17,14 @@ private const val FOR_SALE_HEADER = "For Sale"
 
 class StickerGridAdapter(
     private val themeColors: ThemeColors,
-    private val onStickerClick: (StickerItem) -> Unit
+    private val onStickerClick: (StickerItem) -> Unit,
+    private val onSoundPreview: (StickerItem) -> Unit
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     companion object {
         const val VIEW_TYPE_HEADER = 0
         const val VIEW_TYPE_STICKER = 1
+        const val VIEW_TYPE_SOUND = 2
     }
 
     sealed class ListItem {
@@ -42,6 +44,7 @@ class StickerGridAdapter(
     private val collapsedSections = HashSet<String>()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var diffJob: Job? = null
+    private var playingSoundId: String? = null
 
     init {
         setHasStableIds(true)
@@ -52,15 +55,22 @@ class StickerGridAdapter(
     override fun getItemId(position: Int): Long =
         if (position in items.indices) items[position].stableId else RecyclerView.NO_ID
 
-    fun setData(stickers: List<StickerItem>) {
+    fun setData(
+        stickers: List<StickerItem>,
+        includeForSale: Boolean = true,
+        useDiff: Boolean = true,
+        onApplied: (() -> Unit)? = null
+    ) {
         groups.clear()
 
-        val forSale = stickers.filter { it.isForSale }
-        if (forSale.isNotEmpty()) {
-            groups.add(GroupData(FOR_SALE_HEADER, forSale))
+        if (includeForSale) {
+            val forSale = stickers.filter { it.isForSale }
+            if (forSale.isNotEmpty()) {
+                groups.add(GroupData(FOR_SALE_HEADER, forSale))
+            }
         }
 
-        val owned = stickers.filter { !it.isForSale && it.src.isNotBlank() }
+        val owned = stickers.filter { (!includeForSale || !it.isForSale) && it.src.isNotBlank() }
         val byClan = LinkedHashMap<String, MutableList<StickerItem>>()
         for (s in owned) {
             val key = s.clanName.ifBlank { s.category.ifBlank { "Stickers" } }
@@ -70,7 +80,7 @@ class StickerGridAdapter(
             groups.add(GroupData(groupName, group))
         }
 
-        rebuildItems()
+        rebuildItems(onApplied, useDiff)
     }
 
     fun setSearchResults(stickers: List<StickerItem>) {
@@ -89,7 +99,7 @@ class StickerGridAdapter(
         rebuildItems()
     }
 
-    private fun rebuildItems() {
+    private fun rebuildItems(onApplied: (() -> Unit)? = null, useDiff: Boolean = true) {
         val newItems = ArrayList<ListItem>()
         for (group in groups) {
             val expanded = !collapsedSections.contains(group.name)
@@ -98,15 +108,24 @@ class StickerGridAdapter(
                 for (s in group.stickers) newItems.add(ListItem.Sticker(s))
             }
         }
-        applyNewItems(newItems)
+        if (useDiff) {
+            applyNewItems(newItems, onApplied)
+        } else {
+            diffJob?.cancel()
+            items.clear()
+            items.addAll(newItems)
+            notifyDataSetChanged()
+            onApplied?.invoke()
+        }
     }
 
-    private fun applyNewItems(newItems: ArrayList<ListItem>) {
+    private fun applyNewItems(newItems: ArrayList<ListItem>, onApplied: (() -> Unit)? = null) {
         diffJob?.cancel()
         if (newItems.size < 50 && items.size < 50) {
             val result = DiffUtil.calculateDiff(ItemDiffCallback(items, newItems))
             items.clear(); items.addAll(newItems)
             result.dispatchUpdatesTo(this)
+            onApplied?.invoke()
         } else {
             val oldList = ArrayList(items)
             diffJob = scope.launch {
@@ -115,15 +134,34 @@ class StickerGridAdapter(
                 }
                 items.clear(); items.addAll(newItems)
                 result.dispatchUpdatesTo(this@StickerGridAdapter)
+                onApplied?.invoke()
             }
         }
     }
 
     fun isHeader(position: Int): Boolean = items.getOrNull(position) is ListItem.Header
 
+    fun setPlayingSoundId(id: String?) {
+        if (playingSoundId == id) return
+        val oldId = playingSoundId
+        playingSoundId = id
+        if (oldId != null) {
+            val oldIndex = items.indexOfFirst { it is ListItem.Sticker && it.item.id == oldId }
+            if (oldIndex >= 0) notifyItemChanged(oldIndex)
+        }
+        if (id != null) {
+            val newIndex = items.indexOfFirst { it is ListItem.Sticker && it.item.id == id }
+            if (newIndex >= 0) notifyItemChanged(newIndex)
+        }
+    }
+
     override fun getItemViewType(position: Int): Int = when (items[position]) {
         is ListItem.Header -> VIEW_TYPE_HEADER
-        is ListItem.Sticker -> VIEW_TYPE_STICKER
+        is ListItem.Sticker -> if ((items[position] as ListItem.Sticker).item.isAudio) {
+            VIEW_TYPE_SOUND
+        } else {
+            VIEW_TYPE_STICKER
+        }
     }
 
     override fun getItemCount(): Int = items.size
@@ -142,7 +180,7 @@ class StickerGridAdapter(
                 }
                 vh
             }
-            else -> {
+            VIEW_TYPE_STICKER -> {
                 val cell = StickerCell(parent.context, themeColors)
                 val vh = StickerViewHolder(cell)
                 cell.setOnClickListener {
@@ -154,13 +192,32 @@ class StickerGridAdapter(
                 }
                 vh
             }
+            else -> {
+                val cell = SoundStickerCell(parent.context, themeColors)
+                val vh = SoundViewHolder(cell)
+                cell.onPreviewTap = {
+                    val pos = vh.bindingAdapterPosition
+                    val item = items.getOrNull(pos)
+                    if (item is ListItem.Sticker) onSoundPreview(item.item)
+                }
+                cell.onSendTap = {
+                    val pos = vh.bindingAdapterPosition
+                    val item = items.getOrNull(pos)
+                    if (item is ListItem.Sticker) onStickerClick(item.item)
+                }
+                vh
+            }
         }
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (val item = items[position]) {
             is ListItem.Header -> (holder as HeaderViewHolder).cell.bind(item.title, item.expanded)
-            is ListItem.Sticker -> (holder as StickerViewHolder).cell.setSticker(item.item)
+            is ListItem.Sticker -> if (holder is SoundViewHolder) {
+                holder.cell.bind(item.item, item.item.id == playingSoundId)
+            } else {
+                (holder as StickerViewHolder).cell.setSticker(item.item)
+            }
         }
     }
 
@@ -171,6 +228,7 @@ class StickerGridAdapter(
 
     class HeaderViewHolder(val cell: CollapsibleHeaderCell) : RecyclerView.ViewHolder(cell)
     class StickerViewHolder(val cell: StickerCell) : RecyclerView.ViewHolder(cell)
+    class SoundViewHolder(val cell: SoundStickerCell) : RecyclerView.ViewHolder(cell)
 
     private class ItemDiffCallback(
         private val old: List<ListItem>,

--- a/app/src/main/java/com/mezon/mobile/ui/cells/MezonIcon.kt
+++ b/app/src/main/java/com/mezon/mobile/ui/cells/MezonIcon.kt
@@ -184,6 +184,7 @@ enum class MezonIcon(@DrawableRes val resId: Int) {
     cameraIcon(R.drawable.ic_camera),
     playIcon(R.drawable.ic_play),
     pauseIcon(R.drawable.ic_pause),
+    musicNoteIcon(R.drawable.ic_music_note),
     fileIcon(R.drawable.ic_file),
     paperPlaneIcon(R.drawable.ic_paper_plane),
     heartIcon(R.drawable.ic_heart),

--- a/app/src/main/res/drawable/ic_music_note.xml
+++ b/app/src/main/res/drawable/ic_music_note.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,3v10.55A4,4 0,0 0,10 13c-2.21,0 -4,1.34 -4,3s1.79,3 4,3 4,-1.34 4,-3V7h4V3h-6z" />
+</vector>


### PR DESCRIPTION
task: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-417
result:
<img width="1096" height="2560" alt="image" src="https://github.com/user-attachments/assets/dce2bdfa-9214-4f39-b655-fb0719a22b3f" />

Root Cause
Android did not support sending sound effects from the sticker panel, and audio messages showed an unknown duration when the server did not provide one.
Solution
Added sound-effect browsing, search, preview, pause/resume, and sending in the sticker panel; audio messages now use the server duration when available and read the audio duration only when it is missing.
Test Cases
- Open the sticker panel, tap the speaker button, and verify the sound-effect list appears and can switch back to stickers.
- Search for a sound effect, preview it, pause and resume it, then send it and verify the audio message plays correctly.
- Open an audio message with a server-provided duration and verify the duration appears before playback.
- Open an audio message without a server-provided duration and verify the duration appears after loading and counts down correctly during playback.
- Play an audio message, leave the chat screen, then return and verify the play icon and waveform are reset.