### PR TITLE
260910-ANDROID-Fix bug topic header displayed incorrectly

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/ChatFragment.kt
@@ -8142,29 +8142,16 @@ open class ChatFragment : BaseFragment() {
             chatController.reloadChannelMessageIfMissing(channelId, clanId, rootMessageId)
             var root = chatController.getMessageById(channelId, rootMessageId)
             if (root == null) {
-                val detail = topicController.fetchTopicDetail(topicId)
-                if (detail != null) {
-                    root = MessageEntity(
-                        id = detail.messageId,
-                        channelId = channelId,
-                        senderId = detail.creatorId,
-                        senderName = "",
-                        senderUsername = "",
-                        senderAvatar = "",
-                        content = detail.content,
-                        timestampSeconds = detail.createTimeSeconds,
-                        code = MessageEntity.CODE_TOPIC,
-                        topicId = topicId,
-                        topicCreatorId = detail.creatorId
-                    )
+                val authoritativeRootId = topicController.fetchTopicDetail(topicId)?.messageId ?: 0L
+                if (authoritativeRootId != 0L && authoritativeRootId != rootMessageId) {
+                    chatController.reloadChannelMessageIfMissing(channelId, clanId, authoritativeRootId)
+                    root = chatController.getMessageById(channelId, authoritativeRootId)
                 }
             }
             val base = root ?: return@launch
-            val creatorId = base.topicCreatorId.takeIf { it != 0L } ?: base.senderId
-            val member = memberResolver.resolveMember(creatorId, clanId, channelId, channelType)
+            val member = memberResolver.resolveMember(base.senderId, clanId, channelId, channelType)
             val resolved = if (member != null) {
                 base.copy(
-                    senderId = creatorId,
                     senderName = member.clanNick.ifBlank { member.displayName.ifBlank { member.username } },
                     senderUsername = member.username,
                     senderAvatar = member.clanAvatar.ifBlank { member.avatarUrl }


### PR DESCRIPTION
issue: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-474
Root Cause
The topic header used the topic creator’s profile instead of the original message sender’s profile.
Solution
Use the original message sender for the topic header and load the correct original message when opening a topic from a notification.
Test Cases
1. Open a topic whose creator differs from the original message sender and verify the header shows the original sender’s name and avatar.
2. Open a topic from the Topics tab and verify the original message and sender are displayed correctly.
3. Open a topic from a reply notification and verify the header still shows the correct original message sender.