### PR TITLE
260910-ANDROID-Fix not show react gif and sticker

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatMessageCell.kt
@@ -3346,6 +3346,19 @@ class ChatMessageCell(context: Context, private val theme: ThemeColors) : BaseCe
                 canvas, imgX, yOff, photoWidth.toFloat(), photoHeight.toFloat(), MEDIA_RADIUS,
             )
         }
+
+        yOff += photoHeight + GAP_V_INNER
+
+        if (reactionGroups.isNotEmpty()) {
+            yOff += REACTION_TOP_PAD
+            drawReactionRow(canvas, contentLeft.toFloat(), yOff)
+            yOff += reactionRowHeight
+        }
+
+        if (topicButtonLayout.visible) {
+            topicButtonLayout.layout(contentLeft.toFloat(), yOff, width)
+            topicButtonLayout.draw(canvas)
+        }
     }
 
     private fun drawMessageBubble(canvas: Canvas, msg: MessageEntity) {


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-466
Root Cause
Sticker and GIF messages used a separate display path that did not show the reaction row, although the reaction data was available.
Solution
Updated the sticker and GIF display path to show reactions and the add-reaction button below the media.
Test Cases
- Add a reaction to a sticker message and verify it appears below the sticker.
- Add a reaction to a GIF message and verify it appears below the GIF.
- Remove the reaction and verify it disappears.
- Reopen the channel and verify the reactions are still displayed.