### PR TITLE
260911-ANDROID-Handle show image base64 embed

### DIFF
--- a/app/src/main/java/com/mezon/mobile/home/chat/MezonImageLoader.kt
+++ b/app/src/main/java/com/mezon/mobile/home/chat/MezonImageLoader.kt
@@ -10,6 +10,7 @@ import android.graphics.drawable.Drawable
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.util.Base64
 import android.util.LruCache
 import okhttp3.Call
 import okhttp3.Callback
@@ -231,8 +232,13 @@ class MezonImageLoader private constructor(context: Context) {
         onError: ((Exception) -> Unit)?,
         cacheAnimated: Boolean = false
     ): Cancellable {
-        if (url.isEmpty() || !isValidHttpUrl(url)) {
+        val isDataImage = isBase64ImageDataUri(url)
+        if (url.isEmpty() || (!isDataImage && !isValidHttpUrl(url))) {
             onError?.invoke(IllegalArgumentException("Invalid URL: $url"))
+            return Cancellable.EMPTY
+        }
+        if (isDataImage && url.length > MAX_DATA_IMAGE_URI_CHARS) {
+            onError?.invoke(IllegalArgumentException("Data image exceeds the allowed size"))
             return Cancellable.EMPTY
         }
 
@@ -261,6 +267,22 @@ class MezonImageLoader private constructor(context: Context) {
         val cb = LoadCallback(onSuccess, onError)
 
         if (addCallback(memKey, cb)) {
+            return Cancellable {
+                cb.cancel()
+                removePendingCallback(logicalUrl, memKey, cb)
+            }
+        }
+
+        if (isDataImage) {
+            decodeBase64ImageDataUriInBackground(
+                dataUri = url,
+                cacheKey = memKey,
+                reqWidth = reqWidth,
+                reqHeight = reqHeight,
+                animated = animated,
+                cacheEntry = cacheAnimated,
+                ephemeral = noCache,
+            )
             return Cancellable {
                 cb.cancel()
                 removePendingCallback(logicalUrl, memKey, cb)
@@ -430,6 +452,79 @@ class MezonImageLoader private constructor(context: Context) {
         runOnMain {
             for (cb in copy) {
                 if (!cb.isCancelled()) cb.onError?.invoke(error)
+            }
+        }
+    }
+
+    private fun decodeBase64ImageDataUriInBackground(
+        dataUri: String,
+        cacheKey: String,
+        reqWidth: Int,
+        reqHeight: Int,
+        animated: Boolean,
+        cacheEntry: Boolean,
+        ephemeral: Boolean,
+    ) {
+        DECODE_EXECUTOR.execute {
+            try {
+                val separator = dataUri.indexOf(',')
+                if (separator <= 0) throw IOException("Malformed data image URI")
+
+                val metadata = dataUri.substring(0, separator).lowercase(Locale.US)
+                if (!metadata.startsWith("data:image/") || !metadata.endsWith(";base64")) {
+                    throw IOException("Unsupported data image URI")
+                }
+
+                val encoded = dataUri.substring(separator + 1)
+                if (encoded.isEmpty() || encoded.length > MAX_DATA_IMAGE_BASE64_CHARS) {
+                    throw IOException("Data image exceeds the allowed size")
+                }
+
+                val bytes = try {
+                    Base64.decode(encoded, Base64.DEFAULT)
+                } catch (e: IllegalArgumentException) {
+                    throw IOException("Invalid Base64 image data", e)
+                }
+                if (bytes.isEmpty() || bytes.size > MAX_DATA_IMAGE_BYTES) {
+                    throw IOException("Data image exceeds the allowed size")
+                }
+
+                val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+                BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
+                if (bounds.outWidth <= 0 || bounds.outHeight <= 0) {
+                    throw IOException("Unsupported data image content")
+                }
+
+                val intrinsicMode = reqWidth <= 0 && reqHeight <= 0
+                val options = BitmapFactory.Options().apply {
+                    inSampleSize = if (intrinsicMode) {
+                        calculateInSampleSizeToMaxEdge(bounds, animatedMaxEdge)
+                    } else {
+                        calculateInSampleSize(bounds, reqWidth, reqHeight)
+                    }
+                    val isSmallThumb = reqWidth <= SMALL_IMAGE_THRESHOLD && reqHeight <= SMALL_IMAGE_THRESHOLD
+                    inPreferredConfig = if (isSmallThumb) Bitmap.Config.RGB_565 else Bitmap.Config.ARGB_8888
+                }
+                var bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size, options)
+                    ?: throw IOException("Data image decode failed")
+                bitmap = if (intrinsicMode) {
+                    clampBitmapToMaxEdge(bitmap, animatedMaxEdge)
+                } else {
+                    clampBitmap(bitmap, reqWidth, reqHeight)
+                }
+
+                if (animated) {
+                    val drawable = android.graphics.drawable.BitmapDrawable(appContext.resources, bitmap)
+                    if (cacheEntry && !ephemeral) animatedCache.put(cacheKey, drawable)
+                    dispatchSuccess(cacheKey, drawable)
+                } else {
+                    if (!ephemeral) putToMemory(cacheKey, bitmap, reqWidth, reqHeight)
+                    dispatchSuccess(cacheKey, bitmap)
+                }
+            } catch (e: OutOfMemoryError) {
+                dispatchError(cacheKey, IOException("Data image is too large to decode", e))
+            } catch (e: Exception) {
+                dispatchError(cacheKey, e)
             }
         }
     }
@@ -766,6 +861,9 @@ class MezonImageLoader private constructor(context: Context) {
         private const val MAX_DECODE_QUEUE = 64
         private const val ANIMATED_CACHE_MAX_KB = 48 * 1024
         private const val MAX_LOCAL_COPY_BYTES = 64L * 1024 * 1024
+        private const val MAX_DATA_IMAGE_BYTES = 4 * 1024 * 1024
+        private const val MAX_DATA_IMAGE_BASE64_CHARS = (MAX_DATA_IMAGE_BYTES * 4 / 3) + 4
+        private const val MAX_DATA_IMAGE_URI_CHARS = MAX_DATA_IMAGE_BASE64_CHARS + 256
         private const val STREAM_COPY_CHUNK_BYTES = 64 * 1024
         private const val LARGE_FILE_TRIM_PRIORITY_BYTES = 384_000
         private const val TRIM_DEBOUNCE_MS = 60_000L
@@ -813,6 +911,10 @@ class MezonImageLoader private constructor(context: Context) {
 
         private fun isValidHttpUrl(url: String): Boolean {
             return url.startsWith("http://") || url.startsWith("https://")
+        }
+
+        private fun isBase64ImageDataUri(url: String): Boolean {
+            return url.startsWith("data:image/", ignoreCase = true)
         }
 
         private fun applyExifRotation(file: File, bmp: Bitmap, mimeType: String = ""): Bitmap {

--- a/app/src/main/java/com/mezon/mobile/home/messages/EmbedMessage.kt
+++ b/app/src/main/java/com/mezon/mobile/home/messages/EmbedMessage.kt
@@ -626,6 +626,7 @@ class EmbedMessageRenderer(
                 val rh = embedImageCells[gi].second
                 val ir = imgs.embedGalleryReceiver(gi)
                 ir.setRoundRadius(IMG_RADIUS.toInt())
+                ir.setCenterCrop(false)
                 ir.setImage(
                     createImgproxyUrl(imgRef.url, cw, rh, "fit"),
                     null,

--- a/app/src/main/java/com/mezon/mobile/util/MessageContentParser.kt
+++ b/app/src/main/java/com/mezon/mobile/util/MessageContentParser.kt
@@ -1074,6 +1074,23 @@ fun parseEmbedDataList(content: String): List<EmbedData> =
 
 fun parseEmbedData(content: String): EmbedData? = parseEmbedDataList(content).firstOrNull()
 
+private fun JSONObject.optEmbedImageDimension(key: String): Int {
+    val dimension = when (val value = opt(key)) {
+        is Number -> value.toInt()
+        is String -> {
+            val text = value.trim()
+            val numeric = if (text.endsWith("px", ignoreCase = true)) {
+                text.dropLast(2).trim()
+            } else {
+                text
+            }
+            numeric.toDoubleOrNull()?.toInt()
+        }
+        else -> null
+    }
+    return dimension?.coerceAtLeast(0) ?: 0
+}
+
 private fun parseEmbedImages(embed: JSONObject): List<EmbedImageRef> {
     if (!embed.has("image") || embed.isNull("image")) return emptyList()
     return try {
@@ -1084,7 +1101,11 @@ private fun parseEmbedImages(embed: JSONObject): List<EmbedImageRef> {
             is JSONObject -> {
                 val u = raw.optString("url", "").trim()
                 if (u.isEmpty()) emptyList()
-                else listOf(EmbedImageRef(u, raw.optInt("width", 0), raw.optInt("height", 0)))
+                else listOf(EmbedImageRef(
+                    u,
+                    raw.optEmbedImageDimension("width"),
+                    raw.optEmbedImageDimension("height"),
+                ))
             }
             is JSONArray -> {
                 val list = mutableListOf<EmbedImageRef>()
@@ -1092,7 +1113,13 @@ private fun parseEmbedImages(embed: JSONObject): List<EmbedImageRef> {
                     when (val item = raw.opt(i)) {
                         is JSONObject ->
                             item.optString("url", "").trim().takeIf { it.isNotEmpty() }
-                                ?.let { list.add(EmbedImageRef(it, item.optInt("width", 0), item.optInt("height", 0))) }
+                                ?.let {
+                                    list.add(EmbedImageRef(
+                                        it,
+                                        item.optEmbedImageDimension("width"),
+                                        item.optEmbedImageDimension("height"),
+                                    ))
+                                }
                         is String ->
                             item.trim().takeIf { it.isNotEmpty() }?.let { list.add(EmbedImageRef(it, 0, 0)) }
                         else -> {


### PR DESCRIPTION
task: https://mello.mezon.vn/boards/ab1d77c0-6b09-4935-8aac-0441b8b38160/tickets/MEZON-483
result: 
<img width="1096" height="2560" alt="image" src="https://github.com/user-attachments/assets/66418040-df3c-4a2c-8ed6-4995e0032f17" />

Root Cause
Android rejected the QR image because it was provided as a Base64 Data URI instead of an HTTP URL, and "300px" dimensions caused the square image to be cropped into a 16:9 container.
Solution
Support safe Base64 image decoding, parse dimensions with the px suffix, and display embed images using fit mode to prevent cropping.
Test Cases
- Open a QR embed and verify the full square QR code is visible and scannable.
- Open an embed containing a regular web image and verify it displays normally.
- Open an embed containing invalid image data and verify the app remains stable without crashing.