### PR TITLE
260904-ANDROID-Handle add socket react msg

### DIFF
--- a/app/src/main/java/com/mezon/mobile/network/MezonApi.kt
+++ b/app/src/main/java/com/mezon/mobile/network/MezonApi.kt
@@ -374,6 +374,9 @@ class MezonApi @Inject constructor(
             "RegistFCMDeviceToken",
             "SendChannelMessage"
         )
+        private val SOCKET_MUTATION_API_NAMES = setOf(
+            "ReactChannelMessage"
+        )
         private val SOCKET_RPC_API_NAMES = setOf(
             "GetAccount",
             "GetListEmojisByUserId",
@@ -410,8 +413,9 @@ class MezonApi @Inject constructor(
             "ListWebhookByChannelId",
             "SearchCtrlK",
             "SearchMessage"
-        )
-        private val READ_RETRYABLE_API_NAMES = SOCKET_RPC_API_NAMES + "GenerateHashChannelApps"
+        ) + SOCKET_MUTATION_API_NAMES
+        private val READ_RETRYABLE_API_NAMES =
+            (SOCKET_RPC_API_NAMES - SOCKET_MUTATION_API_NAMES) + "GenerateHashChannelApps"
     }
 
     private val linkInvitePreviewCache = android.util.LruCache<Long, LinkInvitePreview>(256)
@@ -588,10 +592,11 @@ class MezonApi @Inject constructor(
         } catch (e: SocketRpcServerException) {
             throw e
         } catch (e: SocketRpcTransportException) {
-            if (!retryableRead || !e.retryOverHttp) throw e
+            val canFallbackToHttp = retryableRead || method in SOCKET_MUTATION_API_NAMES
+            if (!canFallbackToHttp || !e.retryOverHttp) throw e
             Log.w("MezonApi", "SOCKET unavailable method=$method, falling back to HTTP: ${e.message}")
             sentryReporter.logRpcWarning(method, "socket", "fallback to HTTP: ${e.message}")
-            rpcOverHttpWithRetry(apiUrl, token, method, body, true)
+            rpcOverHttpWithRetry(apiUrl, token, method, body, retryableRead)
         } catch (e: IllegalArgumentException) {
             throw e
         }


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-427
Root cause
Android sent every reaction over HTTP, which returned 503 errors during rapid tapping and caused the count to stop increasing. iOS used socket-first requests.
Solution
Use socket-first requests for reactions with HTTP fallback, keeping each tap separate and disabling automatic HTTP retries.
Test cases
- Tap the same emoji rapidly at least 100 times and verify the count matches the successful reactions after reopening the chat.
- React rapidly with different emojis and verify each emoji shows the correct count.
- Check the same message on another device and verify both devices show matching counts.
- Remove a reaction and verify the updated count remains correct after reopening the chat.