### PR TITLE
260904-ANDROID-Implement share text

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -6996,6 +6996,9 @@ open class ChatFragment : BaseFragment() {
                 clipboard.setPrimaryClip(android.content.ClipData.newPlainText("message", plainText))
                 MezonToast.show(this, ToastOverlay.ToastType.INFO, getString(R.string.message_toast_copy_text))
             }
+            MessageActionBottomSheet.ActionType.ShareText -> {
+                shareMessageText(msg)
+            }
             MessageActionBottomSheet.ActionType.ForwardMessage -> {
                 openForwardScreen(msg)
             }
@@ -7113,6 +7116,17 @@ open class ChatFragment : BaseFragment() {
                 handleGiveCoffee(msg)
             }
         }
+    }
+
+    private fun shareMessageText(msg: MessageEntity) {
+        val activity = getParentActivity() ?: return
+        val plainText = parseContentText(msg.content)
+        if (plainText.isBlank()) return
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, plainText)
+        }
+        activity.startActivity(Intent.createChooser(intent, getString(R.string.action_share_text)))
     }
 
     private fun showReportMessageSheet(msg: MessageEntity) {

--- a/app/src/main/java/com/mezon/mobile/home/chat/MessageActionBottomSheet.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/MessageActionBottomSheet.kt
@@ -20,6 +20,8 @@ import com.mezon.mobile.core.BottomSheet
 import com.mezon.mobile.core.LayoutHelper
 import com.mezon.mobile.core.ThemeColors
 import com.mezon.mobile.ui.cells.MezonIcon
+import com.mezon.mobile.util.messageHasExplicitTextBody
+import com.mezon.mobile.util.parseContentText
 
 
 class MessageActionBottomSheet(
@@ -48,6 +50,7 @@ class MessageActionBottomSheet(
         ForwardAllNearby,
         EditMessage,
         CopyText,
+        ShareText,
         TopicDiscussion,
         PinMessage,
         UnPinMessage,
@@ -355,6 +358,14 @@ class MessageActionBottomSheet(
             context.getString(R.string.action_copy_text),
             R.drawable.ic_copy_icon
         ))
+
+        if (messageHasExplicitTextBody(message.content) && parseContentText(message.content).isNotBlank()) {
+            actions.add(ActionItem(
+                ActionType.ShareText,
+                context.getString(R.string.action_share_text),
+                R.drawable.ic_share_box
+            ))
+        }
 
         if (showPinActions) {
             if (isPinned) {

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1674,6 +1674,7 @@
     <string name="action_save_media">Lưu ảnh</string>
     <string name="action_copy_image">Sao chép ảnh</string>
     <string name="action_share_image">Chia sẻ ảnh</string>
+    <string name="action_share_text">Chia sẻ văn bản</string>
     <string name="action_save_video">Lưu video</string>
     <string name="action_share_video">Chia sẻ video</string>
     <string name="action_share_video_to_mezon">Chia sẻ đến Mezon</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -366,6 +366,7 @@
     <string name="message_attachment_location">Location</string>
     <string name="message_attachment_poll">Poll</string>
     <string name="action_copy_text">Copy Text</string>
+    <string name="action_share_text">Share Text</string>
     <string name="tokens_sent_title">Funds Transferred: %1$s₫</string>
     <string name="give_coffee_action">Give coffee action</string>
     <string name="give_coffee_error_self">Cannot give coffee to yourself</string>


### PR DESCRIPTION
task: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-443
Root cause: The message menu lacked a Share Text option to share message text with Mezon or other apps.
Solution: Added Share Text on Android and iOS using the system share sheet and existing text-sharing support.
Test cases:
Verify that Share Text appears for messages containing text.
Verify that Share Text does not appear for messages containing only images.
Verify that tapping Share Text opens the system app chooser.
Verify that sharing to another app sends the message text correctly.
Verify that selecting Mezon allows sharing the text to a chat.