### PR TITLE
260909-ANDROID-Improve clan event

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/clans/ChannelPickerSheet.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ChannelPickerSheet.kt
@@ -38,6 +38,7 @@ class ChannelPickerSheet(
     channels: List<ClanChannelEntity>,
     private val title: CharSequence,
     private val selectedChannelId: Long = 0L,
+    private val emptyText: CharSequence = context.getString(R.string.webhook_pick_channel_no_match),
     private val onChannelPicked: (ClanChannelEntity) -> Unit,
 ) : BottomSheet(context, needFocusable = true) {
 
@@ -75,7 +76,7 @@ class ChannelPickerSheet(
         val emptyView = TextView(context).apply {
             visibility = View.GONE
             gravity = Gravity.CENTER
-            text = context.getString(R.string.webhook_pick_channel_no_match)
+            text = emptyText
             textSize = 14f
             setTextColor(CreateClanRnUiTokens.textDisabled(themeColors))
             setPadding(LayoutHelper.dp(24), LayoutHelper.dp(12), LayoutHelper.dp(24), LayoutHelper.dp(12))
@@ -206,7 +207,14 @@ class ChannelPickerSheet(
 
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
             val ctx = parent.context
-            val row = LinearLayout(ctx).apply {
+            val row = object : LinearLayout(ctx) {
+                override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+                    super.onMeasure(
+                        MeasureSpec.makeMeasureSpec(MeasureSpec.getSize(widthMeasureSpec), MeasureSpec.EXACTLY),
+                        heightMeasureSpec,
+                    )
+                }
+            }.apply {
                 orientation = LinearLayout.HORIZONTAL
                 gravity = Gravity.CENTER_VERTICAL
                 minimumHeight = LayoutHelper.dp(52)
@@ -230,7 +238,7 @@ class ChannelPickerSheet(
                 textSize = 15f
                 typeface = Typeface.DEFAULT
                 setTextColor(themeColors.onSurface)
-                maxLines = 2
+                maxLines = 1
                 ellipsize = TextUtils.TruncateAt.END
             }
             row.addView(label, LinearLayout.LayoutParams(0, LayoutHelper.WRAP_CONTENT, 1f))

--- a/app/src/main/java/com/mezon/mobile/home/clans/ClanEventBottomSheet.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ClanEventBottomSheet.kt
@@ -23,6 +23,7 @@ import androidx.core.widget.NestedScrollView
 import com.mezon.mobile.BuildConfig
 import com.mezon.mobile.R
 import com.mezon.mobile.core.AndroidUtilities
+import com.mezon.mobile.core.AlertsCreator
 import com.mezon.mobile.core.BottomSheet
 import com.mezon.mobile.core.LayoutHelper
 import com.mezon.mobile.core.NotificationCenter
@@ -93,6 +94,7 @@ class ClanEventBottomSheet(
     private var eventScrollView: NestedScrollView
     private var swipeDismissFromHeader = false
     private var hiddenForNavigation = false
+    private var endingEvent = false
 
     init {
         containerHeight = (AndroidUtilities.displaySize.y * 0.8f).toInt()
@@ -179,6 +181,9 @@ class ClanEventBottomSheet(
                         val interested = !event.isInterested(userId)
                         clanEventController.setInterested(clanId, event.id, interested) { _, _ -> }
                     },
+                    onEndEvent = if (clanEventController.canEndEvent(event)) {
+                        { confirmEndEvent(event) }
+                    } else null,
                     onEdit = if (clanEventController.canModifyEvent(event)) {
                         {
                             val latest = clanEventController.getEvent(clanId, event.id)
@@ -202,6 +207,28 @@ class ClanEventBottomSheet(
                 ),
             )
         }
+    }
+
+    private fun confirmEndEvent(event: ClanEventEntity) {
+        val latest = clanEventController.getEvent(clanId, event.id) ?: return
+        if (endingEvent || !clanEventController.canEndEvent(latest)) return
+        AlertsCreator.createConfirmDialog(
+            context = context,
+            title = context.getString(R.string.clan_event_delete_confirm_title),
+            message = context.getString(R.string.clan_event_delete_confirm_message),
+            confirmText = context.getString(R.string.clan_event_menu_cancel),
+            cancelText = context.getString(R.string.common_cancel),
+            destructive = true,
+            onConfirm = {
+                endingEvent = true
+                clanEventController.deleteEvent(clanId, latest.id, latest.creatorId, latest.title, latest.channelId) { success, error ->
+                    endingEvent = false
+                    val message = if (success) context.getString(R.string.clan_event_delete_success)
+                        else error ?: context.getString(R.string.clan_event_delete_failed)
+                    Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+                }
+            },
+        ).show()
     }
 
     fun hideForNavigation() {
@@ -649,6 +676,7 @@ class ClanEventBottomSheet(
         onOpen: () -> Unit,
         onOpenChannel: (ClanChannelEntity) -> Unit,
         onToggleInterest: () -> Unit,
+        onEndEvent: (() -> Unit)?,
         onEdit: (() -> Unit)?,
         onInviteExternalEvent: (String) -> Unit,
         onLogoLoadToken: (MezonImageLoader.Cancellable) -> Unit,
@@ -896,16 +924,24 @@ class ClanEventBottomSheet(
                 },
             )
         }
-        actions.addView(
-            buildEventActionChip(
-                context,
-                theme,
-                if (interested) MezonIcon.eventBellSlashIcon else MezonIcon.eventBellIcon,
-                if (interested) context.getString(R.string.clan_event_uninterested) else context.getString(R.string.clan_event_interested),
-                onToggleInterest,
-            ),
-            LinearLayout.LayoutParams(0, LayoutHelper.WRAP_CONTENT, 1f),
-        )
+        if (status != ClanEventStatus.ONGOING) {
+            actions.addView(
+                buildEventActionChip(
+                    context,
+                    theme,
+                    if (interested) MezonIcon.eventBellSlashIcon else MezonIcon.eventBellIcon,
+                    if (interested) context.getString(R.string.clan_event_uninterested) else context.getString(R.string.clan_event_interested),
+                    onToggleInterest,
+                ),
+                LinearLayout.LayoutParams(0, LayoutHelper.WRAP_CONTENT, 1f),
+            )
+        } else if (onEndEvent != null) {
+            actions.addView(
+                buildEventActionChip(context, theme, MezonIcon.closeIcon, context.getString(R.string.clan_event_end), onEndEvent),
+                LinearLayout.LayoutParams(0, LayoutHelper.WRAP_CONTENT, 1f),
+            )
+        }
+        actions.visibility = if (actions.childCount == 0) View.GONE else View.VISIBLE
         content.addView(
             actions,
             LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 0f, Gravity.NO_GRAVITY, 0f, 12f, 0f, 8f),

--- a/app/src/main/java/com/mezon/mobile/home/clans/ClanEventController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ClanEventController.kt
@@ -1,6 +1,7 @@
 package com.mezon.mobile.home.clans
 
 import android.util.Log
+import com.mezon.mezon.api.CreateEventRequest
 import com.mezon.mobile.core.NotificationCenter
 import com.mezon.mobile.di.ApplicationScope
 import com.mezon.mobile.di.IoDispatcher
@@ -39,6 +40,7 @@ class ClanEventController @Inject constructor(
     private val loadErrorsByClan = ConcurrentHashMap<Long, String>()
     private val loadingClanIds = ConcurrentHashMap.newKeySet<Long>()
     private val pendingForceEventReload = HashSet<Long>()
+    private val pendingSocketEventsByClan = HashMap<Long, MutableList<CreateEventRequest>>()
     private val cacheLock = Any()
 
     init {
@@ -46,13 +48,122 @@ class ClanEventController @Inject constructor(
     }
 
     private suspend fun observeClanEventCreated() {
-        socketEventDispatcher.clanEventCreated.collect {
-            val clanId = it.clanId
-            if (clanId != 0L) {
-                loadEvents(clanId, force = true)
-            }
+        socketEventDispatcher.clanEventCreated.collect { event ->
+            applyClanEventFromSocket(event)
         }
     }
+
+    private fun applyClanEventFromSocket(event: CreateEventRequest) {
+        val clanId = event.clanId
+        if (clanId == 0L || event.eventId == 0L) return
+        val changed = synchronized(cacheLock) {
+            if (loadingClanIds.contains(clanId)) {
+                pendingSocketEventsByClan.getOrPut(clanId) { ArrayList() }.add(event)
+            }
+            val events = eventsByClan[clanId]
+                ?: if (event.action == ClanEventAction.CREATED || event.action == ClanEventAction.UPDATE) {
+                    ArrayList<ClanEventEntity>().also { eventsByClan[clanId] = it }
+                } else {
+                    return@synchronized false
+                }
+            applySocketEvent(events, event)
+        }
+        if (changed) {
+            notificationCenter.postNotificationOnMainThread(
+                NotificationCenter.clanEventsDidLoad,
+                clanId,
+            )
+        }
+    }
+
+    private fun applySocketEvent(
+        events: ArrayList<ClanEventEntity>,
+        update: CreateEventRequest,
+    ): Boolean {
+        val index = events.indexOfFirst { it.id == update.eventId }
+        val existing = events.getOrNull(index)
+
+        if (update.action == ClanEventAction.CREATED) {
+            if (existing != null) return false
+            events.add(update.toClanEventEntity())
+            return true
+        }
+
+        if (update.eventStatus == ClanEventStatus.UPCOMING || update.eventStatus == ClanEventStatus.ONGOING) {
+            if (existing == null) return false
+            events[index] = existing.copy(eventStatus = update.eventStatus)
+            return true
+        }
+
+        if (update.eventStatus == ClanEventStatus.COMPLETED &&
+            update.repeatType != ClanEventRepeatType.DOES_NOT_REPEAT
+        ) {
+            if (existing == null) return false
+            events[index] = existing.copy(
+                eventStatus = update.eventStatus,
+                startTimeSeconds = update.startTimeSeconds,
+            )
+            return true
+        }
+
+        if (update.action == ClanEventAction.UPDATE) {
+            val updated = update.toClanEventEntity(existing)
+            if (existing == null) {
+                events.add(updated)
+            } else {
+                events[index] = updated
+            }
+            return true
+        }
+
+        if ((update.eventStatus == ClanEventStatus.COMPLETED &&
+                update.repeatType == ClanEventRepeatType.DOES_NOT_REPEAT) ||
+            update.action == ClanEventAction.DELETE
+        ) {
+            if (existing == null) return false
+            events.removeAt(index)
+            return true
+        }
+
+        if (update.action == ClanEventAction.INTERESTED ||
+            update.action == ClanEventAction.UNINTERESTED
+        ) {
+            if (existing == null || update.userId == 0L) return false
+            val userIds = existing.userIds.filter { it != 0L }.toMutableList()
+            if (update.action == ClanEventAction.INTERESTED) {
+                if (update.userId in userIds) return false
+                userIds.add(update.userId)
+            } else if (!userIds.remove(update.userId)) {
+                return false
+            }
+            events[index] = existing.copy(userIds = userIds)
+            return true
+        }
+
+        return false
+    }
+
+    private fun CreateEventRequest.toClanEventEntity(
+        existing: ClanEventEntity? = null,
+    ): ClanEventEntity = ClanEventEntity(
+        id = eventId,
+        title = title,
+        logo = logo,
+        description = description,
+        clanId = clanId,
+        channelVoiceId = channelVoiceId,
+        channelId = channelId,
+        address = address,
+        startTimeSeconds = startTimeSeconds,
+        endTimeSeconds = endTimeSeconds,
+        creatorId = creatorId.takeIf { it != 0L } ?: existing?.creatorId ?: 0L,
+        userIds = existing?.userIds ?: listOfNotNull(creatorId.takeIf { it != 0L }),
+        maxPermission = existing?.maxPermission ?: 0,
+        eventStatus = existing?.eventStatus ?: eventStatus,
+        repeatType = repeatType,
+        isPrivate = isPrivate,
+        externalLink = meetRoom.externalLink.ifBlank { existing?.externalLink.orEmpty() },
+    )
 
     fun getEvents(clanId: Long): List<ClanEventEntity> = synchronized(cacheLock) {
         eventsByClan[clanId]?.toList().orEmpty()
@@ -124,6 +235,9 @@ class ClanEventController @Inject constructor(
                 }
                 val mapped = ArrayList(list.map { it.toClanEventEntity() })
                 synchronized(cacheLock) {
+                    pendingSocketEventsByClan.remove(clanId)?.forEach { event ->
+                        applySocketEvent(mapped, event)
+                    }
                     eventsByClan[clanId] = mapped
                 }
                 loadErrorsByClan.remove(clanId)
@@ -135,6 +249,7 @@ class ClanEventController @Inject constructor(
             } finally {
                 val reload = synchronized(cacheLock) {
                     loadingClanIds.remove(clanId)
+                    pendingSocketEventsByClan.remove(clanId)
                     pendingForceEventReload.remove(clanId)
                 }
                 notificationCenter.postNotificationOnMainThread(

--- a/app/src/main/java/com/mezon/mobile/home/clans/ClanEventController.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ClanEventController.kt
@@ -38,6 +38,7 @@ class ClanEventController @Inject constructor(
     private val eventsByClan = ConcurrentHashMap<Long, ArrayList<ClanEventEntity>>()
     private val loadErrorsByClan = ConcurrentHashMap<Long, String>()
     private val loadingClanIds = ConcurrentHashMap.newKeySet<Long>()
+    private val pendingForceEventReload = HashSet<Long>()
     private val cacheLock = Any()
 
     init {
@@ -81,6 +82,10 @@ class ClanEventController @Inject constructor(
         )
     }
 
+    fun canEndEvent(event: ClanEventEntity): Boolean =
+        event.displayStatus() == ClanEventStatus.ONGOING &&
+            permissionPolicy.checkPermission(PermissionPolicy.CLAN_OWNER, clanId = event.clanId)
+
     fun visibleEvents(clanId: Long, currentUserId: Long): List<ClanEventEntity> {
         val textChannelIds = textChannels(clanId).mapTo(HashSet()) { it.channelId }
         return getEvents(clanId).filter { event ->
@@ -103,7 +108,12 @@ class ClanEventController @Inject constructor(
                     return@launch
                 }
             }
-            loadingClanIds.add(clanId)
+            synchronized(cacheLock) {
+                if (!loadingClanIds.add(clanId)) {
+                    if (force) pendingForceEventReload.add(clanId)
+                    return@launch
+                }
+            }
             notificationCenter.postNotificationOnMainThread(
                 NotificationCenter.clanEventsDidLoad,
                 clanId,
@@ -123,11 +133,15 @@ class ClanEventController @Inject constructor(
                 loadErrorsByClan[clanId] = e.message?.takeIf { it.isNotBlank() }
                     ?: "Failed to load events"
             } finally {
-                loadingClanIds.remove(clanId)
+                val reload = synchronized(cacheLock) {
+                    loadingClanIds.remove(clanId)
+                    pendingForceEventReload.remove(clanId)
+                }
                 notificationCenter.postNotificationOnMainThread(
                     NotificationCenter.clanEventsDidLoad,
                     clanId,
                 )
+                if (reload) loadEvents(clanId, force = true)
             }
         }
     }

--- a/app/src/main/java/com/mezon/mobile/home/clans/ClanEventDetailFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ClanEventDetailFragment.kt
@@ -909,17 +909,27 @@ class ClanEventDetailFragment : BaseFragment() {
             content.addView(it, LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 0f, Gravity.START, 0f, 8f, 0f, 0f))
         }
     
-        val interested = event.isInterested(currentUserId)
-        content.addView(
-            buildEventActionChip(
-                context,
-                theme,
-                if (interested) MezonIcon.eventBellSlashIcon else MezonIcon.eventBellIcon,
-                if (interested) context.getString(R.string.clan_event_uninterested) else context.getString(R.string.clan_event_interested),
-                onToggleInterest,
-            ),
-            LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 0f, Gravity.NO_GRAVITY, 0f, 12f, 0f, 0f),
-        )
+        if (status != ClanEventStatus.ONGOING) {
+            val interested = event.isInterested(currentUserId)
+            content.addView(
+                buildEventActionChip(
+                    context,
+                    theme,
+                    if (interested) MezonIcon.eventBellSlashIcon else MezonIcon.eventBellIcon,
+                    if (interested) context.getString(R.string.clan_event_uninterested) else context.getString(R.string.clan_event_interested),
+                    onToggleInterest,
+                ),
+                LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 0f, Gravity.NO_GRAVITY, 0f, 12f, 0f, 0f),
+            )
+        } else if (clanEventController.canEndEvent(event)) {
+            content.addView(
+                buildEventActionChip(context, theme, MezonIcon.closeIcon, context.getString(R.string.clan_event_end)) {
+                    val latest = clanEventController.getEvent(clanId, event.id)
+                    if (latest != null && clanEventController.canEndEvent(latest)) confirmDeleteEvent(latest)
+                },
+                LayoutHelper.createLinear(LayoutHelper.MATCH_PARENT, LayoutHelper.WRAP_CONTENT, 0f, Gravity.NO_GRAVITY, 0f, 12f, 0f, 0f),
+            )
+        }
 
         content.addView(
             View(context).apply { setBackgroundColor(theme.outlineVariant) },

--- a/app/src/main/java/com/mezon/mobile/home/clans/ClanEventEditorDialog.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ClanEventEditorDialog.kt
@@ -933,16 +933,13 @@ class ClanEventEditorDialog private constructor(
 
     private fun showTextChannelPicker(context: Context) {
         val channels = clanEventController.textChannels(clanId)
-        if (channels.isEmpty()) {
-            showError(ToastOverlay.ToastType.INFO, getString(R.string.clan_invite_need_channel))
-            return
-        }
         showChildDialog(ChannelPickerSheet(
             context,
             themeColors,
             channels,
             getString(R.string.event_creator_channel_picker_title),
             selectedChannelId = channelId,
+            emptyText = getString(R.string.event_creator_no_channels),
         ) { picked ->
             channelId = picked.channelId
             refreshChannelPickerRow()

--- a/app/src/main/java/com/mezon/mobile/home/clans/ClanEventEntity.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ClanEventEntity.kt
@@ -26,12 +26,12 @@ data class ClanEventEntity(
 ) {
     val interestedCount: Int get() = userIds.count { it != 0L }
 
-    fun displayStatus(): Int {
-        if (eventStatus != 0) return eventStatus
-        val nowSec = System.currentTimeMillis() / 1000
-        val delta = startTimeSeconds - nowSec
-        if (delta <= 0) return ClanEventStatus.ONGOING
-        if (delta <= TimeUnit.MINUTES.toSeconds(10)) return ClanEventStatus.UPCOMING
+    fun displayStatus(nowMillis: Long = System.currentTimeMillis()): Int {
+        if (startTimeSeconds == 0) return eventStatus
+        val start = startTimeSeconds.toLong() * 1000
+        val end = if (endTimeSeconds != 0) endTimeSeconds.toLong() * 1000 else start + TimeUnit.HOURS.toMillis(2)
+        if (nowMillis in start..end) return ClanEventStatus.ONGOING
+        if (start > nowMillis && start - nowMillis <= TimeUnit.MINUTES.toMillis(10)) return ClanEventStatus.UPCOMING
         return ClanEventStatus.CREATED
     }
 

--- a/app/src/main/java/com/mezon/mobile/home/clans/ClanEventTypes.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ClanEventTypes.kt
@@ -13,12 +13,12 @@ object ClanEventStatus {
 }
 
 object ClanEventRepeatType {
-    const val DOES_NOT_REPEAT = 0
-    const val WEEKLY_ON_DAY = 1
-    const val EVERY_OTHER_DAY = 2
-    const val MONTHLY = 3
-    const val ANNUALLY = 4
-    const val EVERY_WEEKDAY = 5
+    const val DOES_NOT_REPEAT = 1
+    const val WEEKLY_ON_DAY = 2
+    const val EVERY_OTHER_DAY = 3
+    const val MONTHLY = 4
+    const val ANNUALLY = 5
+    const val EVERY_WEEKDAY = 6
 }
 
 data class CreateEventDraft(

--- a/app/src/main/java/com/mezon/mobile/home/clans/ClanEventTypes.kt
+++ b/app/src/main/java/com/mezon/mobile/home/clans/ClanEventTypes.kt
@@ -10,6 +10,15 @@ object ClanEventStatus {
     const val CREATED = 0
     const val UPCOMING = 1
     const val ONGOING = 2
+    const val COMPLETED = 3
+}
+
+object ClanEventAction {
+    const val CREATED = 1
+    const val UPDATE = 2
+    const val DELETE = 3
+    const val INTERESTED = 4
+    const val UNINTERESTED = 5
 }
 
 object ClanEventRepeatType {

--- a/app/src/main/java/com/mezon/mobile/network/MezonApi.kt
+++ b/app/src/main/java/com/mezon/mobile/network/MezonApi.kt
@@ -402,6 +402,7 @@ class MezonApi @Inject constructor(
             "ListClanDescs",
             "ListClanUsers",
             "ListClanWebhook",
+            "ListEvents",
             "ListFriends",
             "ListLogedDevice",
             "ListNotifications",

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -912,6 +912,7 @@
     <string name="clan_event_badge_clan">Sự kiện clan</string>
     <string name="clan_event_status_upcoming">Bắt đầu sau %1$d phút</string>
     <string name="clan_event_status_ongoing">Sự kiện đang diễn ra</string>
+    <string name="clan_event_end">Kết thúc sự kiện</string>
     <string name="clan_event_interested">Quan tâm</string>
     <string name="clan_event_uninterested">Bỏ quan tâm</string>
     <string name="clan_event_private_room">Phòng họp bên ngoài</string>
@@ -945,6 +946,7 @@
     <string name="event_creator_address_placeholder">Nhập địa điểm sự kiện</string>
     <string name="event_creator_linked_channel_label">Kênh thông báo (tùy chọn)</string>
     <string name="event_creator_channel_picker_title">Chọn kênh</string>
+    <string name="event_creator_no_channels">Không có kênh phù hợp</string>
     <string name="event_creator_details_title">Thông tin sự kiện</string>
     <string name="event_creator_details_subtitle">Thêm tên, lịch và ảnh bìa (tùy chọn).</string>
     <string name="event_creator_name_label">Tên sự kiện</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1027,6 +1027,7 @@
     <string name="clan_event_badge_clan">Clan Event</string>
     <string name="clan_event_status_upcoming">Starts in %1$d min</string>
     <string name="clan_event_status_ongoing">Event is happening now</string>
+    <string name="clan_event_end">End Event</string>
     <string name="clan_event_interested">Interested</string>
     <string name="clan_event_uninterested">Not interested</string>
     <string name="clan_event_private_room">External Meeting Room</string>
@@ -1060,6 +1061,7 @@
     <string name="event_creator_address_placeholder">Enter event location</string>
     <string name="event_creator_linked_channel_label">Announcement channel (optional)</string>
     <string name="event_creator_channel_picker_title">Select channel</string>
+    <string name="event_creator_no_channels">No channels available</string>
     <string name="event_creator_details_title">Tell us about your event</string>
     <string name="event_creator_details_subtitle">Add a name, schedule, and optional cover image.</string>
     <string name="event_creator_name_label">Event name</string>


### PR DESCRIPTION
task: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-440
Root cause:
The event flow did not fully match the latest web behavior, and event updates could be missed when loading data at the same time.
Solution:
Aligned event status, repeat options, action buttons, channel selection, realtime refresh, and empty-state behavior with the web and iOS flows.
Test cases:
1. Create each event type and confirm the event appears with the correct information.
2. Edit an event and confirm all updated information appears in the list and detail screens.
3. Open the channel picker with no available channels and confirm the empty message is shown.
4. Confirm long channel and voice names stay on one line with ....
5. Confirm an ongoing event hides Interested and shows End Event only to the clan owner.
6. Create or update an event from another device and confirm the event list refreshes automatically.
